### PR TITLE
[#105] Use atomic_load for pgagroal_limit_awaiting

### DIFF
--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -1904,7 +1904,7 @@ connection_awaiting_information(int client_fd)
          data = append(data, config->limits[i].database);
          data = append(data, "\"} ");
 
-         data = append_int(data, prometheus->connections_awaiting[i]);
+         data = append_ulong(data, atomic_load(&prometheus->connections_awaiting[i]));
          data = append(data, "\n");
 
          if (strlen(data) > CHUNK_SIZE)


### PR DESCRIPTION
Since the array of connections_awaiting is defined as of type atomic,
use `atomic_load` and consequently `append_ulong`.