### PR TITLE
[#224] Prefill a new server when doing a `switch-to`

### DIFF
--- a/src/include/pool.h
+++ b/src/include/pool.h
@@ -94,9 +94,11 @@ pgagroal_flush(int mode, char* database);
 /**
  * Flush the pool for a specific server
  * @param server The server
+ * @param prefillNextServer true if the next selected server must be prefilled.
+ *                          (.e.g, when doing a switch-to)   
  */
 void
-pgagroal_flush_server(signed char server);
+pgagroal_flush_server(signed char server, bool prefillNextServer);
 
 /**
  * Prefill the pool

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -193,7 +193,7 @@ start:
 
             if (!fork())
             {
-               pgagroal_flush_server(server);
+               pgagroal_flush_server(server, false);
             }
 
             if (config->failover)
@@ -799,7 +799,7 @@ pgagroal_flush(int mode, char* database)
 }
 
 void
-pgagroal_flush_server(signed char server)
+pgagroal_flush_server(signed char server, bool prefillNextServer)
 {
    struct configuration* config;
 
@@ -808,7 +808,7 @@ pgagroal_flush_server(signed char server)
 
    config = (struct configuration*)shmem;
 
-   pgagroal_log_debug("pgagroal_flush_server");
+   pgagroal_log_debug("pgagroal_flush_server %s (prefill next server = %d)", config->servers[server].name, prefillNextServer);
    for (int i = 0; i < config->max_connections; i++)
    {
       if (config->connections[i].server == server)
@@ -849,7 +849,7 @@ pgagroal_flush_server(signed char server)
    {
       if (!fork())
       {
-         pgagroal_prefill(false);
+         pgagroal_prefill(prefillNextServer);
       }
    }
 

--- a/src/libpgagroal/server.c
+++ b/src/libpgagroal/server.c
@@ -233,7 +233,7 @@ pgagroal_server_failover(int slot)
 
       if (!fork())
       {
-         pgagroal_flush_server(old_primary);
+         pgagroal_flush_server(old_primary, true);
       }
    }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1448,7 +1448,7 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
                shutdown_ports();
                if (old_primary != -1)
                {
-                  pgagroal_flush_server(old_primary);
+                  pgagroal_flush_server(old_primary, true);
                }
                else
                {


### PR DESCRIPTION
When a `switch-to` operation is issued, the old server is flushed
(i.e., connections are closed) and new connections to the new primary
server are established.
When such connections are established, the system does a full prefill
against the new primary, so that when the `switch-to` completes, the
new primary is prefilled as the old one was.

Adds also a better detail about the server that is going to be
flushed.

Close #224