### PR TITLE
[#230] Correctly read last line of configuration file if no new-line

### DIFF
--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -2225,7 +2225,7 @@ extract_key_value(char* str, char** key, char** value)
       while (str[c] != ' ' && str[c] != '\r' && str[c] != '\n' && c < length)
          c++;
 
-      if (c < length)
+      if (c <= length)
       {
          v = malloc((c - offset) + 1);
          memset(v, 0, (c - offset) + 1);
@@ -2542,7 +2542,7 @@ extract_value(char* str, int offset, char** value)
       while ((str[offset] != ' ' && str[offset] != '\t' && str[offset] != '\r' && str[offset] != '\n') && offset < length)
          offset++;
 
-      if (offset < length)
+      if (offset <= length)
       {
          to = offset;
 


### PR DESCRIPTION
In the case the main configuration file has no new line in it, the
line is ignored by the function `extract_key_value()`.
This can be a little tricky, since the line is ignored and the user
has no clue about it.
With this fix, the last line of `pgagroal.conf` is always interpreted
even if no new line is present.

Fixes the same problem even for `pgagroal_hba.conf` file read within `extract_hba`.

Clse #230