### PR TITLE
[#163] Add internal network traffic metrics

### DIFF
--- a/contrib/grafana/dashboard.json
+++ b/contrib/grafana/dashboard.json
@@ -572,7 +572,7 @@
           "refId": "pgagroal_wait_time"
         }
       ],
-      "title": "Client Waiting time",
+      "title": "Client waiting time",
       "type": "timeseries"
     },
     {
@@ -729,7 +729,7 @@
           "refId": "A"
         }
       ],
-      "title": "Transaction Rate",
+      "title": "Transaction rate",
       "type": "timeseries"
     },
     {
@@ -746,11 +746,170 @@
     },
     {
       "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 11,
+        "x": 0,
+        "y": 35
+      },
+      "id": 46,
+      "interval": "1s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "pgagroal_network_sent - (pgagroal_network_sent offset 1s)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Send traffic",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 11,
+        "x": 11,
+        "y": 35
+      },
+      "id": 48,
+      "interval": "1s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "pgagroal_network_received - (pgagroal_network_received offset 1s)",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Receive traffic",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 43
       },
       "id": 10,
       "title": "Connection",
@@ -813,7 +972,7 @@
         "h": 8,
         "w": 11,
         "x": 0,
-        "y": 36
+        "y": 44
       },
       "id": 24,
       "options": {
@@ -916,7 +1075,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 52
       },
       "id": 8,
       "title": "Client",
@@ -975,7 +1134,7 @@
         "h": 8,
         "w": 11,
         "x": 0,
-        "y": 45
+        "y": 53
       },
       "id": 38,
       "options": {
@@ -1015,7 +1174,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 53
+        "y": 61
       },
       "id": 6,
       "panels": [],
@@ -1077,7 +1236,7 @@
         "h": 8,
         "w": 11,
         "x": 0,
-        "y": 54
+        "y": 62
       },
       "id": 34,
       "options": {
@@ -1159,7 +1318,7 @@
         "h": 8,
         "w": 12,
         "x": 11,
-        "y": 54
+        "y": 62
       },
       "id": 36,
       "options": {
@@ -1193,12 +1352,12 @@
     "list": []
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "pgagroal dashboard",
   "uid": "t_a1YcR7k",
-  "version": 28
+  "version": 30
 }

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -254,6 +254,9 @@ struct prometheus
    atomic_ullong query_count;           /**< The number of queries */
    atomic_ullong tx_count;              /**< The number of transactions */
 
+   atomic_ullong network_sent;          /**< The bytes sent by clients*/
+   atomic_ullong network_received;      /**< The bytes received from servers*/
+
    atomic_ulong server_error[NUMBER_OF_SERVERS]; /**< The number of errors for a server */
    atomic_ulong failed_servers;                  /**< The number of failed servers */
    struct prometheus_connection prometheus_connections[];  /**< The number of prometheus connections (FMA) */

--- a/src/include/prometheus.h
+++ b/src/include/prometheus.h
@@ -171,6 +171,20 @@ void
 pgagroal_prometheus_tx_count_add(void);
 
 /**
+ * Increase network_sent
+ * @param s The size
+ */
+void
+pgagroal_prometheus_network_sent_add(ssize_t s);
+
+/**
+ * Increase network_received
+ * @param s The size
+ */
+void
+pgagroal_prometheus_network_received_add(ssize_t s);
+
+/**
  * Reset the counters and histograms
  */
 void

--- a/src/libpgagroal/pipeline_session.c
+++ b/src/libpgagroal/pipeline_session.c
@@ -225,6 +225,8 @@ session_client(struct ev_loop *loop, struct ev_io *watcher, int revents)
    }
    if (likely(status == MESSAGE_STATUS_OK))
    {
+      pgagroal_prometheus_network_sent_add(msg->length);
+
       if (likely(msg->kind != 'X'))
       {
          if (msg->kind == 'Q' || msg->kind == 'E')
@@ -314,6 +316,8 @@ session_server(struct ev_loop *loop, struct ev_io *watcher, int revents)
    status = pgagroal_read_socket_message(wi->server_fd, &msg);
    if (likely(status == MESSAGE_STATUS_OK))
    {
+      pgagroal_prometheus_network_received_add(msg->length);
+
       int offset = 0;
 
       while (offset < msg->length)

--- a/src/libpgagroal/pipeline_transaction.c
+++ b/src/libpgagroal/pipeline_transaction.c
@@ -234,6 +234,8 @@ transaction_client(struct ev_loop* loop, struct ev_io* watcher, int revents)
    }
    if (likely(status == MESSAGE_STATUS_OK))
    {
+      pgagroal_prometheus_network_sent_add(msg->length);
+
       if (likely(msg->kind != 'X'))
       {
          if (msg->kind == 'Q' || msg->kind == 'E')
@@ -371,6 +373,8 @@ transaction_server(struct ev_loop *loop, struct ev_io *watcher, int revents)
    status = pgagroal_read_socket_message(wi->server_fd, &msg);
    if (likely(status == MESSAGE_STATUS_OK))
    {
+      pgagroal_prometheus_network_received_add(msg->length);
+
       int offset = 0;
 
       while (offset < msg->length)


### PR DESCRIPTION
Add new network traffic panels in the dashboard and the following metrics:
* pgagroal_network_sent
* pgagroal_network_received

Modify the spelling of some words in the dashboard.