### PR TITLE
[#259] Omit configuration warnings when running cli

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -237,7 +237,7 @@ main(int argc, char** argv)
 
    if (configuration_path != NULL)
    {
-      ret = pgagroal_read_configuration(shmem, configuration_path);
+      ret = pgagroal_read_configuration(shmem, configuration_path, false);
       if (ret)
       {
          printf("pgagroal-cli: Configuration not found: %s\n", configuration_path);
@@ -262,7 +262,7 @@ main(int argc, char** argv)
    }
    else
    {
-      ret = pgagroal_read_configuration(shmem, "/etc/pgagroal/pgagroal.conf");
+      ret = pgagroal_read_configuration(shmem, "/etc/pgagroal/pgagroal.conf", false);
       if (ret)
       {
          if (host == NULL || port == NULL)

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -53,10 +53,12 @@ pgagroal_init_configuration(void* shmem);
  * Read the configuration from a file
  * @param shmem The shared memory segment
  * @param filename The file name
+ * @param emitWarnings true if unknown parameters have to
+ *        reported on stderr
  * @return 0 upon success, otherwise 1
  */
 int
-pgagroal_read_configuration(void* shmem, char* filename);
+pgagroal_read_configuration(void* shmem, char* filename, bool emitWarnings);
 
 /**
  * Validate the configuration

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -144,7 +144,7 @@ pgagroal_init_configuration(void* shm)
  *
  */
 int
-pgagroal_read_configuration(void* shm, char* filename)
+pgagroal_read_configuration(void* shm, char* filename, bool emitWarnings)
 {
    FILE* file;
    char section[LINE_LENGTH];
@@ -557,7 +557,7 @@ pgagroal_read_configuration(void* shm, char* filename)
                   unknown = true;
                }
 
-               if (unknown)
+               if (unknown && emitWarnings)
                {
                   // we cannot use logging here...
                   fprintf(stderr, "\nUnknown key <%s> with value <%s> in section [%s]",
@@ -1772,7 +1772,7 @@ pgagroal_reload_configuration(void)
 
    pgagroal_init_configuration((void*)reload);
 
-   if (pgagroal_read_configuration((void*)reload, config->configuration_path))
+   if (pgagroal_read_configuration((void*)reload, config->configuration_path, true))
    {
       goto error;
    }

--- a/src/main.c
+++ b/src/main.c
@@ -404,7 +404,7 @@ main(int argc, char** argv)
 
    if (configuration_path != NULL)
    {
-      if (pgagroal_read_configuration(shmem, configuration_path))
+      if (pgagroal_read_configuration(shmem, configuration_path, true))
       {
          printf("pgagroal: Configuration not found: %s\n", configuration_path);
 #ifdef HAVE_LINUX
@@ -415,7 +415,7 @@ main(int argc, char** argv)
    }
    else
    {
-      if (pgagroal_read_configuration(shmem, "/etc/pgagroal/pgagroal.conf"))
+      if (pgagroal_read_configuration(shmem, "/etc/pgagroal/pgagroal.conf", true))
       {
          printf("pgagroal: Configuration not found: /etc/pgagroal/pgagroal.conf\n");
 #ifdef HAVE_LINUX


### PR DESCRIPTION
`pgagroal-cli` reparses the configuration file as the daemon.
Due to that, if there is a problem with the configuration a warning
is emitted to the stderr.
This commit avoids the `pgagroal-cli` to report warnings on the command line
since such problems could have been alread fixed by the running daemon.

Close #259