### PR TITLE
Return value coherent to logging type macros.

### DIFF
--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -2252,7 +2252,7 @@ as_logging_type(char* str)
    if (!strcasecmp(str, "syslog"))
       return PGAGROAL_LOGGING_TYPE_SYSLOG;
 
-   return 0;
+   return PGAGROAL_LOGGING_TYPE_CONSOLE;
 }
 
 static int


### PR DESCRIPTION
The as_logging_type() function must return
the default logging type PGAGROAL_LOGGING_TYPE_CONSOLE
that has the value 0.
This does not change the behaviour of the application
but makes the code coherent with other
configuration parsing functions.

I don't believe there is the need for an issue for such a commit, since it's just syntax sugar.