### PR TITLE
[#244] Allows spaces and comments in configuration parameters

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -13,10 +13,23 @@ instance.
 
 All properties are in the format `key = value`.
 
-The characters `#` and `;` can be used for comments; must be the first character on the line.
+The characters `#` and `;` can be used for comments. A line is totally ignored if the
+very first non-space character is a comment one, but it is possible to put a comment at the end of a line.
 The `Bool` data type supports the following values: `on`, `1`, `true`, `off`, `0` and `false`.
 
-See a [sample](./etc/pgagroal.conf) configuration for running `pgagroal` on `localhost`.
+Each value can be quoted by means of `"` or `'`. Quoted strings must begin and end with the very same quoting character. It is possible to nest quotes.
+As an example of configuration snippet including quoting and comments:
+
+```
+# This line is ignored since it starts with '#'
+# and so is this one
+log_line_prefix = "PGAGROAL #%Y-%m-%d-%H:%M:%S" # quoted because it contains spaces
+log_type= console#log to stdout
+pipeline = 'performance' # no need to quote since it does not contain any spaces
+
+```
+
+See a more complete [sample](./etc/pgagroal.conf) configuration for running `pgagroal` on `localhost`.
 
 ## [pgagroal]
 
@@ -32,7 +45,7 @@ See a [sample](./etc/pgagroal.conf) configuration for running `pgagroal` on `loc
 | log_path | pgagroal.log | String | No | The log file location. Can be a strftime(3) compatible string. |
 | log_rotation_age | -1 | String | No | The age that will trigger a log file rotation. If expressed as a positive number, is managed as seconds. Supports suffixes: 'S' (seconds, the default), 'M' (minutes), 'H' (hours), 'D' (days), 'W' (weeks) |
 | log_rotation_size | -1 | String | No | The size of the log file that will trigger a log rotation. Supports suffixes: 'B' (bytes), the default if omitted, 'K' (kilobytes), 'M' (megabytes), 'G' (gigabytes). |
-| log_line_prefix | %Y-%m-%d %H:%M:%S | String | No | A strftime(3) compatible string to use as prefix for every log line. Must not contain any space. |
+| log_line_prefix | %Y-%m-%d %H:%M:%S | String | No | A strftime(3) compatible string to use as prefix for every log line. Must be quoted if contains spaces. |
 | log_mode | append | String | No | Append to or create the log file (append, create) |
 | log_connections | `off` | Bool | No | Log connects |
 | log_disconnections | `off` | Bool | No | Log disconnects |


### PR DESCRIPTION
This commit refactors the `extract_key_value()` function to handle
quoted strings as values. A quoted string must start with either '"'
or '\''. Everything between the quotes is handled as a value.
If quotes do not match (e.g., "foo') the value is not set, so the line
is ignored at all.
Quoted strings can contain also spaces and comment charaters.
Therefore, the following is a good string:

  log_line_prefix = "PGAGROAL #%Y-%m-%d-%H:%M:%S"

Also, quotes can be nested:

  log_line_prefix = "'PGAGROAL' #%Y-%m-%d-%H:%M:%S"

Values that do not need a quoting (because of spaces or comment signs)
can be quoted as well, and that will not affect the value parsing. The
following two lines are the same:

   log_rotation_size = 1M
   log_rotation_size = "1M"

The `extract_key_value()` function now returns also an integer to
indicate if it has parsed the key and the value correctly. The return
value is not used because there is already a check on the validity of
both key and value in `pgagroal_read_configuration()`, but to be
coherent the function returns a status.

This commit also allows to use comment-only line that begin with
spaces or tabs, therefore the following are all ignored lines. The
`is_comment_line()` function has therefore been refactored so that the
following is a valid snippet of configuration:

; comment
   ; comment
<tab> ; comment

Last, a comment can be placed on the right side of a configuration
option, so

   log_line_prefix  = "PGAGROAL #%Y-%m-%d-%H:%M:%S" # the prefix

is a valid line. The trick here is that any space after the option
makes the rest of the line ignored. But now, even without spaces the
comment is ignored:

log_type = create; overwrites the file

Updated also the documentation to reflect the changes.

Close #244