### PR TITLE
[#240] Cleanup `pgagroal_read_configuration()`

### DIFF
--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -35,6 +35,12 @@ extern "C" {
 
 #include <stdlib.h>
 
+/*
+ * The main section that must be present in the `pgagroal.conf`
+ * configuration file.
+ */
+#define PGAGROAL_MAIN_INI_SECTION "pgagroal"
+
 /**
  * Initialize the configuration structure
  * @param shmem The shared memory segment


### PR DESCRIPTION
This commit introduces a few utility functions withing the
configuration code:
- `key_in_section()` is able to determine if a particular
configuration key is within a specific section, that could either the
main `[pgagroal]` section or a custom (i.e., server specific) one.
- `section_line()` handles a configuration line that appear to be a
section.
- `is_comment_line()` handles a line that starts with a comment.

Thanks to these functions, the code of `pgagroal_read_configuration()`
is shorter and also, to some extent, easier to read.

Moreover, in the case of an unknown configuration setting, the
`printf()` call has been changed to `fprintf()` to `stderr`, so that
the user is informed on the standard error.

Minor changes also to other configuration related functions.

Close [#240]