### PR TITLE
Prometheus added metrics

### DIFF
--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -247,6 +247,10 @@ struct prometheus
    atomic_ulong connection_flush;       /**< The number of flush calls */
    atomic_ulong connection_success;     /**< The number of success calls */
 
+   /**< The number of connection awaiting due to `blocking_timeout` */
+   atomic_ulong connections_awaiting[NUMBER_OF_LIMITS];
+   atomic_ulong connections_awaiting_total;
+
    atomic_ulong auth_user_success;      /**< The number of AUTH_SUCCESS calls */
    atomic_ulong auth_user_bad_password; /**< The number of AUTH_BAD_PASSWORD calls */
    atomic_ulong auth_user_error;        /**< The number of AUTH_ERROR calls */

--- a/src/include/prometheus.h
+++ b/src/include/prometheus.h
@@ -105,6 +105,31 @@ void
 pgagroal_prometheus_connection_idletimeout(void);
 
 /**
+ * Connection awaiting due to `blocking_timeout`.
+ * Tracks the total awaiting connections and also the
+ * per-limit ones.
+ *
+ * @param limit_index if greater or equal to zero
+ * tracks the awaiting connection for the limits entry
+ * (i.e., per user and database)
+ */
+void
+pgagroal_prometheus_connection_awaiting(int limit_index);
+
+/**
+ * An awaiting conection, i.e., one holded by `blocking_timeout`
+ * that is no more on hold and can restart its workflo.
+ *
+ * The function decreases the total counter of the awaiting connections as
+ * well as the per-limit ones.
+ *
+ * @param limit_entry if greater or equal to zero
+ * it untracks the corresponding limit entry
+ */
+void
+pgagroal_prometheus_connection_unawaiting(int limit_index);
+
+/**
  * Connection flush
  */
 void

--- a/src/include/prometheus.h
+++ b/src/include/prometheus.h
@@ -109,6 +109,12 @@ pgagroal_prometheus_connection_idletimeout(void);
  * Tracks the total awaiting connections and also the
  * per-limit ones.
  *
+ * <b>
+ * Every call to this function should be paired
+ * by the same number of calls
+ * to `pgagroal_prometheus_connection_unawaiting()`
+ * </b>
+ *
  * @param limit_index if greater or equal to zero
  * tracks the awaiting connection for the limits entry
  * (i.e., per user and database)
@@ -119,6 +125,13 @@ pgagroal_prometheus_connection_awaiting(int limit_index);
 /**
  * An awaiting conection, i.e., one holded by `blocking_timeout`
  * that is no more on hold and can restart its workflo.
+ *
+ *
+ * <b>
+ * Every call to this function should be after
+ * the call
+ * to `pgagroal_prometheus_connection_awaiting()`
+ * </b>
  *
  * The function decreases the total counter of the awaiting connections as
  * well as the per-limit ones.

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -84,6 +84,7 @@ pgagroal_get_connection(char* username, char* database, bool reuse, bool transac
    best_rule = find_best_rule(username, database);
    retries = 0;
    start_time = time(NULL);
+   pgagroal_prometheus_connection_awaiting(best_rule);
 
 start:
 
@@ -271,7 +272,7 @@ start:
       atomic_store(&prometheus->client_wait_time, difftime(time(NULL), start_time));
       pgagroal_prometheus_connection_success();
       pgagroal_tracking_event_slot(TRACKER_GET_CONNECTION_SUCCESS, *slot);
-
+      pgagroal_prometheus_connection_unawaiting(best_rule);
       return 0;
    }
    else
@@ -288,14 +289,12 @@ retry:
 retry2:
       if (config->blocking_timeout > 0)
       {
-         pgagroal_prometheus_connection_awaiting(best_rule);
 
          /* Sleep for 500ms */
          struct timespec ts;
          ts.tv_sec = 0;
          ts.tv_nsec = 500000000L;
          nanosleep(&ts, NULL);
-         pgagroal_prometheus_connection_unawaiting(best_rule);
 
          double diff = difftime(time(NULL), start_time);
          if (diff >= (double)config->blocking_timeout)
@@ -351,7 +350,7 @@ timeout:
    atomic_store(&prometheus->client_wait_time, difftime(time(NULL), start_time));
    pgagroal_prometheus_connection_timeout();
    pgagroal_tracking_event_basic(TRACKER_GET_CONNECTION_TIMEOUT, username, database);
-
+   pgagroal_prometheus_connection_unawaiting(best_rule);
    return 1;
 
 error:
@@ -362,6 +361,7 @@ error:
    atomic_fetch_sub(&config->active_connections, 1);
    atomic_store(&prometheus->client_wait_time, difftime(time(NULL), start_time));
    pgagroal_prometheus_connection_error();
+   pgagroal_prometheus_connection_unawaiting(best_rule);
    pgagroal_tracking_event_basic(TRACKER_GET_CONNECTION_ERROR, username, database);
 
    return 2;

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -288,11 +288,14 @@ retry:
 retry2:
       if (config->blocking_timeout > 0)
       {
+         pgagroal_prometheus_connection_awaiting(best_rule);
+
          /* Sleep for 500ms */
          struct timespec ts;
          ts.tv_sec = 0;
          ts.tv_nsec = 500000000L;
          nanosleep(&ts, NULL);
+         pgagroal_prometheus_connection_unawaiting(best_rule);
 
          double diff = difftime(time(NULL), start_time);
          if (diff >= (double)config->blocking_timeout)

--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -1480,7 +1480,6 @@ static void
 limit_information(int client_fd)
 {
    char* data = NULL;
-   char limit_info[MISC_LENGTH];
    struct configuration* config;
    struct prometheus* prometheus;
 
@@ -1493,45 +1492,75 @@ limit_information(int client_fd)
       data = append(data, "#TYPE pgagroal_limit gauge\n");
       for (int i = 0; i < config->number_of_limits; i++)
       {
-         snprintf( limit_info, MISC_LENGTH,
-                   "pgagroal_limit{user=\"%s\",database=\"%s\",type=\"%s\"} %d\n",
-                   config->limits[i].username,
-                   config->limits[i].database,
-                   "min",
-                   config->limits[i].min_size);
-         data = append(data, limit_info);
+         data = append(data, "pgagroal_limit{");
 
-         snprintf( limit_info, MISC_LENGTH,
-                   "pgagroal_limit{user=\"%s\",database=\"%s\",type=\"%s\"} %d\n",
-                   config->limits[i].username,
-                   config->limits[i].database,
-                   "initial",
-                   config->limits[i].initial_size);
-         data = append(data, limit_info);
+         data = append(data, "user=\"");
+         data = append(data, config->limits[i].username);
+         data = append(data, "\",");
 
-         snprintf( limit_info, MISC_LENGTH,
-                   "pgagroal_limit{user=\"%s\",database=\"%s\",type=\"%s\"} %d\n",
-                   config->limits[i].username,
-                   config->limits[i].database,
-                   "max",
-                   config->limits[i].max_size);
-         data = append(data, limit_info);
+         data = append(data, "database=\"");
+         data = append(data, config->limits[i].database);
+         data = append(data, "\",");
 
-         snprintf( limit_info, MISC_LENGTH,
-                   "pgagroal_limit{user=\"%s\",database=\"%s\",type=\"%s\"} %d\n",
-                   config->limits[i].username,
-                   config->limits[i].database,
-                   "active",
-                   config->limits[i].active_connections);
-         data = append(data, limit_info);
+         data = append(data, "type=\"min\"} ");
+         data = append_int(data, config->limits[i].min_size);
+         data = append(data, "\n");
 
-         snprintf( limit_info, MISC_LENGTH,
-                   "pgagroal_limit{user=\"%s\",database=\"%s\",type=\"%s\"} %lu\n",
-                   config->limits[i].username,
-                   config->limits[i].database,
-                   "awaiting",
-                   prometheus->connections_awaiting[i]);
-         data = append(data, limit_info);
+         data = append(data, "pgagroal_limit{");
+
+         data = append(data, "user=\"");
+         data = append(data, config->limits[i].username);
+         data = append(data, "\",");
+
+         data = append(data, "database=\"");
+         data = append(data, config->limits[i].database);
+         data = append(data, "\",");
+
+         data = append(data, "type=\"initial\"} ");
+         data = append_int(data, config->limits[i].initial_size);
+         data = append(data, "\n");
+
+         data = append(data, "pgagroal_limit{");
+
+         data = append(data, "user=\"");
+         data = append(data, config->limits[i].username);
+         data = append(data, "\",");
+
+         data = append(data, "database=\"");
+         data = append(data, config->limits[i].database);
+         data = append(data, "\",");
+
+         data = append(data, "type=\"max\"} ");
+         data = append_int(data, config->limits[i].max_size);
+         data = append(data, "\n");
+
+         data = append(data, "pgagroal_limit{");
+
+         data = append(data, "user=\"");
+         data = append(data, config->limits[i].username);
+         data = append(data, "\",");
+
+         data = append(data, "database=\"");
+         data = append(data, config->limits[i].database);
+         data = append(data, "\",");
+
+         data = append(data, "type=\"active\"} ");
+         data = append_int(data, config->limits[i].active_connections);
+         data = append(data, "\n");
+
+         data = append(data, "pgagroal_limit{");
+
+         data = append(data, "user=\"");
+         data = append(data, config->limits[i].username);
+         data = append(data, "\",");
+
+         data = append(data, "database=\"");
+         data = append(data, config->limits[i].database);
+         data = append(data, "\",");
+
+         data = append(data, "type=\"awaiting\"} ");
+         data = append_int(data, prometheus->connections_awaiting[i]);
+         data = append(data, "\n");
 
          if (strlen(data) > CHUNK_SIZE)
          {

--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -1905,6 +1905,7 @@ connection_awaiting_information(int client_fd)
          data = append(data, "\"} ");
 
          data = append_int(data, prometheus->connections_awaiting[i]);
+         data = append(data, "\n");
 
          if (strlen(data) > CHUNK_SIZE)
          {

--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -1480,6 +1480,7 @@ static void
 limit_information(int client_fd)
 {
    char* data = NULL;
+   char limit_info[MISC_LENGTH];
    struct configuration* config;
    struct prometheus* prometheus;
 
@@ -1492,75 +1493,45 @@ limit_information(int client_fd)
       data = append(data, "#TYPE pgagroal_limit gauge\n");
       for (int i = 0; i < config->number_of_limits; i++)
       {
-         data = append(data, "pgagroal_limit{");
+         snprintf( limit_info, MISC_LENGTH,
+                   "pgagroal_limit{user=\"%s\",database=\"%s\",type=\"%s\"} %d\n",
+                   config->limits[i].username,
+                   config->limits[i].database,
+                   "min",
+                   config->limits[i].min_size);
+         data = append(data, limit_info);
 
-         data = append(data, "user=\"");
-         data = append(data, config->limits[i].username);
-         data = append(data, "\",");
+         snprintf( limit_info, MISC_LENGTH,
+                   "pgagroal_limit{user=\"%s\",database=\"%s\",type=\"%s\"} %d\n",
+                   config->limits[i].username,
+                   config->limits[i].database,
+                   "initial",
+                   config->limits[i].initial_size);
+         data = append(data, limit_info);
 
-         data = append(data, "database=\"");
-         data = append(data, config->limits[i].database);
-         data = append(data, "\",");
+         snprintf( limit_info, MISC_LENGTH,
+                   "pgagroal_limit{user=\"%s\",database=\"%s\",type=\"%s\"} %d\n",
+                   config->limits[i].username,
+                   config->limits[i].database,
+                   "max",
+                   config->limits[i].max_size);
+         data = append(data, limit_info);
 
-         data = append(data, "type=\"min\"} ");
-         data = append_int(data, config->limits[i].min_size);
-         data = append(data, "\n");
+         snprintf( limit_info, MISC_LENGTH,
+                   "pgagroal_limit{user=\"%s\",database=\"%s\",type=\"%s\"} %d\n",
+                   config->limits[i].username,
+                   config->limits[i].database,
+                   "active",
+                   config->limits[i].active_connections);
+         data = append(data, limit_info);
 
-         data = append(data, "pgagroal_limit{");
-
-         data = append(data, "user=\"");
-         data = append(data, config->limits[i].username);
-         data = append(data, "\",");
-
-         data = append(data, "database=\"");
-         data = append(data, config->limits[i].database);
-         data = append(data, "\",");
-
-         data = append(data, "type=\"initial\"} ");
-         data = append_int(data, config->limits[i].initial_size);
-         data = append(data, "\n");
-
-         data = append(data, "pgagroal_limit{");
-
-         data = append(data, "user=\"");
-         data = append(data, config->limits[i].username);
-         data = append(data, "\",");
-
-         data = append(data, "database=\"");
-         data = append(data, config->limits[i].database);
-         data = append(data, "\",");
-
-         data = append(data, "type=\"max\"} ");
-         data = append_int(data, config->limits[i].max_size);
-         data = append(data, "\n");
-
-         data = append(data, "pgagroal_limit{");
-
-         data = append(data, "user=\"");
-         data = append(data, config->limits[i].username);
-         data = append(data, "\",");
-
-         data = append(data, "database=\"");
-         data = append(data, config->limits[i].database);
-         data = append(data, "\",");
-
-         data = append(data, "type=\"active\"} ");
-         data = append_int(data, config->limits[i].active_connections);
-         data = append(data, "\n");
-
-         data = append(data, "pgagroal_limit{");
-
-         data = append(data, "user=\"");
-         data = append(data, config->limits[i].username);
-         data = append(data, "\",");
-
-         data = append(data, "database=\"");
-         data = append(data, config->limits[i].database);
-         data = append(data, "\",");
-
-         data = append(data, "type=\"awaiting\"} ");
-         data = append_int(data, prometheus->connections_awaiting[i]);
-         data = append(data, "\n");
+         snprintf( limit_info, MISC_LENGTH,
+                   "pgagroal_limit{user=\"%s\",database=\"%s\",type=\"%s\"} %lu\n",
+                   config->limits[i].username,
+                   config->limits[i].database,
+                   "awaiting",
+                   prometheus->connections_awaiting[i]);
+         data = append(data, limit_info);
 
          if (strlen(data) > CHUNK_SIZE)
          {

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -4805,11 +4805,15 @@ retry:
    {
       if (config->blocking_timeout > 0)
       {
+         pgagroal_prometheus_connection_awaiting(-1);
+
          /* Sleep for 100ms */
          struct timespec ts;
          ts.tv_sec = 0;
          ts.tv_nsec = 100000000L;
          nanosleep(&ts, NULL);
+
+         pgagroal_prometheus_connection_unawaiting(-1);
 
          double diff = difftime(time(NULL), start_time);
          if (diff >= (double)config->blocking_timeout)

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -4765,6 +4765,8 @@ auth_query_get_connection(char* username, char* password, char* database, int* s
 
    *server_fd = -1;
 
+   pgagroal_prometheus_connection_awaiting(-1);
+
    /* We need to find the server for the connection */
    if (pgagroal_get_primary(&server))
    {
@@ -4805,15 +4807,12 @@ retry:
    {
       if (config->blocking_timeout > 0)
       {
-         pgagroal_prometheus_connection_awaiting(-1);
 
          /* Sleep for 100ms */
          struct timespec ts;
          ts.tv_sec = 0;
          ts.tv_nsec = 100000000L;
          nanosleep(&ts, NULL);
-
-         pgagroal_prometheus_connection_unawaiting(-1);
 
          double diff = difftime(time(NULL), start_time);
          if (diff >= (double)config->blocking_timeout)
@@ -4901,6 +4900,8 @@ retry:
 
    free(error);
 
+   pgagroal_prometheus_connection_unawaiting(-1);
+
    pgagroal_free_copy_message(startup_msg);
    pgagroal_free_copy_message(startup_response_msg);
    pgagroal_free_message(msg);
@@ -4908,7 +4909,7 @@ retry:
    return AUTH_SUCCESS;
 
 bad_password:
-
+   pgagroal_prometheus_connection_unawaiting(-1);
    pgagroal_log_debug("auth_query_get_connection: BAD_PASSWORD");
 
    if (*server_fd != -1)
@@ -4927,7 +4928,7 @@ bad_password:
    return AUTH_BAD_PASSWORD;
 
 error:
-
+   pgagroal_prometheus_connection_unawaiting(-1);
    pgagroal_log_debug("auth_query_get_connection: ERROR (%d)", auth_type);
 
    if (*server_fd != -1)
@@ -4946,6 +4947,7 @@ error:
    return AUTH_ERROR;
 
 timeout:
+   pgagroal_prometheus_connection_unawaiting(-1);
 
    pgagroal_log_debug("auth_query_get_connection: TIMEOUT");
 


### PR DESCRIPTION
This is a (possibly more) complete implementation to solve issue #105 depending on the initial work and discussion done in #248.
It adds a global counter for awaiting connections as well as an array of counter for every limit entry.
The two counters are increased and decreased within the same function.

There are two commits:
- f6ce8f2 does the job
- 45b02bf refactors the function to emit prometheous limits in order to be more readable. This is not fully related to #105 and could be removed.