### PR TITLE
[#228] No warning messages about pid file when configuration reloads.

### DIFF
--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -171,6 +171,17 @@ pgagroal_validate_superuser_configuration(void* shmem);
 int
 pgagroal_reload_configuration(void);
 
+/**
+ * Automatically initialize the 'pidfile'
+ * if none has been specified.
+ * This function is called as last step
+ * from pgagroal_validate_configuration
+ * because it builds the pidfile on the value
+ * of unix_socket_dir.
+ */
+void
+pgagroal_init_pidfile_if_needed(struct configuration* config);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -1140,6 +1140,10 @@ pgagroal_validate_configuration(void* shm, bool has_unix_socket, bool has_main_s
       }
    }
 
+   // do some last initialization here, since the configuration
+   // looks good so far
+   pgagroal_init_pidfile_if_needed(config);
+
    return 0;
 }
 
@@ -2971,4 +2975,17 @@ as_logging_rotation_age(char* str, int* age)
       *age = PGAGROAL_LOGGING_ROTATION_DISABLED;
       return 1;
    }
+}
+
+void
+pgagroal_init_pidfile_if_needed(struct configuration* config)
+{
+    if (strlen(config->pidfile) == 0)
+    {
+        // no pidfile set, use a default one
+        snprintf(config->pidfile, sizeof(config->pidfile), "%s/pgagraol.%d.pid",
+                 config->unix_socket_dir,
+                 config->port);
+        pgagroal_log_debug("PID file automatically set to: [%s]", config->pidfile);
+    }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1931,15 +1931,6 @@ create_pidfile(void)
 
    config = (struct configuration*)shmem;
 
-   if (strlen(config->pidfile) == 0)
-   {
-      // no pidfile set, use a default one
-      snprintf(config->pidfile, sizeof(config->pidfile), "%s/pgagraol.%d.pid",
-               config->unix_socket_dir,
-               config->port);
-      pgagroal_log_debug("PID file automatically set to: [%s]", config->pidfile);
-   }
-
    if (strlen(config->pidfile) > 0)
    {
       // check pidfile is not there


### PR DESCRIPTION
When configuration is reloaded via `pgagroal-cli reload`, the system
checks all the parameters and warns the user about the need of a
restart if some particular parameters have changed.
The check for the `pidfile` parameter is done via `restart_string()`
that, in the case the pidfile has not been specified in the
configuration file, finds a value in the old configuration (the one
running) and no value at all in the new one.
To avoid the misbehaviour, `pgagroal_validate_configuration()` now
invokes a new function `pgagroal_init_pidfile_if_needed()` that sets
the default value of the `pidfile` in the configuration structure.
This way, if the parameter has its default value, no difference will
be spot and no warning message will be issued.

It is safe to make the pidfile default configuration as the last step
in `pgagroal_validate_configuration()` because this function should be
called whenever the configuration is read, and after all this ensures
the configuration is in a "valid" state. On the other hand, it is not
safe to do such configuration within `pgagroal_read_configuration()`
because the default pidfile is built on top of `unix_socket_dir`, that
at that time could be not set.

Close #228