### PR TITLE
[#45][#44] Log rotation and formatting support.

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -29,7 +29,10 @@ See a [sample](./etc/pgagroal/pgagroal.conf) configuration for running `pgagroal
 | management | 0 | Int | No | The remote management port (disable = 0) |
 | log_type | console | String | No | The logging type (console, file, syslog) |
 | log_level | info | String | No | The logging level (fatal, error, warn, info, debug, debug1 thru debug5). Debug level greater than 5 will be set to `debug5`. Not recognized values will make the log_level be `info` |
-| log_path | pgagroal.log | String | No | The log file location |
+| log_path | pgagroal.log | String | No | The log file location. Can be a strftime(3) compatible string. |
+| log_rotation_age | -1 | String | No | The age that will trigger a log file rotation. If expressed as a positive number, is managed as seconds. Supports suffixes: 'S' (seconds, the default), 'M' (minutes), 'H' (hours), 'D' (days), 'W' (weeks) |
+| log_rotation_size | -1 | String | No | The size of the log file that will trigger a log rotation. Supports suffixes: 'B' (bytes), the default if omitted, 'K' (kilobytes), 'M' (megabytes), 'G' (gigabytes). |
+| log_line_prefix | %Y-%m-%d %H:%M:%S | String | No | A strftime(3) compatible string to use as prefix for every log line. Must not contain any space. |
 | log_mode | append | String | No | Append to or create the log file (append, create) |
 | log_connections | `off` | Bool | No | Log connects |
 | log_disconnections | `off` | Bool | No | Log disconnects |

--- a/src/include/logging.h
+++ b/src/include/logging.h
@@ -52,6 +52,10 @@ extern "C" {
 #define PGAGROAL_LOGGING_MODE_CREATE 0
 #define PGAGROAL_LOGGING_MODE_APPEND 1
 
+#define PGAGROAL_LOGGING_ROTATION_DISABLED -1
+
+#define PGAGROAL_LOGGING_DEFAULT_LOG_LINE_PREFIX "%Y-%m-%d %H:%M:%S"
+
 #define pgagroal_log_trace(...) pgagroal_log_line(PGAGROAL_LOGGING_LEVEL_DEBUG5, __FILE__, __LINE__, __VA_ARGS__)
 #define pgagroal_log_debug(...) pgagroal_log_line(PGAGROAL_LOGGING_LEVEL_DEBUG1, __FILE__, __LINE__, __VA_ARGS__)
 #define pgagroal_log_info(...)  pgagroal_log_line(PGAGROAL_LOGGING_LEVEL_INFO,  __FILE__, __LINE__,  __VA_ARGS__)
@@ -85,6 +89,75 @@ pgagroal_log_line(int level, char *file, int line, char *fmt, ...);
 
 void
 pgagroal_log_mem(void* data, size_t size);
+
+/**
+ * Utility function to understand if log rotation
+ * is enabled or not.
+ * Returns `true` if the rotation is enabled.
+ */
+bool
+log_rotation_enabled(void);
+
+/**
+ * Forces a disabling of the log rotation.
+ * Useful when the system cannot determine how to rotate logs.
+ */
+void
+log_rotation_disable(void);
+
+/**
+ * Checks if there are the requirements to perform a log rotation.
+ * It returns true in either the case of the size exceeded or
+ * the age exceeded. The age is contained into a global
+ * variable 'next_log_rotation_age' that express the number
+ * of seconds at which the next rotation will be performed.
+ */
+bool
+log_rotation_required(void);
+
+/**
+ * Function to compute the next instant at which a log rotation
+ * will happen. It computes only if the logging is to a file
+ * and only if the configuration tells to compute the rotation
+ * age.
+ * Returns true on success.
+ */
+bool
+log_rotation_set_next_rotation_age(void);
+
+/**
+ * Opens the log file defined in the configuration.
+ * Works only for a real log file, i.e., the configuration
+ * must be set up to log to a file, not console.
+ *
+ * The function considers the settings in the configuration
+ * to determine the mode (append, create) and the filename
+ * to open.
+ *
+ * It sets the global variable 'log_file'.
+ *
+ * If it succeed in opening the log file, it calls
+ * the log_rotation_set_next_rotation_age() function to
+ * determine the next instant at which the log file
+ * must be rotated. Calling such function is safe
+ * because if the log rotation is disabled, the function
+ * does nothing.
+ *
+ * Returns 0 on success, 1 on error.
+ */
+int
+log_file_open(void);
+
+/**
+ * Performs a log file rotation.
+ * It flushes and closes the current log file,
+ * then re-opens it.
+ *
+ * DO NOT LOG WITHIN THIS FUNCTION as long as this
+ * is invoked by log_line
+ */
+void
+log_file_rotate(void);
 
 #ifdef __cplusplus
 }

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -304,6 +304,9 @@ struct configuration
    bool log_disconnections;    /**< Log disconnects */
    int log_mode;               /**< The logging mode */
    atomic_schar log_lock;      /**< The logging lock */
+   int log_rotation_size;      /**< bytes to force log rotation */
+   int log_rotation_age;       /**< minutes for log rotation */
+   char log_line_prefix[MISC_LENGTH]; /**< The logging prefix */
 
    bool authquery; /**< Is authentication query enabled */
 

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -49,6 +49,7 @@
 #ifdef HAVE_LINUX
 #include <systemd/sd-daemon.h>
 #endif
+#include <ctype.h>
 
 #define LINE_LENGTH 512
 
@@ -58,6 +59,8 @@ static int as_bool(char* str, bool* b);
 static int as_logging_type(char* str);
 static int as_logging_level(char* str);
 static int as_logging_mode(char* str);
+static int as_logging_rotation_size(char* str, int* size);
+static int as_logging_rotation_age(char* str, int* age);
 static int as_validation(char* str);
 static int as_pipeline(char* str);
 static int as_hugepage(char* str);
@@ -588,6 +591,51 @@ pgagroal_read_configuration(void* shm, char* filename)
                      if (max > MISC_LENGTH - 1)
                         max = MISC_LENGTH - 1;
                      memcpy(config->log_path, value, max);
+                  }
+                  else
+                  {
+                     unknown = true;
+                  }
+               }
+               else if (!strcmp(key, "log_rotation_size"))
+               {
+                  if (!strcmp(section, "pgagroal"))
+                  {
+                     if (as_logging_rotation_size(value, &config->log_rotation_size))
+                     {
+                        unknown = true;
+                     }
+                  }
+                  else
+                  {
+                     unknown = true;
+                  }
+
+               }
+               else if (!strcmp(key, "log_rotation_age"))
+               {
+                  if (!strcmp(section, "pgagroal"))
+                  {
+                     if (as_logging_rotation_age(value, &config->log_rotation_age))
+                     {
+                        unknown = true;
+                     }
+                  }
+                  else
+                  {
+                     unknown = true;
+                  }
+
+               }
+               else if (!strcmp(key, "log_line_prefix"))
+               {
+                  if (!strcmp(section, "pgagroal"))
+                  {
+                     max = strlen(value);
+                     if (max > MISC_LENGTH - 1)
+                        max = MISC_LENGTH - 1;
+
+                     memcpy(config->log_line_prefix, value, max);
                   }
                   else
                   {
@@ -2757,4 +2805,168 @@ is_empty_string(char* s)
    }
 
    return true;
+}
+
+/**
+ * Parses a string to see if it contains
+ * a valid value for log rotation size.
+ * Returns 0 if parsing ok, 1 otherwise.
+ *
+ * Valid strings have one of the suffixes:
+ * - k for kilobytes
+ * - m for megabytes
+ * - g for gigabytes
+ *
+ * The default is expressed always as kilobytes. The functions sets the
+ * rotation size in kilobytes.
+ */
+static int
+as_logging_rotation_size(char* str, int* size)
+{
+   int multiplier = 1;
+   int index;
+   char value[MISC_LENGTH];
+   bool multiplier_set = false;
+
+   if (is_empty_string(str))
+   {
+      *size = PGAGROAL_LOGGING_ROTATION_DISABLED;
+      return 0;
+   }
+
+   index = 0;
+   for (int i = 0; i < strlen(str); i++)
+   {
+      if (isdigit(str[i]))
+      {
+         value[index++] = str[i];
+      }
+      else if (isalpha(str[i]) && multiplier_set)
+      {
+         *size = PGAGROAL_LOGGING_ROTATION_DISABLED;
+         return 1;
+      }
+      else if (isalpha(str[i]) && ! multiplier_set)
+      {
+         if (str[i] == 'M' || str[i] == 'm')
+         {
+            multiplier = 1024 * 1024;
+            multiplier_set = true;
+         }
+         else if(str[i] == 'G' || str[i] == 'g')
+         {
+            multiplier = 1024 * 1024 * 1024;
+            multiplier_set = true;
+         }
+         else if(str[i] == 'K' || str[i] == 'k')
+         {
+            multiplier = 1024;
+            multiplier_set = true;
+         }
+         else if(str[i] == 'B' || str[i] == 'b')
+         {
+            multiplier = 1;
+            multiplier_set = true;
+         }
+      }
+      else
+        // ignore alien chars
+        continue;
+   }
+
+   value[index] = '\0';
+   if (!as_int(value, size))
+   {
+      *size = *size * multiplier;
+      return 0;
+   }
+   else
+   {
+      *size = PGAGROAL_LOGGING_ROTATION_DISABLED;
+      return 1;
+   }
+}
+
+/**
+ * Parses the log_rotation_age string.
+ * The string accepts
+ * - s for seconds
+ * - m for minutes
+ * - h for hours
+ * - d for days
+ * - w for weeks
+ *
+ * The default is expressed in seconds.
+ * The function sets the number of rotationg age as minutes.
+ * Returns 1 for errors, 0 for correct parsing.
+ */
+static int
+as_logging_rotation_age(char* str, int* age)
+{
+   int multiplier = 1;
+   int index;
+   char value[MISC_LENGTH];
+   bool multiplier_set = false;
+
+   if (is_empty_string(str))
+   {
+      *age = PGAGROAL_LOGGING_ROTATION_DISABLED;
+      return 0;
+   }
+
+   index = 0;
+   for (int i = 0; i < strlen(str); i++)
+   {
+      if (isdigit(str[i]))
+      {
+         value[index++] = str[i];
+      }
+      else if (isalpha(str[i]) && multiplier_set)
+      {
+         *age = PGAGROAL_LOGGING_ROTATION_DISABLED;
+         return 1;
+      }
+      else if (isalpha(str[i]) && ! multiplier_set)
+      {
+         if (str[i] == 's' || str[i] == 'S')
+         {
+            multiplier = 1;
+	    multiplier_set = true;
+         }
+         else if (str[i] == 'm' || str[i] == 'M')
+         {
+            multiplier = 60;
+            multiplier_set = true;
+         }
+         else if (str[i] == 'h' || str[i] == 'H')
+         {
+            multiplier = 3600;
+            multiplier_set = true;
+         }
+         else if (str[i] == 'd' || str[i] == 'D')
+         {
+            multiplier = 24 * 3600;
+            multiplier_set = true;
+         }
+         else if (str[i] == 'w' || str[i] == 'W')
+         {
+            multiplier = 24 * 3600 * 7;
+            multiplier_set = true;
+         }
+      }
+      else
+        continue;
+   }
+
+   value[index] = '\0';
+   if (!as_int(value, age))
+   {
+      *age = *age * multiplier;
+      return 0;
+   }
+   else
+   {
+      *age = PGAGROAL_LOGGING_ROTATION_DISABLED;
+      return 1;
+   }
 }

--- a/src/libpgagroal/logging.c
+++ b/src/libpgagroal/logging.c
@@ -36,10 +36,19 @@
 #include <stdlib.h>
 #include <string.h>
 #include <syslog.h>
+#include <time.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <time.h>
 
 #define LINE_LENGTH 32
 
 FILE *log_file;
+
+time_t next_log_rotation_age;  /* number of seconds at which the next location will happen */
+
+char current_log_path[MAX_PATH]; /* the current log file */
 
 static const char* levels[] =
 {
@@ -61,6 +70,97 @@ static const char* colors[] =
   "\x1b[35m"
 };
 
+bool
+log_rotation_enabled(void)
+{
+   struct configuration* config;
+   config = (struct configuration*)shmem;
+
+   // disable log rotation in the case
+   // logging is not to a file
+   if (config->log_type != PGAGROAL_LOGGING_TYPE_FILE)
+   {
+      log_rotation_disable();
+      return false;
+   }
+
+   // log rotation is enabled if either log_rotation_age or
+   // log_rotation_size is enabled
+   return config->log_rotation_age != PGAGROAL_LOGGING_ROTATION_DISABLED
+      || config->log_rotation_size != PGAGROAL_LOGGING_ROTATION_DISABLED;
+}
+
+void
+log_rotation_disable(void)
+{
+   struct configuration* config;
+   config = (struct configuration*)shmem;
+
+   config->log_rotation_age  = PGAGROAL_LOGGING_ROTATION_DISABLED;
+   config->log_rotation_size = PGAGROAL_LOGGING_ROTATION_DISABLED;
+   next_log_rotation_age = 0;
+}
+
+bool
+log_rotation_required(void)
+{
+   struct stat log_stat;
+   struct configuration* config;
+
+   config = (struct configuration*)shmem;
+
+   if (!log_rotation_enabled())
+   {
+      return false;
+   }
+
+   if (stat(current_log_path, &log_stat))
+   {
+      return false;
+   }
+
+   if (config->log_rotation_size > 0 && log_stat.st_size >= config->log_rotation_size)
+   {
+      return true;
+   }
+
+   if (config->log_rotation_age > 0 && next_log_rotation_age > 0 && next_log_rotation_age <= log_stat.st_ctime)
+   {
+      return true;
+   }
+
+   return false;
+}
+
+
+bool
+log_rotation_set_next_rotation_age(void)
+{
+   struct configuration* config;
+   time_t now;
+
+   config = (struct configuration*)shmem;
+
+   if (config->log_type == PGAGROAL_LOGGING_TYPE_FILE && config->log_rotation_age > 0)
+   {
+      now = time(NULL);
+      if (!now)
+      {
+         config->log_rotation_age = PGAGROAL_LOGGING_ROTATION_DISABLED;
+         return false;
+      }
+
+      next_log_rotation_age = now + config->log_rotation_age;
+      return true;
+   }
+   else
+   {
+      config->log_rotation_age = PGAGROAL_LOGGING_ROTATION_DISABLED;
+      return false;
+   }
+}
+
+
 /**
  *
  */
@@ -73,33 +173,13 @@ pgagroal_init_logging(void)
 
    if (config->log_type == PGAGROAL_LOGGING_TYPE_FILE)
    {
-      if (strlen(config->log_path) > 0)
-      {
-         if (config->log_mode == PGAGROAL_LOGGING_MODE_APPEND)
-         {
-            log_file = fopen(config->log_path, "a");
-         }
-         else
-         {
-            log_file = fopen(config->log_path, "w");
-         }
-      }
-      else
-      {
-         if (config->log_mode == PGAGROAL_LOGGING_MODE_APPEND)
-         {
-            log_file = fopen("pgagroal.log", "a");
-         }
-         else
-         {
-            log_file = fopen("pgagroal.log", "w");
-         }
-      }
+      log_file_open();
 
       if (!log_file)
       {
          printf("Failed to open log file %s due to %s\n", strlen(config->log_path) > 0 ? config->log_path : "pgagroal.log", strerror(errno));
          errno = 0;
+         log_rotation_disable();
          return 1;
       }
    }
@@ -117,16 +197,9 @@ pgagroal_start_logging(void)
 
    config = (struct configuration*)shmem;
 
-   if (config->log_type == PGAGROAL_LOGGING_TYPE_FILE)
+   if (config->log_type == PGAGROAL_LOGGING_TYPE_FILE && !log_file)
    {
-      if (strlen(config->log_path) > 0)
-      {
-         log_file = fopen(config->log_path, "a");
-      }
-      else
-      {
-         log_file = fopen("pgagroal.log", "a");
-      }
+      log_file_open();
 
       if (!log_file)
       {
@@ -142,6 +215,62 @@ pgagroal_start_logging(void)
 
    return 0;
 }
+
+int
+log_file_open(void)
+{
+   struct configuration* config;
+   time_t htime;
+   struct tm *tm;
+
+   config = (struct configuration*)shmem;
+
+   if (config->log_type == PGAGROAL_LOGGING_TYPE_FILE)
+   {
+      htime = time( NULL );
+      if (!htime)
+      {
+         log_file = NULL;
+	 return 1;
+      }
+
+      tm = localtime(&htime);
+      if (tm == NULL )
+      {
+         log_file = NULL;
+	 return 1;
+      }
+
+      if (strftime(current_log_path, sizeof(current_log_path), config->log_path, tm) <= 0 )
+      {
+         // cannot parse the format string, fallback to default logging
+         memcpy(current_log_path, "pgagroal.log", strlen("pgagroal.log"));
+         log_rotation_disable();
+      }
+
+      log_file = fopen(current_log_path, config->log_mode == PGAGROAL_LOGGING_MODE_APPEND ? "a" : "w");
+
+      if (!log_file)
+         return 1;
+
+      log_rotation_set_next_rotation_age();
+      return 0;
+   }
+
+   return 1;
+}
+
+void
+log_file_rotate(void)
+{
+   if (log_rotation_enabled())
+   {
+      fflush(log_file);
+      fclose(log_file);
+      log_file_open();
+   }
+}
+
 
 /**
  *
@@ -209,11 +338,16 @@ retry:
             filename = file;
          }
 
+	 if (config->log_line_prefix == NULL || strlen(config->log_line_prefix) == 0)
+	 {
+	    memcpy(config->log_line_prefix,PGAGROAL_LOGGING_DEFAULT_LOG_LINE_PREFIX,strlen(PGAGROAL_LOGGING_DEFAULT_LOG_LINE_PREFIX));
+	 }
+
          va_start(vl, fmt);
 
          if (config->log_type == PGAGROAL_LOGGING_TYPE_CONSOLE)
          {
-            buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", tm)] = '\0';
+            buf[strftime(buf, sizeof(buf), config->log_line_prefix, tm)] = '\0';
             fprintf(stdout, "%s %s%-5s\x1b[0m \x1b[90m%s:%d\x1b[0m ",
                     buf, colors[level - 1], levels[level - 1],
                     filename, line);
@@ -223,12 +357,17 @@ retry:
          }
          else if (config->log_type == PGAGROAL_LOGGING_TYPE_FILE)
          {
-            buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", tm)] = '\0';
+            buf[strftime(buf, sizeof(buf), config->log_line_prefix, tm)] = '\0';
             fprintf(log_file, "%s %-5s %s:%d ",
                     buf, levels[level - 1], filename, line);
             vfprintf(log_file, fmt, vl);
             fprintf(log_file, "\n");
             fflush(log_file);
+
+	    if (log_rotation_required())
+	    {
+	       log_file_rotate();
+	    }
          }
          else if (config->log_type == PGAGROAL_LOGGING_TYPE_SYSLOG)
          {


### PR DESCRIPTION
See initial work in #213.
This patch implements the log rotation and formatting support.
There are now three new configuration options:
- log_line_prefix is a strftime(3) compatible string that is used
  as a prefix whenever a new line is logged to console or file;
- log_rotation_age provides the age (in seconds) of when the log must
  be rotated. There is raw support for human strings like '1d' for
  'one day';
- log_rotation_size provides the size in bytes when the log must be
  rotated.

Log rotation is evaluated at every new log line issuing, that means
the age and the size are not honored effectively until a new log line
is issued. When the system decides to rotate the log, the log file
is flushed and a new one is opened. To allow rotation, log_path
supports a strftime(3) compatible string like
log_path  = /var/log/pgagroal/pgagroal-%Y-%m-%d-%H-%M-%S.log
so that whnever a new log file must to be created, it can be
placed side by side the closed one.
In the case the new log file already exists, the log_mode is
used to decide if the log must be truncated or used in append mode.

In the case the log_mode is set to console or to syslog, the
log rotation is automatically disabled, therefore the overhead of
the rotation machinery will be applied only when logging to a file.

Example of configuration:

log_type  = file
log_level = info
log_path  = /var/log/pgagroal/pgagroal-%Y-%m-%d-%H-%M-%S.log
log_mode  = create
log_rotation_size = 2M
log_rotation_age = 1m
log_line_prefix  = PGAGROAL-%Y-%m-%d-%H:%M:%S'

Close #44
Close #45