### PR TITLE
[#206] Remove is_valid_password function and provide better messages.

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -354,19 +354,19 @@ master_key(char* password, bool generate_pwd, int pwd_length)
    {
       if (!generate_pwd)
       {
-        while( password == NULL )
-        {
-          printf("Master key (will not echo): ");
-          password = pgagroal_get_password();
-          printf("\n");
+         while( password == NULL )
+         {
+            printf("Master key (will not echo): ");
+            password = pgagroal_get_password();
+            printf("\n");
 
-          if (password != NULL && strlen(password) < MIN_PASSWORD_LENGTH )
-          {
-            printf("Invalid key length, must be at least %d chars.\n", MIN_PASSWORD_LENGTH );
-            free(password);
-            password = NULL;
-          }
-        }
+            if (password != NULL && strlen(password) < MIN_PASSWORD_LENGTH )
+            {
+               printf("Invalid key length, must be at least %d chars.\n", MIN_PASSWORD_LENGTH );
+               free(password);
+               password = NULL;
+            }
+         }
       }
       else
       {


### PR DESCRIPTION
Close #206.

See <https://github.com/agroal/pgagroal/pull/200#issuecomment-1032660243>.
The is_valid_password() was checking only the password length and the fact
that was made by ASCII chars.
The check for the length can be done "inline" directly within a loop.
Added a constant with the minimal length of the password, so that it is possible
to insert a warning message for the user in the case she inputs a too short password.

The system also prompts the user for a password with a message that explicitly tells
her the password will not appear on the terminal.

See also the initial work on #200.