### PR TITLE
[#105] Blocked connections metrics

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -13,10 +13,23 @@ instance.
 
 All properties are in the format `key = value`.
 
-The characters `#` and `;` can be used for comments; must be the first character on the line.
+The characters `#` and `;` can be used for comments. A line is totally ignored if the
+very first non-space character is a comment one, but it is possible to put a comment at the end of a line.
 The `Bool` data type supports the following values: `on`, `1`, `true`, `off`, `0` and `false`.
 
-See a [sample](./etc/pgagroal.conf) configuration for running `pgagroal` on `localhost`.
+Each value can be quoted by means of `"` or `'`. Quoted strings must begin and end with the very same quoting character. It is possible to nest quotes.
+As an example of configuration snippet including quoting and comments:
+
+```
+# This line is ignored since it starts with '#'
+# and so is this one
+log_line_prefix = "PGAGROAL #%Y-%m-%d-%H:%M:%S" # quoted because it contains spaces
+log_type= console#log to stdout
+pipeline = 'performance' # no need to quote since it does not contain any spaces
+
+```
+
+See a more complete [sample](./etc/pgagroal.conf) configuration for running `pgagroal` on `localhost`.
 
 ## [pgagroal]
 
@@ -32,7 +45,7 @@ See a [sample](./etc/pgagroal.conf) configuration for running `pgagroal` on `loc
 | log_path | pgagroal.log | String | No | The log file location. Can be a strftime(3) compatible string. |
 | log_rotation_age | -1 | String | No | The age that will trigger a log file rotation. If expressed as a positive number, is managed as seconds. Supports suffixes: 'S' (seconds, the default), 'M' (minutes), 'H' (hours), 'D' (days), 'W' (weeks) |
 | log_rotation_size | -1 | String | No | The size of the log file that will trigger a log rotation. Supports suffixes: 'B' (bytes), the default if omitted, 'K' (kilobytes), 'M' (megabytes), 'G' (gigabytes). |
-| log_line_prefix | %Y-%m-%d %H:%M:%S | String | No | A strftime(3) compatible string to use as prefix for every log line. Must not contain any space. |
+| log_line_prefix | %Y-%m-%d %H:%M:%S | String | No | A strftime(3) compatible string to use as prefix for every log line. Must be quoted if contains spaces. |
 | log_mode | append | String | No | Append to or create the log file (append, create) |
 | log_connections | `off` | Bool | No | Log connects |
 | log_disconnections | `off` | Bool | No | Log disconnects |

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -246,6 +246,7 @@ struct prometheus
    atomic_ulong connection_idletimeout; /**< The number of idle timeout calls */
    atomic_ulong connection_flush;       /**< The number of flush calls */
    atomic_ulong connection_success;     /**< The number of success calls */
+   atomic_ulong connection_awaiting;    /**< The number of connection awaiting due to `blocking_timeout` */
 
    atomic_ulong auth_user_success;      /**< The number of AUTH_SUCCESS calls */
    atomic_ulong auth_user_bad_password; /**< The number of AUTH_BAD_PASSWORD calls */

--- a/src/include/prometheus.h
+++ b/src/include/prometheus.h
@@ -105,6 +105,18 @@ void
 pgagroal_prometheus_connection_idletimeout(void);
 
 /**
+ * Connection awaiting due to `blocking_timeout`.
+ */
+void
+pgagroal_prometheus_connection_awaiting(void);
+
+/**
+ * An awaiting conection that restarts.
+ */
+void
+pgagroal_prometheus_connection_unawaiting(void);
+
+/**
  * Connection flush
  */
 void

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -347,7 +347,7 @@ pgagroal_read_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (key_in_section("idle_tiemout", section, key, true, &unknown))
+               else if (key_in_section("idle_timeout", section, key, true, &unknown))
                {
                   if (as_int(value, &config->idle_timeout))
                   {

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -199,7 +199,7 @@ pgagroal_read_configuration(void* shm, char* filename)
 
                //printf("\nSection <%s> key <%s> = <%s>", section, key, value);
 
-               if (key_in_section( "host", section, key, true, &unknown))
+               if (key_in_section( "host", section, key, true, NULL))
                {
                   max = strlen(value);
                   if (max > MISC_LENGTH - 1)
@@ -224,7 +224,7 @@ pgagroal_read_configuration(void* shm, char* filename)
                   memcpy(&srv.host, value, max);
                   atomic_store(&srv.state, SERVER_NOTINIT);
                }
-               else if (key_in_section("port", section, key, true, &unknown))
+               else if (key_in_section("port", section, key, true, NULL))
                {
                   if (as_int(value, &config->port))
                   {

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -288,11 +288,14 @@ retry:
 retry2:
       if (config->blocking_timeout > 0)
       {
+         pgagroal_prometheus_connection_awaiting();
+
          /* Sleep for 500ms */
          struct timespec ts;
          ts.tv_sec = 0;
          ts.tv_nsec = 500000000L;
          nanosleep(&ts, NULL);
+         pgagroal_prometheus_connection_unawaiting();
 
          double diff = difftime(time(NULL), start_time);
          if (diff >= (double)config->blocking_timeout)

--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -1726,7 +1726,7 @@ pool_information(int client_fd)
    data = append(data, "\n\n");
 
    data = append(data, "#HELP pgagroal_connection_awaiting Number of connection awaiting\n");
-   data = append(data, "#TYPE pgagroal_connection_awaiting counter\n");
+   data = append(data, "#TYPE pgagroal_connection_awaiting gauge\n");
    data = append(data, "pgagroal_connection_awaiting ");
    data = append_ulong(data, atomic_load(&prometheus->connection_awaiting));
    data = append(data, "\n\n");

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -4805,11 +4805,15 @@ retry:
    {
       if (config->blocking_timeout > 0)
       {
+          pgagroal_prometheus_connection_awaiting();
+
          /* Sleep for 100ms */
          struct timespec ts;
          ts.tv_sec = 0;
          ts.tv_nsec = 100000000L;
          nanosleep(&ts, NULL);
+
+         pgagroal_prometheus_connection_unawaiting();
 
          double diff = difftime(time(NULL), start_time);
          if (diff >= (double)config->blocking_timeout)


### PR DESCRIPTION
Creates a new metric named "connection awaiting" to keep track of the
number of connection enqueued but not served due to a reached limit.

This commit introduces a new field in the `prometheus` structure named
`connection_awaiting` to keep track of the connections that have been
suspended due to `blocking_timeout` configuration parameter.
Whenever a connection is suspended by the pool, the
`pgagroal_prometheus_connection_awaiting()` function is invoked to
increment the counter of awaiting connections, and following the
opposite happens with the
`pgagroal_prometheus_connection_unawaiting()` that decrements the
counter, since the connection workflow is going to restart (or abort).

The metric is exported as `pgagroal_connection_awaiting`.

Close #105