### PR TITLE
Avoid reload loose status

### DIFF
--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -2738,7 +2738,7 @@ transfer_configuration(struct configuration* config, struct configuration* reloa
    /* states */
 
    // decreasing the number of servers is probably a bad idea
-   if ( config->number_of_servers > reload->number_of_servers)
+   if (config->number_of_servers > reload->number_of_servers)
       restart_int("decreasing number of servers", config->number_of_servers, reload->number_of_servers);
 
    for (int i = 0; i < reload->number_of_servers; i++)

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -2737,6 +2737,10 @@ transfer_configuration(struct configuration* config, struct configuration* reloa
 
    /* states */
 
+   // decreasing the number of servers is probably a bad idea
+   if ( config->number_of_servers > reload->number_of_servers)
+      restart_int("decreasing number of servers", config->number_of_servers, reload->number_of_servers);
+
    for (int i = 0; i < reload->number_of_servers; i++)
    {
       restart_server(&reload->servers[i], &config->servers[i]);


### PR DESCRIPTION
This is a first attempt to solve the issue #232.
I've done two separated commits.
In the first one, there are a few new utility functions to catch a possible "misconfiguration" of the same server. This works on a positional basis (so fitrst server against the new first server and so on).
Handles also server reordering, that means it can tell the user the server order has changed.

The problem is to identify a server as "the same". So far I've built `is_same_connection()`, that allows us for changing the server name and primary status.

Now the problems becomes what we want to check: a user could change either a server name or a connection string. The latter is probably something we should avoid, and hence the implementation of `is_same_connection()`.

The second commit adds also another warning if the user has decreased the number of servers withing a reload: this probably means a restart should be required. At least, it look simpler than trying to understand what the user wants to do (e.g., delete a replica).