### PR TITLE
[#210] Understand all 'debug' levels for log_level.

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -28,7 +28,7 @@ See a [sample](./etc/pgagroal/pgagroal.conf) configuration for running `pgagroal
 | metrics | 0 | Int | No | The metrics port (disable = 0) |
 | management | 0 | Int | No | The remote management port (disable = 0) |
 | log_type | console | String | No | The logging type (console, file, syslog) |
-| log_level | info | String | No | The logging level (fatal, error, warn, info, debug1, ..., debug5) |
+| log_level | info | String | No | The logging level (fatal, error, warn, info, debug, debug1 thru debug5). Debug level greater than 5 will be set to `debug5`. Not recognized values will make the log_level be `info` |
 | log_path | pgagroal.log | String | No | The log file location |
 | log_mode | append | String | No | Append to or create the log file (append, create) |
 | log_connections | `off` | Bool | No | Log connects |

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -2258,20 +2258,29 @@ as_logging_type(char* str)
 static int
 as_logging_level(char* str)
 {
-   if (!strcasecmp(str, "debug5"))
-      return PGAGROAL_LOGGING_LEVEL_DEBUG5;
+    int debug_level = 1;
+    char* debug_value = NULL;
 
-   if (!strcasecmp(str, "debug4"))
-      return PGAGROAL_LOGGING_LEVEL_DEBUG4;
+   if (!strncasecmp(str, "debug", strlen("debug")))
+   {
+      if (strlen(str) > strlen("debug"))
+      {
+         debug_value = (char *) malloc( (strlen(str) - strlen("debug")) * sizeof(char));
+         memcpy(debug_value, str + sizeof("debug") - 1, strlen(str) - strlen("debug") + 1);
+         debug_level = atoi(debug_value);
+     }
 
-   if (!strcasecmp(str, "debug3"))
-      return PGAGROAL_LOGGING_LEVEL_DEBUG3;
-
-   if (!strcasecmp(str, "debug2"))
-      return PGAGROAL_LOGGING_LEVEL_DEBUG2;
-
-   if (!strcasecmp(str, "debug1"))
-      return PGAGROAL_LOGGING_LEVEL_DEBUG1;
+     if (debug_level <= 1)
+       return PGAGROAL_LOGGING_LEVEL_DEBUG1;
+     else if (debug_level == 2)
+       return PGAGROAL_LOGGING_LEVEL_DEBUG2;
+     else if (debug_level == 3)
+       return PGAGROAL_LOGGING_LEVEL_DEBUG3;
+     else if (debug_level == 4)
+       return PGAGROAL_LOGGING_LEVEL_DEBUG4;
+     else if (debug_level >= 5)
+       return PGAGROAL_LOGGING_LEVEL_DEBUG5;
+   }
 
    if (!strcasecmp(str, "info"))
       return PGAGROAL_LOGGING_LEVEL_INFO;

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -2258,8 +2258,8 @@ as_logging_type(char* str)
 static int
 as_logging_level(char* str)
 {
-    int debug_level = 1;
-    char* debug_value = NULL;
+   int debug_level = 1;
+   char* debug_value = NULL;
 
    if (!strncasecmp(str, "debug", strlen("debug")))
    {
@@ -2271,15 +2271,15 @@ as_logging_level(char* str)
      }
 
      if (debug_level <= 1)
-       return PGAGROAL_LOGGING_LEVEL_DEBUG1;
+        return PGAGROAL_LOGGING_LEVEL_DEBUG1;
      else if (debug_level == 2)
-       return PGAGROAL_LOGGING_LEVEL_DEBUG2;
+        return PGAGROAL_LOGGING_LEVEL_DEBUG2;
      else if (debug_level == 3)
-       return PGAGROAL_LOGGING_LEVEL_DEBUG3;
+        return PGAGROAL_LOGGING_LEVEL_DEBUG3;
      else if (debug_level == 4)
-       return PGAGROAL_LOGGING_LEVEL_DEBUG4;
+        return PGAGROAL_LOGGING_LEVEL_DEBUG4;
      else if (debug_level >= 5)
-       return PGAGROAL_LOGGING_LEVEL_DEBUG5;
+        return PGAGROAL_LOGGING_LEVEL_DEBUG5;
    }
 
    if (!strcasecmp(str, "info"))


### PR DESCRIPTION
This makes `log_level` configuration parameter understand
any "debug*" string, like "debug10", as well as "debug".
In particular, if `log_level = debug` (without any number)
the level will be set to `debug1`.
On the other hand, if `log_level = debug99` the
level will be adjusted to `debug5`.

Close #210