### PR TITLE
Admin master key wrong message

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -55,12 +55,6 @@
 #define ACTION_REMOVE_USER 4
 #define ACTION_LIST_USERS  5
 
-static char CHARS[] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-                       'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-                       '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-                       '!', '@', '#', '$', '%', '^', '&',  '*', '(', ')', '-', '_', '=', '+', '[', '{', ']', '}', '\\', '|', ';', ':',
-                       '\'', '\"', ',', '<', '.',  '>', '/', '?'};
-
 static char ALPHA_UC[] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z' };
 static char ALPHA_LC[] = { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z' };
 static char DIGITS[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
@@ -933,6 +927,23 @@ generate_password(int pwd_length)
    char* pwd;
    size_t s;
    time_t t;
+   char* alphabet;
+
+   // the alphabet array is the "cat" of all available chars
+   alphabet = malloc(sizeof(char) * (sizeof(ALPHA_UC)
+                                     + sizeof(ALPHA_LC)
+                                     + sizeof(DIGITS)
+                                     + sizeof(SPECIALS) ));
+   int offset = 0;
+   memcpy(alphabet + offset, ALPHA_UC, sizeof(ALPHA_UC) );
+   offset += sizeof(ALPHA_UC);
+   memcpy(alphabet + offset, ALPHA_LC, sizeof(ALPHA_LC) );
+   offset += sizeof(ALPHA_LC);
+   memcpy(alphabet + offset, DIGITS, sizeof(DIGITS) );
+   offset += sizeof(DIGITS);
+   memcpy(alphabet + offset, SPECIALS, sizeof(SPECIALS) );
+   offset = 0;
+
 
    s = pwd_length + 1;
 
@@ -943,10 +954,11 @@ generate_password(int pwd_length)
 
    for (int i = 0; i < s; i++)
    {
-      *((char*)(pwd + i)) = CHARS[rand() % sizeof(CHARS)];
+     *((char*)(pwd + i)) = alphabet[rand() % sizeof(alphabet)];
    }
    *((char*)(pwd + pwd_length)) = '\0';
 
+   free(alphabet);
    return pwd;
 }
 

--- a/src/admin.c
+++ b/src/admin.c
@@ -929,22 +929,6 @@ generate_password(int pwd_length)
    time_t t;
    char* alphabet;
 
-   // the alphabet array is the "cat" of all available chars
-   alphabet = malloc(sizeof(char) * (sizeof(ALPHA_UC)
-                                     + sizeof(ALPHA_LC)
-                                     + sizeof(DIGITS)
-                                     + sizeof(SPECIALS) ));
-   int offset = 0;
-   memcpy(alphabet + offset, ALPHA_UC, sizeof(ALPHA_UC) );
-   offset += sizeof(ALPHA_UC);
-   memcpy(alphabet + offset, ALPHA_LC, sizeof(ALPHA_LC) );
-   offset += sizeof(ALPHA_LC);
-   memcpy(alphabet + offset, DIGITS, sizeof(DIGITS) );
-   offset += sizeof(DIGITS);
-   memcpy(alphabet + offset, SPECIALS, sizeof(SPECIALS) );
-   offset = 0;
-
-
    s = pwd_length + 1;
 
    pwd = malloc(s);
@@ -954,11 +938,19 @@ generate_password(int pwd_length)
 
    for (int i = 0; i < s; i++)
    {
+     if (i % 2 == 0 )
+       alphabet = ALPHA_UC;
+     else if ( i % 3 == 0 )
+       alphabet = ALPHA_LC;
+     else if ( i % 4 == 0 )
+       alphabet = DIGITS;
+     else
+       alphabet = SPECIALS;
+     
      *((char*)(pwd + i)) = alphabet[rand() % sizeof(alphabet)];
    }
    *((char*)(pwd + pwd_length)) = '\0';
 
-   free(alphabet);
    return pwd;
 }
 

--- a/src/admin.c
+++ b/src/admin.c
@@ -403,6 +403,7 @@ master_key(char* password, bool generate_pwd, int pwd_length)
    fclose(file);
 
    chmod(&buf[0], S_IRUSR | S_IWUSR);
+   printf( "Master Key stored into [%s]\n", &buf[0] );
 
    return 0;
 

--- a/src/admin.c
+++ b/src/admin.c
@@ -352,6 +352,8 @@ master_key(char* password, bool generate_pwd, int pwd_length)
 
    if (password == NULL)
    {
+     int loops = 0; /* keep track about how many times the user has tried */
+     
       if (!generate_pwd)
       {
          while (!is_valid_key(password))
@@ -362,9 +364,15 @@ master_key(char* password, bool generate_pwd, int pwd_length)
                password = NULL;
             }
 
-            printf("Master key: ");
+	    // if the user has tried with an invalid
+	    // password, warn her!
+	    if ( loops > 0 )
+	      printf( "Invalid master key, try again\n" );
+	    
+            printf("Master key (will not echo): ");
             password = pgagroal_get_password();
             printf("\n");
+	    loops++;
          }
       }
       else


### PR DESCRIPTION
While using `pgagroal-admin` I found some odd cases that could be improved:
- warn the user when the inserted password is not valid, otherwise the user will see `Master Key` on the screen without any hint;
- print out where the vault is stored
- catch SIGINT during the insertion of the master key.

Since I'm not a day-by-day C developer, please review carefully.