### PR TITLE
Log rotation and formatting

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -30,7 +30,9 @@ See a [sample](./etc/pgagroal/pgagroal.conf) configuration for running `pgagroal
 | log_type | console | String | No | The logging type (console, file, syslog) |
 | log_level | info | String | No | The logging level (fatal, error, warn, info, debug1, ..., debug5) |
 | log_path | pgagroal.log | String | No | The log file location |
-| log_mode | append | String | No | Append to or create the log file (append, create) |
+| log_rotation_age | -1 | String | No | The age that will trigger a log file rotation. If expressed as a positive number, is managed as minutes. Supports suffixes: 'H' (hours), 'D' (days), 'W' (weeks), 'M' (months) and 'Y' (years) |
+| log_rotation_size | -1 | String | No | The size of the log file that will trigger a log rotation. Supports suffixes: 'B' (bytes), the default if omitted, 'K' (kilobytes), 'M' (megabytes), 'G' (gigabytes). |
+| log_mode | append | String | No | Append to or create the log file (append, create). The create option truncates an already existing file. |
 | log_connections | `off` | Bool | No | Log connects |
 | log_disconnections | `off` | Bool | No | Log disconnects |
 | blocking_timeout | 30 | Int | No | The number of seconds the process will be blocking for a connection (disable = 0) |

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -29,7 +29,8 @@ See a [sample](./etc/pgagroal/pgagroal.conf) configuration for running `pgagroal
 | management | 0 | Int | No | The remote management port (disable = 0) |
 | log_type | console | String | No | The logging type (console, file, syslog) |
 | log_level | info | String | No | The logging level (fatal, error, warn, info, debug1, ..., debug5) |
-| log_path | pgagroal.log | String | No | The log file location |
+| log_line_prefix | %Y-%m-%d %H:%M:%S | String | No | A prefix to place on every log entry, accepts escape sequences that strftime(3) can parse. No spaces between the string parts are allowed. |
+| log_path | pgagroal.log | String | No | The log file location. Can include escape sequences that strftime(3) accepts, e.g., pgagroal-%Y-%m-%d-%H-%M-%S.log |
 | log_rotation_age | -1 | String | No | The age that will trigger a log file rotation. If expressed as a positive number, is managed as seconds. Supports suffixes: 'S' (seconds, the default), 'M' (minutes), 'H' (hours), 'D' (days), 'W' (weeks) |
 | log_rotation_size | -1 | String | No | The size of the log file that will trigger a log rotation. Supports suffixes: 'B' (bytes), the default if omitted, 'K' (kilobytes), 'M' (megabytes), 'G' (gigabytes). |
 | log_mode | append | String | No | Append to or create the log file (append, create). The create option truncates an already existing file. |

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -30,7 +30,7 @@ See a [sample](./etc/pgagroal/pgagroal.conf) configuration for running `pgagroal
 | log_type | console | String | No | The logging type (console, file, syslog) |
 | log_level | info | String | No | The logging level (fatal, error, warn, info, debug1, ..., debug5) |
 | log_path | pgagroal.log | String | No | The log file location |
-| log_rotation_age | -1 | String | No | The age that will trigger a log file rotation. If expressed as a positive number, is managed as minutes. Supports suffixes: 'H' (hours), 'D' (days), 'W' (weeks), 'M' (months) and 'Y' (years) |
+| log_rotation_age | -1 | String | No | The age that will trigger a log file rotation. If expressed as a positive number, is managed as seconds. Supports suffixes: 'S' (seconds, the default), 'M' (minutes), 'H' (hours), 'D' (days), 'W' (weeks) |
 | log_rotation_size | -1 | String | No | The size of the log file that will trigger a log rotation. Supports suffixes: 'B' (bytes), the default if omitted, 'K' (kilobytes), 'M' (megabytes), 'G' (gigabytes). |
 | log_mode | append | String | No | Append to or create the log file (append, create). The create option truncates an already existing file. |
 | log_connections | `off` | Bool | No | Log connects |

--- a/src/include/logging.h
+++ b/src/include/logging.h
@@ -90,21 +90,74 @@ pgagroal_log_line(int level, char *file, int line, char *fmt, ...);
 void
 pgagroal_log_mem(void* data, size_t size);
 
-  
+/**
+ * Utility function to understand if log rotation
+ * is enabled or not.
+ * Returns `true` if the rotation is enabled.
+ */  
 bool
 log_rotation_enabled(void);
 
+/**
+ * Forces a disabling of the log rotation.
+ * Useful when the system cannot determine how to rotate logs.
+ */  
 void
 log_rotation_disable(void);
 
+/**
+ * Checks if there are the requirements to perform a log rotation.
+ * It returns true in either the case of the size exceeded or
+ * the age exceeded. The age is contained into a global
+ * variable 'next_log_rotation_age' that express the number
+ * of seconds at which the next rotation will be performed.
+ */  
 bool
 log_rotation_required(void);
 
+/**
+ * Function to compute the next instant at which a log rotation
+ * will happen. It computes only if the logging is to a file
+ * and only if the configuration tells to compute the rotation
+ * age.
+ * Returns true on success.
+ */  
 bool
 log_rotation_set_next_rotation_age(void);  
 
+/**
+ * Opens the log file defined in the configuration.
+ * Works only for a real log file, i.e., the configuration
+ * must be set up to log to a file, not console.
+ *
+ * The function considers the settings in the configuration
+ * to determine the mode (append, create) and the filename
+ * to open.
+ *
+ * It sets the global variable 'log_file'.
+ *
+ * If it succeed in opening the log file, it calls
+ * the log_rotation_set_next_rotation_age() function to
+ * determine the next instant at which the log file
+ * must be rotated. Calling such function is safe
+ * because if the log rotation is disabled, the function
+ * does nothing.
+ *
+ * Returns 0 on success, 1 on error.
+ */  
 int
-log_file_open(void);  
+log_file_open(void);
+
+/**
+ * Performs a log file rotation.
+ * It flushes and closes the current log file,
+ * then re-opens it.
+ *
+ * DO NOT LOG WITHIN THIS FUNCTION as long as this
+ * is invoked by log_line
+ */
+void
+log_file_rotate(void);
 
 #ifdef __cplusplus
 }

--- a/src/include/logging.h
+++ b/src/include/logging.h
@@ -52,6 +52,9 @@ extern "C" {
 #define PGAGROAL_LOGGING_MODE_CREATE 0
 #define PGAGROAL_LOGGING_MODE_APPEND 1
 
+#define PGAGROAL_LOGGING_ROTATION_DISABLED -1
+
+  
 #define pgagroal_log_trace(...) pgagroal_log_line(PGAGROAL_LOGGING_LEVEL_DEBUG5, __FILE__, __LINE__, __VA_ARGS__)
 #define pgagroal_log_debug(...) pgagroal_log_line(PGAGROAL_LOGGING_LEVEL_DEBUG1, __FILE__, __LINE__, __VA_ARGS__)
 #define pgagroal_log_info(...)  pgagroal_log_line(PGAGROAL_LOGGING_LEVEL_INFO,  __FILE__, __LINE__,  __VA_ARGS__)
@@ -85,6 +88,22 @@ pgagroal_log_line(int level, char *file, int line, char *fmt, ...);
 
 void
 pgagroal_log_mem(void* data, size_t size);
+
+  
+bool
+log_rotation_enabled(void);
+
+void
+log_rotation_disable(void);
+
+bool
+log_rotation_required(void);
+
+bool
+log_rotation_set_next_rotation_age(void);  
+
+int
+log_file_open(void);  
 
 #ifdef __cplusplus
 }

--- a/src/include/logging.h
+++ b/src/include/logging.h
@@ -54,6 +54,7 @@ extern "C" {
 
 #define PGAGROAL_LOGGING_ROTATION_DISABLED -1
 
+#define PGAGROAL_LOGGING_DEFAULT_LOG_LINE_PREFIX "%Y-%m-%d %H:%M:%S"
   
 #define pgagroal_log_trace(...) pgagroal_log_line(PGAGROAL_LOGGING_LEVEL_DEBUG5, __FILE__, __LINE__, __VA_ARGS__)
 #define pgagroal_log_debug(...) pgagroal_log_line(PGAGROAL_LOGGING_LEVEL_DEBUG1, __FILE__, __LINE__, __VA_ARGS__)

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -306,7 +306,7 @@ struct configuration
    atomic_schar log_lock;      /**< The logging lock */
    int log_rotation_size;      /**< bytes to force log rotation */
    int log_rotation_age;       /**< minutes for log rotation */
-   bool log_truncate;          /**< Truncate an existing log on rotation */
+   char log_line_prefix[MISC_LENGTH]; /**< The logging prefix */
 
    bool authquery; /**< Is authentication query enabled */
 

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -304,6 +304,9 @@ struct configuration
    bool log_disconnections;    /**< Log disconnects */
    int log_mode;               /**< The logging mode */
    atomic_schar log_lock;      /**< The logging lock */
+   int log_rotation_size;      /**< bytes to force log rotation */
+   int log_rotation_age;       /**< minutes for log rotation */
+   bool log_truncate;          /**< Truncate an existing log on rotation */
 
    bool authquery; /**< Is authentication query enabled */
 

--- a/src/include/pool.h
+++ b/src/include/pool.h
@@ -92,6 +92,13 @@ void
 pgagroal_flush(int mode, char* database);
 
 /**
+ * Flush the pool for a specific server
+ * @param server The server
+ */
+void
+pgagroal_flush_server(signed char server);
+
+/**
  * Prefill the pool
  * @param initial Use initial size
  */

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -2252,7 +2252,7 @@ as_logging_type(char* str)
    if (!strcasecmp(str, "syslog"))
       return PGAGROAL_LOGGING_TYPE_SYSLOG;
 
-   return 0;
+   return PGAGROAL_LOGGING_TYPE_CONSOLE;
 }
 
 static int

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -627,6 +627,22 @@ pgagroal_read_configuration(void* shm, char* filename)
                  }
 
                }
+	       else if (!strcmp(key, "log_line_prefix"))
+               {
+                 if (!strcmp(section, "pgagroal"))
+                 {
+                    max = strlen(value);
+		    if (max > MISC_LENGTH - 1)
+		      max = MISC_LENGTH - 1;
+
+		    memcpy(config->log_line_prefix, value, max);
+                 }
+                 else
+                 {
+                   unknown = true;
+                 }
+
+               }
                else if (!strcmp(key, "log_connections"))
                {
                   if (!strcmp(section, "pgagroal"))

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -627,15 +627,15 @@ pgagroal_read_configuration(void* shm, char* filename)
                  }
 
                }
-	       else if (!strcmp(key, "log_line_prefix"))
+               else if (!strcmp(key, "log_line_prefix"))
                {
                  if (!strcmp(section, "pgagroal"))
                  {
                     max = strlen(value);
-		    if (max > MISC_LENGTH - 1)
-		      max = MISC_LENGTH - 1;
+                    if (max > MISC_LENGTH - 1)
+                      max = MISC_LENGTH - 1;
 
-		    memcpy(config->log_line_prefix, value, max);
+                    memcpy(config->log_line_prefix, value, max);
                  }
                  else
                  {

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -49,6 +49,7 @@
 #ifdef HAVE_LINUX
 #include <systemd/sd-daemon.h>
 #endif
+#include <ctype.h>
 
 #define LINE_LENGTH 512
 
@@ -58,6 +59,8 @@ static int as_bool(char* str, bool* b);
 static int as_logging_type(char* str);
 static int as_logging_level(char* str);
 static int as_logging_mode(char* str);
+static int as_logging_rotation_size(char* str, int* size);
+static int as_logging_rotation_age(char* str, int* age);
 static int as_validation(char* str);
 static int as_pipeline(char* str);
 static int as_hugepage(char* str);
@@ -593,6 +596,36 @@ pgagroal_read_configuration(void* shm, char* filename)
                   {
                      unknown = true;
                   }
+               }
+               else if (!strcmp(key, "log_rotation_size"))
+               {
+                 if (!strcmp(section, "pgagroal"))
+                 {
+                   if (as_logging_rotation_size(value, &config->log_rotation_size))
+                   {
+                     unknown = true;
+                   }
+                 }
+                 else
+                 {
+                   unknown = true;
+                 }
+
+               }
+               else if (!strcmp(key, "log_rotation_age"))
+               {
+                 if (!strcmp(section, "pgagroal"))
+                 {
+                   if (as_logging_rotation_age(value, &config->log_rotation_age))
+                   {
+                     unknown = true;
+                   }
+                 }
+                 else
+                 {
+                   unknown = true;
+                 }
+
                }
                else if (!strcmp(key, "log_connections"))
                {
@@ -2748,4 +2781,172 @@ is_empty_string(char* s)
    }
 
    return true;
+}
+
+
+/**
+ * Parses a string to see if it contains
+ * a valid value for log rotation size.
+ * Returns 0 if parsing ok, 1 otherwise.
+ *
+ * Valid strings have one of the suffixes:
+ * - k for kilobytes
+ * - m for megabytes
+ * - g for gigabytes
+ *
+ * The default is expressed always as kilobytes. The functions sets the
+ * rotation size in kilobytes.
+ */
+static int
+as_logging_rotation_size(char* str, int* size)
+{
+  int multiplier = 1;
+  int index;
+  char value[MISC_LENGTH];
+  bool multiplier_set = false;
+  
+  if (is_empty_string(str))
+  {
+    *size = PGAGROAL_LOGGING_ROTATION_DISABLED;
+    return 0;
+  }
+
+  index = 0;
+  for (int i = 0; i < strlen(str); i++)
+  {
+    if (isdigit(str[i]))
+    {
+      value[index++] = str[i];
+    }
+    else if (isalpha(str[i]) && multiplier_set)
+    {
+      *size = PGAGROAL_LOGGING_ROTATION_DISABLED;
+      return 1; 
+    }
+    else if (isalpha(str[i]) && ! multiplier_set)
+    {
+      
+      if (str[i] == 'M' || str[i] == 'm')
+      {
+        multiplier = 1024 * 1024;
+        multiplier_set = true;
+      }
+      else if(str[i] == 'G' || str[i] == 'g')
+      {
+        multiplier = 1024 * 1024 * 1024;
+        multiplier_set = true;
+      }
+      else if(str[i] == 'K' || str[i] == 'k')
+      {
+        multiplier = 1024;
+        multiplier_set = true;
+      }
+      else if(str[i] == 'B' || str[i] == 'b')
+      {
+        multiplier = 1;
+        multiplier_set = true;
+      }
+    }
+    else
+      // ignore alien chars
+      continue;
+  }
+
+  value[index] = '\0';
+  if (!as_int(value, size))
+  {
+    *size = *size * multiplier;
+    return 0;
+  }
+  else
+  {
+      *size = PGAGROAL_LOGGING_ROTATION_DISABLED;
+      return 1;
+  }
+
+}
+
+
+/**
+ * Parses the log_rotation_age string.
+ * The string accepts
+ * - h for hours
+ * - d for days
+ * - w for weeks
+ * - m for months
+ * - y for years
+ *
+ * The default is expressed in minutes.
+ * The function sets the number of rotationg age as minutes.
+ * Returns 1 for errors, 0 for correct parsing.
+ */
+static int
+as_logging_rotation_age(char* str, int* age)
+{
+  int multiplier = 1;
+  int index;
+  char value[MISC_LENGTH];
+  bool multiplier_set = false;
+  
+  if (is_empty_string(str))
+  {
+    *age = PGAGROAL_LOGGING_ROTATION_DISABLED;
+    return 0;
+  }
+
+  index = 0;
+  for (int i = 0; i < strlen(str); i++)
+  {
+    if (isdigit(str[i]))
+    {
+      value[index++] = str[i];
+    }
+    else if (isalpha(str[i]) && multiplier_set)
+    {
+      *age = PGAGROAL_LOGGING_ROTATION_DISABLED;
+      return 1;
+    }
+    else if (isalpha(str[i]) && ! multiplier_set)
+    {
+      if (str[i] == 'h' || str[i] == 'H')
+      {
+        multiplier = 60;
+        multiplier_set = true;
+      }
+      else if (str[i] == 'd' || str[i] == 'D')
+      {
+        multiplier = 24 * 60;
+        multiplier_set = true;
+      }
+      else if (str[i] == 'w' || str[i] == 'W')
+      {
+        multiplier = 24 * 60 * 7;
+        multiplier_set = true;
+      }
+      else if (str[i] == 'm' || str[i] == 'M')
+      {
+        multiplier = 24 * 60 * 7 * 31;
+        multiplier_set = true;
+      }
+      else if (str[i] == 'y' || str[i] == 'Y')
+      {
+        multiplier = 24 * 60 * 365;
+        multiplier_set = true;
+      }
+    }
+    else
+      continue;
+  }
+
+  value[index] = '\0';
+  if (!as_int(value, age))
+  {
+    *age = *age * multiplier;
+    return 0;
+  }
+  else
+  {
+      *age = PGAGROAL_LOGGING_ROTATION_DISABLED;
+      return 1;
+  }
 }

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -2870,13 +2870,13 @@ as_logging_rotation_size(char* str, int* size)
 /**
  * Parses the log_rotation_age string.
  * The string accepts
+ * - s for seconds
+ * - m for minutes
  * - h for hours
  * - d for days
  * - w for weeks
- * - m for months
- * - y for years
  *
- * The default is expressed in minutes.
+ * The default is expressed in seconds.
  * The function sets the number of rotationg age as minutes.
  * Returns 1 for errors, 0 for correct parsing.
  */
@@ -2908,29 +2908,29 @@ as_logging_rotation_age(char* str, int* age)
     }
     else if (isalpha(str[i]) && ! multiplier_set)
     {
-      if (str[i] == 'h' || str[i] == 'H')
+      if (str[i] == 's' || str[i] == 'S')
       {
-        multiplier = 60;
-        multiplier_set = true;
-      }
-      else if (str[i] == 'd' || str[i] == 'D')
-      {
-        multiplier = 24 * 60;
-        multiplier_set = true;
-      }
-      else if (str[i] == 'w' || str[i] == 'W')
-      {
-        multiplier = 24 * 60 * 7;
+        multiplier = 1;
         multiplier_set = true;
       }
       else if (str[i] == 'm' || str[i] == 'M')
       {
-        multiplier = 24 * 60 * 7 * 31;
+        multiplier = 60;
         multiplier_set = true;
       }
-      else if (str[i] == 'y' || str[i] == 'Y')
+      else if (str[i] == 'h' || str[i] == 'H')
       {
-        multiplier = 24 * 60 * 365;
+        multiplier = 3600;
+        multiplier_set = true;
+      }
+      else if (str[i] == 'd' || str[i] == 'D')
+      {
+        multiplier = 24 * 3600;
+        multiplier_set = true;
+      }
+      else if (str[i] == 'w' || str[i] == 'W')
+      {
+        multiplier = 24 * 3600 * 7;
         multiplier_set = true;
       }
     }

--- a/src/libpgagroal/logging.c
+++ b/src/libpgagroal/logging.c
@@ -71,91 +71,70 @@ static const char* colors[] =
 };
 
 
-/**
- * Utility function to understand if log rotation
- * is enabled or not.
- * Returns `true` if the rotation is enabled.
- */
+
 bool
 log_rotation_enabled(void)
 {
-  struct configuration* config;
-  config = (struct configuration*)shmem;
+   struct configuration* config;
+   config = (struct configuration*)shmem;
 
-  // disable log rotation in the case
-  // logging is not to a file
-  if (config->log_type != PGAGROAL_LOGGING_TYPE_FILE)
-  {
-     log_rotation_disable();
-     return false;
-  }
+   // disable log rotation in the case
+   // logging is not to a file
+   if (config->log_type != PGAGROAL_LOGGING_TYPE_FILE)
+   {
+      log_rotation_disable();
+      return false;
+   }
 
-  // log rotation is enabled if either log_rotation_age or
-  // log_rotation_size is enabled
-  return config->log_rotation_age != PGAGROAL_LOGGING_ROTATION_DISABLED
-      || config->log_rotation_size != PGAGROAL_LOGGING_ROTATION_DISABLED;
+   // log rotation is enabled if either log_rotation_age or
+   // log_rotation_size is enabled
+   return config->log_rotation_age != PGAGROAL_LOGGING_ROTATION_DISABLED
+       || config->log_rotation_size != PGAGROAL_LOGGING_ROTATION_DISABLED;
 }
 
-/**
- * Forces a disabling of the log rotation.
- * Useful when the system cannot determine how to rotate logs.
- */
+
 void
 log_rotation_disable(void)
 {
-  struct configuration* config;
-  config = (struct configuration*)shmem;
+   struct configuration* config;
+   config = (struct configuration*)shmem;
 
-  config->log_rotation_age  = PGAGROAL_LOGGING_ROTATION_DISABLED;
-  config->log_rotation_size = PGAGROAL_LOGGING_ROTATION_DISABLED;
-  next_log_rotation_age = 0;
+   config->log_rotation_age  = PGAGROAL_LOGGING_ROTATION_DISABLED;
+   config->log_rotation_size = PGAGROAL_LOGGING_ROTATION_DISABLED;
+   next_log_rotation_age     = 0;
 }
 
-/**
- * Checks if there are the requirements to perform a log rotation.
- * It returns true in either the case of the size exceeded or
- * the age exceeded. The age is contained into a global
- * variable 'next_log_rotation_age' that express the number
- * of seconds at which the next rotation will be performed.
- */
 bool
 log_rotation_required(void)
 {
-  struct stat log_stat;
-  struct configuration* config;
+   struct stat log_stat;
+   struct configuration* config;
   
-  config = (struct configuration*)shmem;
+   config = (struct configuration*)shmem;
 
-  if (!log_rotation_enabled())
-  {
-    return false;
-  }
+   if (!log_rotation_enabled())
+   {
+      return false;
+   }
 
-  if (stat(current_log_path, &log_stat))
-  {
-    return false;
-  }
+   if (stat(current_log_path, &log_stat))
+   {
+      return false;
+   }
 
-  if (config->log_rotation_size > 0 && log_stat.st_size >= config->log_rotation_size)
-  {
-    return true;
-  }
+   if (config->log_rotation_size > 0 && log_stat.st_size >= config->log_rotation_size)
+   {
+      return true;
+   }
 
-  if (config->log_rotation_age > 0 && next_log_rotation_age > 0 && next_log_rotation_age <= log_stat.st_ctime)
-  {
-    return true;
-  }
+   if (config->log_rotation_age > 0 && next_log_rotation_age > 0 && next_log_rotation_age <= log_stat.st_ctime)
+   {
+      return true;
+   }
 
-  return false;
+   return false;
 }
 
-/**
- * Function to compute the next instant at which a log rotation
- * will happen. It computes only if the logging is to a file
- * and only if the configuration tells to compute the rotation
- * age.
- * Returns true on success.
- */
 bool
 log_rotation_set_next_rotation_age(void)
 {
@@ -169,8 +148,8 @@ log_rotation_set_next_rotation_age(void)
       now = time(NULL);
       if (!now)
       {
-	config->log_rotation_age = PGAGROAL_LOGGING_ROTATION_DISABLED;
-	return false;
+	 config->log_rotation_age = PGAGROAL_LOGGING_ROTATION_DISABLED;
+         return false;
       }
       
       next_log_rotation_age = now + config->log_rotation_age;
@@ -178,10 +157,9 @@ log_rotation_set_next_rotation_age(void)
    }
    else
    {
-     config->log_rotation_age = PGAGROAL_LOGGING_ROTATION_DISABLED;
-     return false;
+      config->log_rotation_age = PGAGROAL_LOGGING_ROTATION_DISABLED;
+      return false;
    }
-
 }
 
 
@@ -240,88 +218,61 @@ pgagroal_start_logging(void)
    return 0;
 }
 
-/**
- * Opens the log file defined in the configuration.
- * Works only for a real log file, i.e., the configuration
- * must be set up to log to a file, not console.
- *
- * The function considers the settings in the configuration
- * to determine the mode (append, create) and the filename
- * to open.
- *
- * It sets the global variable 'log_file'.
- *
- * If it succeed in opening the log file, it calls
- * the log_rotation_set_next_rotation_age() function to
- * determine the next instant at which the log file
- * must be rotated. Calling such function is safe
- * because if the log rotation is disabled, the function
- * does nothing.
- *
- * Returns 0 on success, 1 on error.
- */
+
 int
 log_file_open(void)
 {
-  struct configuration* config;
-  time_t htime;
-  struct tm *tm;
+   struct configuration* config;
+   time_t htime;
+   struct tm *tm;
   
-  config = (struct configuration*)shmem;
+   config = (struct configuration*)shmem;
 
-  if (config->log_type == PGAGROAL_LOGGING_TYPE_FILE)
-  {
-    htime = time( NULL );
-    if (!htime)
-    {
-      log_file = NULL;
-      return 1;
-    }
+   if (config->log_type == PGAGROAL_LOGGING_TYPE_FILE)
+   {
+      htime = time( NULL );
+      if (!htime)
+      {
+         log_file = NULL;
+         return 1;
+      }
       
-    tm = localtime(&htime);
-    if (tm == NULL )
-    {
-      log_file = NULL;
-      return 1;
-    }
+      tm = localtime(&htime);
+      if (tm == NULL )
+      {
+         log_file = NULL;
+         return 1;
+      }
 
-    if (strftime(current_log_path, sizeof(current_log_path), config->log_path, tm) <= 0 )
-    {
-      // cannot parse the format string, fallback to default logging
-      memcpy(current_log_path, "pgagroal.log", strlen("pgagroal.log"));
-      log_rotation_disable();
-    }
+      if (strftime(current_log_path, sizeof(current_log_path), config->log_path, tm) <= 0 )
+      {
+         // cannot parse the format string, fallback to default logging
+         memcpy(current_log_path, "pgagroal.log", strlen("pgagroal.log"));
+         log_rotation_disable();
+      }
 
-    log_file = fopen(current_log_path,
-		     config->log_mode == PGAGROAL_LOGGING_MODE_APPEND ? "a" : "w");
+      log_file = fopen(current_log_path,
+                       config->log_mode == PGAGROAL_LOGGING_MODE_APPEND ? "a" : "w");
 
-    if (!log_file)
-      return 1;
+      if (!log_file)
+        return 1;
 
-    log_rotation_set_next_rotation_age();
-    return 0;
-  }
+      log_rotation_set_next_rotation_age();
+      return 0;
+   }
 
-  return 1;
+   return 1;
 }
 
-/**
- * Performs a log file rotation.
- * It flushes and closes the current log file,
- * then re-opens it.
- *
- * DO NOT LOG WITHIN THIS FUNCTION as long as this
- * is invoked by log_line
- */
 void
 log_file_rotate(void)
 {
-  if (log_rotation_enabled())
-  {
-    fflush(log_file);
-    fclose(log_file);
-    log_file_open();
-  }
+   if (log_rotation_enabled())
+   {
+      fflush(log_file);
+      fclose(log_file);
+      log_file_open();
+   }
 }
 
 


### PR DESCRIPTION
This is a possible not-so-efficient implementation of log rotation and formatting (see #45  and #44).
The idea is that `log_path` supports `strftime(3)`, so that rotation can be enabled. Also added `log_rotation_age` (seconds) and `log_rotation_size` (bytes) and `log_line_prefix` (string).
Example of final configuration:
```
log_path  = /var/log/pgagroal/pgagroal-%Y-%m-%d-%H-%M-%S.log   
log_mode  = create
log_rotation_size = 2M
log_rotation_age = 1m
log_line_prefix  = PGAGROAL-%Y-%m-%d-%H:%M:%S'
```

There are now several `log_rotation_xxx` functions that help keeping the code cleaner. If any of `log_rotation_age` or `log_rotation_size` parameters are enabled, and the logging is to a file, the rotation is enabled, otherwise is disabled.
Whenever a new entry is loggeg, the application looks for the need to rotate.
This is not efficient, since under heavy load the system could spend too much time in trying to understand if rotation is required.
If a rotation is required, the log file is closed and a new one is opened.
The `log_rotation_age` is used in conjunction with a global variable that keeps track of when the next rotation will happen.
Since rotation is evaluated only when a new log entry is issued, rotation will not happen automatically until the next log entry arrives. This means that is an almost-rotation.

Drawbacks:
- rotation happens when a new log entry arrives. Probably we should improve this by means of a kind of "try every n entries", like inspecting for rotation only after 10 entries are logged to improve performances.
-  `log_line_prefix` does not allow spaces, since the `extract_key_value` does not handle spaces too.

We should also evaluate to store global variables `next_log_rotation_age` and `current_log_path` within the configuration structure, because they could be useful also outside of the `logging.c` file (I'm not sure).