### PR TITLE
[#235] Do not emit "restart" messages when adding a new server

### DIFF
--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -2745,7 +2745,12 @@ transfer_configuration(struct configuration* config, struct configuration* reloa
 
    for (int i = 0; i < reload->number_of_servers; i++)
    {
-      restart_server(&reload->servers[i], &config->servers[i]);
+      // check and emit restart warning only for not-added servers
+      if (i < config->number_of_servers)
+      {
+         restart_server(&reload->servers[i], &config->servers[i]);
+      }
+
       copy_server(&config->servers[i], &reload->servers[i]);
    }
    config->number_of_servers = reload->number_of_servers;


### PR DESCRIPTION
The `restart_server()` function checks if two configurations identify
the same server.
When a new server is added, there is no previous configuration to
compare against, and therefore there is no need to emit a restart
warning message between the added server and "nothing".

Close #235