### PR TITLE
Add grafana dashboard to pgagroal

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ pgagroal was created by the following authors:
 Jesper Pedersen <jesper.pedersen@redhat.com>
 David Fetter <david@fetter.org>
 Will Leinweber <will@bitfission.com>
+Junduo Dong <andj4cn@gmail.com>

--- a/contrib/grafana/README.md
+++ b/contrib/grafana/README.md
@@ -1,0 +1,26 @@
+# Grafana dashboard for pgagroal
+
+## Getting Started
+
+### Step1: Configure the Prometheus
+
+1. Open the prometheus metric port like `8000` in `pgagroal.conf`.
+
+2. Add the pgagroal instance in Prometheus configuration file `prometheus.yml` like follows:
+    ```
+    ...
+    scrape_configs:
+    - job_name: 'pgagroal'
+        static_configs:
+        - targets: ['localhost:8000']
+    ...
+    ```
+
+### Step2: Start the Grafana
+
+1. Integrate the Prometheus instance as a data source into Grafana.
+2. Open Grafana web page, click <kbd>+</kbd> -> <kbd>Import</kbd>.
+
+3. Upload JSON file `contrib/grafana/dashboard.json` with <kbd>Upload JSON file</kbd>, then change the options if necessary.
+
+4. Click <kbd>Import</kbd>. Let's start using it!

--- a/contrib/grafana/dashboard.json
+++ b/contrib/grafana/dashboard.json
@@ -1,0 +1,872 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 28,
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "description": "pgagroal state",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "UP"
+                },
+                "2": {
+                  "color": "yellow",
+                  "index": 2,
+                  "text": "GRACEFUL"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "max": 1,
+          "min": 0,
+          "noValue": "UNKNOWN",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.2",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "pgagroal_state",
+          "interval": "",
+          "legendFormat": "state",
+          "refId": "pgagroal_state"
+        }
+      ],
+      "title": "State",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "Active connections",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 2,
+        "y": 1
+      },
+      "id": 30,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "8.0.2",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "pgagroal_active_connections",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "active connections"
+        }
+      ],
+      "title": "Active connections",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "description": "Session time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 13,
+        "x": 11,
+        "y": 1
+      },
+      "id": 32,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": false,
+        "text": {}
+      },
+      "pluginVersion": "8.0.2",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "pgagroal_session_time_seconds_bucket",
+          "format": "heatmap",
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "pgagroal_session_time_seconds_bucket"
+        }
+      ],
+      "title": "Session time",
+      "type": "bargauge"
+    },
+    {
+      "datasource": null,
+      "description": "Failed servers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 0,
+        "y": 5
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.2",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "pgagroal_failed_servers",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "pgagroal_failed_servers"
+        }
+      ],
+      "title": "Failed servers",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "Connection state",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 11,
+        "x": 0,
+        "y": 9
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "pgagroal_active_connections",
+          "interval": "",
+          "legendFormat": "active connections",
+          "refId": "pgagroal_active_connections"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgagroal_total_connections",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "total connections",
+          "refId": "pgagroal_total_connections"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgagroal_max_connections",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "max connections",
+          "refId": "pgagroal_max_connections"
+        }
+      ],
+      "title": "Connection state",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 14,
+      "title": "Pool",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "description": "Authentication details",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 11,
+        "x": 0,
+        "y": 18
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "pgagroal_auth_user_success",
+          "interval": "",
+          "legendFormat": "success",
+          "refId": "pgagroal_auth_user_success"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgagroal_auth_user_error",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "error",
+          "refId": "pgagroal_auth_user_error"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgagroal_auth_user_bad_password",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "bad password",
+          "refId": "pgagroal_auth_user_bad_password"
+        }
+      ],
+      "title": "Authentication",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 12,
+      "title": "Internal",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 10,
+      "title": "Connection",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "description": "Connection events",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 11,
+        "x": 0,
+        "y": 28
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "pgagroal_connection_error",
+          "interval": "",
+          "legendFormat": "error",
+          "refId": "pgagroal_connection_error"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgagroal_connection_kill",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "kill",
+          "refId": "pgagroal_connection_kill"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgagroal_connection_remove",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "remove",
+          "refId": "pgagroal_connection_remove"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgagroal_connection_timeout",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "timeout",
+          "refId": "pgagroal_connection_timeout"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgagroal_connection_return",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "return",
+          "refId": "pgagroal_connection_return"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgagroal_connection_invalid",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "invalid",
+          "refId": "pgagroal_connection_invalid"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgagroal_connection_get",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "get",
+          "refId": "pgagroal_connection_get"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgagroal_connection_idletimeout",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "idletimeout",
+          "refId": "pgagroal_connection_idletimeout"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgagroal_connection_flush",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "flush",
+          "refId": "pgagroal_connection_flush"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgagroal_connection_success",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "success",
+          "refId": "pgagroal_connection_success"
+        }
+      ],
+      "title": "Connection events",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 8,
+      "title": "Client",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 6,
+      "panels": [],
+      "title": "Server",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "description": "Server connections",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 11,
+        "x": 0,
+        "y": 38
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(pgagroal_connection) by (database) > 0",
+          "interval": "",
+          "legendFormat": "{{database}}",
+          "refId": "pgagroal_connection per database"
+        }
+      ],
+      "title": "Server connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "description": "Server errors",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 11,
+        "y": 38
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(pgagroal_server_error) by (name)",
+          "interval": "",
+          "legendFormat": "{{name}}",
+          "refId": "pgagroal_server_error"
+        }
+      ],
+      "title": "Server errors",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "pgagroal dashboard",
+  "uid": "t_a1YcR7k",
+  "version": 23
+}


### PR DESCRIPTION
# Feature
Add grafana dashboard to pgagroal.

# How to use it
Importing the configuration file by following the steps in `contrib/grafana/README.md`.

You can get the grafana dashboard of pgagroal.