### PR TITLE
[#245] Fix warnings about server sections.

### DIFF
--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -199,7 +199,7 @@ pgagroal_read_configuration(void* shm, char* filename)
 
                //printf("\nSection <%s> key <%s> = <%s>", section, key, value);
 
-               if (key_in_section( "host", section, key, true, &unknown))
+               if (key_in_section( "host", section, key, true, NULL))
                {
                   max = strlen(value);
                   if (max > MISC_LENGTH - 1)
@@ -224,7 +224,7 @@ pgagroal_read_configuration(void* shm, char* filename)
                   memcpy(&srv.host, value, max);
                   atomic_store(&srv.state, SERVER_NOTINIT);
                }
-               else if (key_in_section("port", section, key, true, &unknown))
+               else if (key_in_section("port", section, key, true, NULL))
                {
                   if (as_int(value, &config->port))
                   {


### PR DESCRIPTION
Due to #242, when the `key_in_section()` function checks a paramter
that can be both global and local (e.g., `host`, `port`), the first
call to the function could set the `unknown` flag to true, because the
section does not match, and then the flag remains set even for the
other check.

This commit fixes the problem by resetting the `unknown` flag every
time the function `key_in_section()` is invoked. This is safe because
the function returns a false value if the section does not matches,
thus another if..else if branch is executed.

Close #245