### PR TITLE
[#235] Wrap `pgagroal_prefill()`

### DIFF
--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -182,6 +182,17 @@ pgagroal_reload_configuration(void);
 void
 pgagroal_init_pidfile_if_needed(struct configuration* config);
 
+/**
+ * Checks if the configuration has a min set of values to
+ * take into account doing a prefill. For example, there must
+ * be users and limits set, otherwise it does not
+ * make any sense to attempt a prefill.
+ * This can be used to wrap the condituion before calling
+ * other prefill functions, e.g., `pgagroal_prefill()`.
+ */
+bool
+pgagroal_can_prefill(struct configuration* config);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -191,7 +191,7 @@ pgagroal_init_pidfile_if_needed(struct configuration* config);
  * other prefill functions, e.g., `pgagroal_prefill()`.
  */
 bool
-pgagroal_can_prefill(struct configuration* config);
+pgagroal_can_prefill(void);
 
 #ifdef __cplusplus
 }

--- a/src/include/pool.h
+++ b/src/include/pool.h
@@ -126,6 +126,24 @@ pgagroal_pool_shutdown(void);
 int
 pgagroal_pool_status(void);
 
+/**
+ * This function wraps around the logic to call `pgagroal_prefill()`.
+ * In order to avoid code repetition, this function can be used safely
+ * wherever there is the possibility to activate the prefill. The function
+ * does check if the configuration allows for a prefill, and in such case
+ * tries to `fork(2)` and executes the prefill.
+ * Also, the function checks for the presence of a primary with
+ * `pgagroal_get_primary()` and refuses to do a prefill if there
+ * is no primary at all.
+ *
+ * @param initial true if the prefill has to be done with the INITIAL
+ *        value of the pgagroal_database.conf file, false if it has
+ *        to be done with the MINIMAL value.
+ *
+ */
+void
+pgagroal_prefill_if_can(bool initial);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -3171,8 +3171,12 @@ pgagroal_init_pidfile_if_needed(struct configuration* config)
 }
 
 bool
-pgagroal_can_prefill(struct configuration* config)
+pgagroal_can_prefill(void)
 {
+   struct configuration* config;
+
+   config = (struct configuration*)shmem;
+
    if (config->number_of_users > 0 && config->number_of_limits > 0)
    {
       return true;

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -3169,3 +3169,16 @@ pgagroal_init_pidfile_if_needed(struct configuration* config)
       pgagroal_log_debug("PID file automatically set to: [%s]", config->pidfile);
    }
 }
+
+bool
+pgagroal_can_prefill(struct configuration* config)
+{
+   if (config->number_of_users > 0 && config->number_of_limits > 0)
+   {
+      return true;
+   }
+   else
+   {
+      return false;
+   }
+}

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -1347,11 +1347,8 @@ void
 pgagroal_prefill_if_can(bool initial)
 {
    int primary;
-   struct configuration* config;
 
-   config = (struct configuration*)shmem;
-
-   if (pgagroal_can_prefill(config))
+   if (pgagroal_can_prefill())
    {
       if (pgagroal_get_primary(&primary))
       {

--- a/src/main.c
+++ b/src/main.c
@@ -1060,12 +1060,12 @@ main(int argc, char** argv)
       pgagroal_log_warn("No users allowed");
    }
 
-   if (config->number_of_users > 0)
+   if (pgagroal_can_prefill(config))
    {
       if (!fork())
       {
          shutdown_ports();
-         pgagroal_prefill(true);
+         pgagroal_prefill_if_can(true);
       }
    }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1060,7 +1060,7 @@ main(int argc, char** argv)
       pgagroal_log_warn("No users allowed");
    }
 
-   if (pgagroal_can_prefill(config))
+   if (pgagroal_can_prefill())
    {
       if (!fork())
       {


### PR DESCRIPTION
In order to make calls to `pgagroal_prefill()` consistent around the
code and avoid repetitions, there is a new function named
`pgagroal_prefill_if_can()` that wraps several checks and does the
forking and prefilling.
Therefore there is no need to check against the configuration limits
and users before calling `pgagroal_prefill()` because
`pgagroal_prefill_if_can()` will do by itself.

Also `pgagroal_prefill_if_can()` will check for a primary server, and
in the case there is none, will avoid issuing the prefill at all.

Last, this introduces also the `pgagroal_can_prefill()` function that
is used in turn by `pgagroal_prefill_if_can()` and aims at testing the
configuration for the presence of limits and users. This function can
be used as a condition checker before doing clean-up stuff right
before calling `pgagroal_prefill_if_can()`.

Close #223