### PR TITLE
Add additional description to metrics page and grafana dashboard

### DIFF
--- a/contrib/grafana/dashboard.json
+++ b/contrib/grafana/dashboard.json
@@ -650,6 +650,7 @@
     },
     {
       "datasource": null,
+      "description": "Only session and transaction modes are supported",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -730,7 +731,7 @@
     },
     {
       "datasource": null,
-      "description": "",
+      "description": "Only session and transaction modes are supported",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -811,6 +812,7 @@
     },
     {
       "datasource": null,
+      "description": "Only session and transaction modes are supported",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -903,6 +905,7 @@
     },
     {
       "datasource": null,
+      "description": "Only session and transaction modes are supported",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -983,6 +986,7 @@
     },
     {
       "datasource": null,
+      "description": "Only session and transaction modes are supported",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1687,5 +1691,5 @@
   "timezone": "",
   "title": "pgagroal dashboard",
   "uid": "t_a1YcR7k",
-  "version": 32
+  "version": 1
 }

--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -840,10 +840,10 @@ home_page(int client_fd)
    data = append(data, "  The waiting time of clients\n");
    data = append(data, "  <p>\n");
    data = append(data, "  <h2>pgagroal_query_count</h2>\n");
-   data = append(data, "  The number of queries\n");
+   data = append(data, "  The number of queries. Only session and transaction modes are supported\n");
    data = append(data, "  <p>\n");
    data = append(data, "  <h2>pgagroal_connection_query_count</h2>\n");
-   data = append(data, "  The number of queries per connection\n");
+   data = append(data, "  The number of queries per connection. Only session and transaction modes are supported\n");
    data = append(data, "  <table border=\"1\">\n");
    data = append(data, "    <tbody>\n");
    data = append(data, "      <tr>\n");
@@ -866,7 +866,7 @@ home_page(int client_fd)
    data = append(data, "  </table>\n");
    data = append(data, "  <p>\n");
    data = append(data, "  <h2>pgagroal_tx_count</h2>\n");
-   data = append(data, "  The number of transactions\n");
+   data = append(data, "  The number of transactions. Only session and transaction modes are supported\n");
    data = append(data, "  <p>\n");
    data = append(data, "  <h2>pgagroal_active_connections</h2>\n");
    data = append(data, "  The number of active connections\n");
@@ -991,10 +991,10 @@ home_page(int client_fd)
    data = append(data, "  Number of active clients\n");
    data = append(data, "  <p>\n");
    data = append(data, "  <h2>pgagroal_network_sent</h2>\n");
-   data = append(data, "  Bytes sent by clients\n");
+   data = append(data, "  Bytes sent by clients. Only session and transaction modes are supported\n");
    data = append(data, "  <p>\n");
    data = append(data, "  <h2>pgagroal_network_received</h2>\n");
-   data = append(data, "  Bytes received from servers\n");
+   data = append(data, "  Bytes received from servers. Only session and transaction modes are supported\n");
    data = append(data, "  <p>\n");
    data = append(data, "  <h2>pgagroal_client_sockets</h2>\n");
    data = append(data, "  Number of sockets the client used\n");


### PR DESCRIPTION
Some metrics only support session and transaction modes:

* pgagroal_query_count
* pgagroal_tx_count
* pgagroal_connection_query_count
* pgagroal_network_sent
* pgagroal_network_received