### PR TITLE
[#208] Tell the user where the master key is stored.

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -391,7 +391,7 @@ master_key(char* password, bool generate_pwd, int pwd_length)
    fclose(file);
 
    chmod(&buf[0], S_IRUSR | S_IWUSR);
-
+   printf("Master Key stored into %s\n", &buf[0]);
    return 0;
 
 error:


### PR DESCRIPTION
Close #208.

Similar to commit 5de2957
When the master key file is saved, a message is printed out on the terminal
so that the user knows where the file is.
Example of session:

% pgagroal-admin master-key
Master key (will not echo):
Master Key stored into /home/luca/.pgagroal/master.key