### PR TITLE
Config error messages

### DIFF
--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -208,6 +208,7 @@ struct limit
    int max_size;                       /**< The maximum pool size */
    int initial_size;                   /**< The initial pool size */
    int min_size;                       /**< The minimum pool size */
+   int lineno;                         /**< The line number within the configuration file */
 } __attribute__ ((aligned (64)));
 
 /** @struct

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -1250,19 +1250,25 @@ pgagroal_read_limit_configuration(void* shm, char* filename)
    int min_size;
    int server_max;
    struct configuration* config;
+   int lineno;
 
    file = fopen(filename, "r");
 
    if (!file)
       return 1;
 
-   index = 0;
+   index  = 0;
+   lineno = 0;
    config = (struct configuration*)shm;
 
    server_max = config->max_connections;
 
    while (fgets(line, sizeof(line), file))
    {
+     // set immediatly the line number that can be used in
+     // error messages
+     config->limits[index].lineno = ++lineno;
+       
       if (!is_empty_string(line))
       {
          if (line[0] == '#' || line[0] == ';')
@@ -1302,7 +1308,10 @@ pgagroal_read_limit_configuration(void* shm, char* filename)
 					line );
                      server_max = 0;
                      max_size = 0;
-		     pgagroal_log_warn( "max_size greater than remaining available connections at entry %d, adjusting max_size to zero for this entry", index );
+		     pgagroal_log_warn( "max_size greater than remaining available connections at entry %d (line %d of file %s), adjusting max_size to zero for this entry",
+					index + 1,
+					config->limits[index].lineno,
+					filename );
 
                   }
 

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -1297,23 +1297,30 @@ pgagroal_read_limit_configuration(void* shm, char* filename)
                      min_size = max_size;
                   }
 
-                  server_max -= max_size;
+		  if ( server_max == 0 )
+		    // already hit lower limit, no need to produce error messages again
+		    max_size = 0;
+		  else
+		    {
+		  
+		      server_max -= max_size;
 
-                  if (server_max < 0)
-                  {
-		    pgagroal_log_debug( "limit entry %d with max_size = %d exceeds remaining available connections %d. Line: %s",
-					index,
-					max_size,
-					max_size + server_max,
-					line );
-                     server_max = 0;
-                     max_size = 0;
-		     pgagroal_log_warn( "max_size greater than remaining available connections at entry %d (line %d of file %s), adjusting max_size to zero for this entry",
-					index + 1,
-					config->limits[index].lineno,
-					filename );
+		      if (server_max < 0)
+			{
+			  pgagroal_log_debug( "limit entry %d with max_size = %d exceeds remaining available connections %d. Line: %s",
+					      index,
+					      max_size,
+					      max_size + server_max,
+					      line );
+			  server_max = 0;
+			  max_size = 0;
+			  pgagroal_log_warn( "max_size greater than remaining available connections at entry %d (line %d of file %s), adjusting max_size to zero for this entry",
+					     index + 1,
+					     config->limits[index].lineno,
+					     filename );
 
-                  }
+			}
+		    }
 
                   memcpy(&(config->limits[index].database), database, strlen(database));
                   memcpy(&(config->limits[index].username), username, strlen(username));

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -1295,8 +1295,15 @@ pgagroal_read_limit_configuration(void* shm, char* filename)
 
                   if (server_max < 0)
                   {
+		    pgagroal_log_debug( "limit entry %d with max_size = %d exceeds remaining available connections %d. Line: %s",
+					index,
+					max_size,
+					max_size + server_max,
+					line );
                      server_max = 0;
                      max_size = 0;
+		     pgagroal_log_warn( "max_size greater than remaining available connections at entry %d, adjusting max_size to zero for this entry", index );
+
                   }
 
                   memcpy(&(config->limits[index].database), database, strlen(database));

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -808,7 +808,7 @@ pgagroal_prefill(bool initial)
 
    config = (struct configuration*)shmem;
 
-   pgagroal_log_debug("pgagroal_prefill");
+   pgagroal_log_debug("pgagroal_prefill with %d limits", config->number_of_limits );
 
    for (int i = 0; i < config->number_of_limits; i++)
    {


### PR DESCRIPTION
As per discussion <https://github.com/agroal/pgagroal/discussions/199>, this implements a better warning message for limits that go beyond the availability of connections.

The end result is:

```
DEBUG configuration.c:1314 limit entry 0 with max_size = 50 exceeds remaining available connections 10. Line: pgbench pgbench 50 10  5

WARN  configuration.c:1320 max_size greater than remaining available connections at entry 1 (line 2 of file /etc/pgagroal/pgagroal_databases.conf), adjusting max_size to zero for this entry

FATAL configuration.c:1388 max_size must be greater than 0 for limit entry 1
```

the `DEBUG` and `WARN` are added messages that explain when the user should look at to fix the problem. Only one warning message is printed out, even if the subsequent entries are zeroed too.
This attaches also a `lineno` field to the `limit` struct to keep track of the configruation line, in order to help the user to fix the problem.