### PR TITLE
[241] Remove `config` parameter from `pgagroal_init_pidfile_if_needed()`

### DIFF
--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -180,7 +180,7 @@ pgagroal_reload_configuration(void);
  * of unix_socket_dir.
  */
 void
-pgagroal_init_pidfile_if_needed(struct configuration* config);
+pgagroal_init_pidfile_if_needed(void);
 
 /**
  * Checks if the configuration has a min set of values to

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -1169,7 +1169,7 @@ pgagroal_validate_configuration(void* shm, bool has_unix_socket, bool has_main_s
 
    // do some last initialization here, since the configuration
    // looks good so far
-   pgagroal_init_pidfile_if_needed(config);
+   pgagroal_init_pidfile_if_needed();
 
    return 0;
 }
@@ -3158,8 +3158,12 @@ as_logging_rotation_age(char* str, int* age)
 }
 
 void
-pgagroal_init_pidfile_if_needed(struct configuration* config)
+pgagroal_init_pidfile_if_needed(void)
 {
+   struct configuration* config;
+
+   config = (struct configuration*)shmem;
+
    if (strlen(config->pidfile) == 0)
    {
       // no pidfile set, use a default one


### PR DESCRIPTION
Since the `struct configuration*` can be obtained out of shared
memory, functions should not use it as a parameter if not explicitly
needed.
This commit refactors the function `pgagroal_init_pidfile_if_needed()`
to avoid the need to pass a `struct configuration*` parameter.

Close #241