### PR TITLE
[#221] Fix broken link to sample configuration file.

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -16,7 +16,7 @@ All properties are in the format `key = value`.
 The characters `#` and `;` can be used for comments; must be the first character on the line.
 The `Bool` data type supports the following values: `on`, `1`, `true`, `off`, `0` and `false`.
 
-See a [sample](./etc/pgagroal/pgagroal.conf) configuration for running `pgagroal` on `localhost`.
+See a [sample](./etc/pgagroal.conf) configuration for running `pgagroal` on `localhost`.
 
 ## [pgagroal]
 


### PR DESCRIPTION
The `pgagroal.conf` sample file is linked from the configuration page,
but the link was using an extra `/pgagroal/` folder.

Close #221