### PR TITLE
[#223] Keep server state during a `reload`

### DIFF
--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -2698,7 +2698,7 @@ copy_server(struct server* dst, struct server* src)
    memcpy(&dst->name[0], &src->name[0], MISC_LENGTH);
    memcpy(&dst->host[0], &src->host[0], MISC_LENGTH);
    dst->port = src->port;
-   atomic_init(&dst->state, SERVER_NOTINIT);
+   atomic_init(&dst->state, src->state);
 }
 
 static void


### PR DESCRIPTION
When doing a `pgagroal-cli reload` the system reloads the
configuration and copies the server information via `copy_server`
function.
This commit makes the `copy_server` to keep the original server status
among a reload process.
This makes a "primary" as "not init (primary)" status, that is surely
better than "not init".