### PR TITLE
[#219] Provide Prometheus metrics cache

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -39,6 +39,8 @@ See a more complete [sample](./etc/pgagroal.conf) configuration for running `pga
 | port | | Int | Yes | The bind port for pgagroal |
 | unix_socket_dir | | String | Yes | The Unix Domain Socket location |
 | metrics | 0 | Int | No | The metrics port (disable = 0) |
+| metrics_cache_max_age | 0 | String | No | The number of seconds to keep in cache a Prometheus (metrics) response. If set to zero, the caching will be disabled. Can be a string with a suffix, like `2m` to indicate 2 minutes |
+| metrics_cache_max_size | 256k | String | No | The maximum amount of data to keep in cache when serving Prometheus responses. Changes require restart. This parameter determines the size of memory allocated for the cache even if `metrics_cache_max_age` or `metrics` are disabled. Its value, however, it taken into account only if `metrics_cache_max_age` is set to a non-zero value. |
 | management | 0 | Int | No | The remote management port (disable = 0) |
 | log_type | console | String | No | The logging type (console, file, syslog) |
 | log_level | info | String | No | The logging level (fatal, error, warn, info, debug, debug1 thru debug5). Debug level greater than 5 will be set to `debug5`. Not recognized values will make the log_level be `info` |

--- a/src/include/prometheus.h
+++ b/src/include/prometheus.h
@@ -36,6 +36,27 @@ extern "C" {
 #include <ev.h>
 #include <stdlib.h>
 
+/*
+ * Value to disable the Prometheus cache,
+ * it is equivalent to set `metrics_cache`
+ * to 0 (seconds).
+ */
+#define PGAGROAL_PROMETHEUS_CACHE_DISABLED 0
+
+/**
+ * Max size of the cache (in bytes).
+ * If the cache request exceeds this size
+ * the caching should be aborted in some way.
+ */
+#define PROMETHEUS_MAX_CACHE_SIZE (1024 * 1024)
+
+/**
+ * The default cache size in the case
+ * the user did not set any particular
+ * configuration option.
+ */
+#define PROMETHEUS_DEFAULT_CACHE_SIZE (256 * 1024)
+
 /**
  * Create a prometheus instance
  * @param fd The client descriptor
@@ -278,6 +299,30 @@ pgagroal_prometheus_server_error(int server);
  */
 void
 pgagroal_prometheus_failed_servers(void);
+
+/**
+ * Allocates, for the first time, the Prometheus cache.
+ *
+ * The cache structure, as well as its dynamically sized payload,
+ * are created as shared memory chunks.
+ *
+ * Assumes the shared memory for the cofiguration is already set.
+ *
+ * The cache will be allocated as soon as this method is invoked,
+ * even if the cache has not been configured at all!
+ *
+ * If the memory cannot be allocated, the function issues errors
+ * in the logs and disables the caching machinaery.
+ *
+ * @param p_size a pointer to where to store the size of
+ * allocated chunk of memory
+ * @param p_shmem the pointer to the pointer at which the allocated chunk
+ * of shared memory is going to be inserted
+ *
+ * @return 0 on success
+ */
+int
+pgagroal_init_prometheus_cache(size_t* p_size, void** p_shmem);
 
 #ifdef __cplusplus
 }

--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -91,6 +91,13 @@ static char* append_int(char* orig, int i);
 static char* append_ulong(char* orig, unsigned long i);
 static char* append_ullong(char* orig, unsigned long long l);
 
+static bool is_metrics_cache_configured(void);
+static bool is_metrics_cache_valid(void);
+static bool metrics_cache_append(char* data);
+static bool metrics_cache_finalize(void);
+static size_t metrics_cache_size_to_alloc(void);
+static void metrics_cache_invalidate(void);
+
 void
 pgagroal_prometheus(int client_fd)
 {
@@ -1110,54 +1117,104 @@ metrics_page(int client_fd)
    char time_buf[32];
    int status;
    struct message msg;
+   struct prometheus_cache* cache;
+   signed char cache_is_free;
+
+   cache = (struct prometheus_cache*)prometheus_cache_shmem;
 
    memset(&msg, 0, sizeof(struct message));
 
-   now = time(NULL);
-
-   memset(&time_buf, 0, sizeof(time_buf));
-   ctime_r(&now, &time_buf[0]);
-   time_buf[strlen(time_buf) - 1] = 0;
-
-   data = append(data, "HTTP/1.1 200 OK\r\n");
-   data = append(data, "Content-Type: text/plain; version=0.0.3; charset=utf-8\r\n");
-   data = append(data, "Date: ");
-   data = append(data, &time_buf[0]);
-   data = append(data, "\r\n");
-   data = append(data, "Transfer-Encoding: chunked\r\n");
-   data = append(data, "\r\n");
-
-   msg.kind = 0;
-   msg.length = strlen(data);
-   msg.data = data;
-
-   status = pgagroal_write_message(NULL, client_fd, &msg);
-   if (status != MESSAGE_STATUS_OK)
+retry_cache_locking:
+   cache_is_free = STATE_FREE;
+   if (atomic_compare_exchange_strong(&cache->lock, &cache_is_free, STATE_IN_USE))
    {
-      goto error;
+      // can serve the message out of cache?
+      if (is_metrics_cache_configured() && is_metrics_cache_valid())
+      {
+         // serve the message directly out of the cache
+         pgagroal_log_debug("Serving metrics out of cache (%d/%d bytes valid until %lld)",
+                            strlen(cache->data),
+                            cache->size,
+                            cache->valid_until);
+
+         msg.kind = 0;
+         msg.length = strlen(cache->data);
+         msg.data = cache->data;
+      }
+      else
+      {
+         // build the message without the cache
+         metrics_cache_invalidate();
+
+         now = time(NULL);
+
+         memset(&time_buf, 0, sizeof(time_buf));
+         ctime_r(&now, &time_buf[0]);
+         time_buf[strlen(time_buf) - 1] = 0;
+
+         data = append(data, "HTTP/1.1 200 OK\r\n");
+         data = append(data, "Content-Type: text/plain; version=0.0.3; charset=utf-8\r\n");
+         data = append(data, "Date: ");
+         data = append(data, &time_buf[0]);
+         data = append(data, "\r\n");
+         metrics_cache_append(data);  // cache here to avoid the chunking for the cache
+         data = append(data, "Transfer-Encoding: chunked\r\n");
+         data = append(data, "\r\n");
+
+         msg.kind = 0;
+         msg.length = strlen(data);
+         msg.data = data;
+
+         status = pgagroal_write_message(NULL, client_fd, &msg);
+         if (status != MESSAGE_STATUS_OK)
+         {
+            metrics_cache_invalidate();
+            atomic_store(&cache->lock, STATE_FREE);
+
+            goto error;
+         }
+
+         free(data);
+         data = NULL;
+
+         general_information(client_fd);
+         connection_information(client_fd);
+         limit_information(client_fd);
+         session_information(client_fd);
+         pool_information(client_fd);
+         auth_information(client_fd);
+         client_information(client_fd);
+         internal_information(client_fd);
+         connection_awaiting_information(client_fd);
+
+         /* Footer */
+         data = append(data, "0\r\n\r\n");
+
+         msg.kind = 0;
+         msg.length = strlen(data);
+         msg.data = data;
+
+         metrics_cache_finalize();
+
+      }
+
+      // free the cache
+      atomic_store(&cache->lock, STATE_FREE);
+
+   } // end of cache locking
+   else
+   {
+      /* Sleep for 1ms */
+      struct timespec ts;
+      ts.tv_sec = 0;
+      ts.tv_nsec = 1000000L;
+      nanosleep(&ts, NULL);
+
+      goto retry_cache_locking;
    }
 
-   free(data);
-   data = NULL;
-
-   general_information(client_fd);
-   connection_information(client_fd);
-   limit_information(client_fd);
-   session_information(client_fd);
-   pool_information(client_fd);
-   auth_information(client_fd);
-   client_information(client_fd);
-   internal_information(client_fd);
-   connection_awaiting_information(client_fd);
-
-   /* Footer */
-   data = append(data, "0\r\n\r\n");
-
-   msg.kind = 0;
-   msg.length = strlen(data);
-   msg.data = data;
-
    status = pgagroal_write_message(NULL, client_fd, &msg);
+
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;
@@ -1335,6 +1392,7 @@ general_information(int client_fd)
    if (data != NULL)
    {
       send_chunk(client_fd, data);
+      metrics_cache_append(data);
       free(data);
       data = NULL;
    }
@@ -1477,6 +1535,7 @@ connection_information(int client_fd)
       if (strlen(data) > CHUNK_SIZE)
       {
          send_chunk(client_fd, data);
+         metrics_cache_append(data);
          free(data);
          data = NULL;
       }
@@ -1487,6 +1546,7 @@ connection_information(int client_fd)
    if (data != NULL)
    {
       send_chunk(client_fd, data);
+      metrics_cache_append(data);
       free(data);
       data = NULL;
    }
@@ -1565,6 +1625,7 @@ limit_information(int client_fd)
          if (strlen(data) > CHUNK_SIZE)
          {
             send_chunk(client_fd, data);
+            metrics_cache_append(data);
             free(data);
             data = NULL;
          }
@@ -1575,6 +1636,7 @@ limit_information(int client_fd)
       if (data != NULL)
       {
          send_chunk(client_fd, data);
+         metrics_cache_append(data);
          free(data);
          data = NULL;
       }
@@ -1694,6 +1756,7 @@ session_information(int client_fd)
    data = append(data, "\n\n");
 
    send_chunk(client_fd, data);
+   metrics_cache_append(data);
    free(data);
    data = NULL;
 }
@@ -1767,6 +1830,7 @@ pool_information(int client_fd)
    data = append(data, "\n\n");
 
    send_chunk(client_fd, data);
+   metrics_cache_append(data);
    free(data);
    data = NULL;
 }
@@ -1798,6 +1862,7 @@ auth_information(int client_fd)
    data = append(data, "\n\n");
 
    send_chunk(client_fd, data);
+   metrics_cache_append(data);
    free(data);
    data = NULL;
 }
@@ -1823,6 +1888,7 @@ client_information(int client_fd)
    data = append(data, "\n\n");
 
    send_chunk(client_fd, data);
+   metrics_cache_append(data);
    free(data);
    data = NULL;
 }
@@ -1860,6 +1926,7 @@ internal_information(int client_fd)
    data = append(data, "\n\n");
 
    send_chunk(client_fd, data);
+   metrics_cache_append(data);
    free(data);
    data = NULL;
 }
@@ -1910,6 +1977,7 @@ connection_awaiting_information(int client_fd)
          if (strlen(data) > CHUNK_SIZE)
          {
             send_chunk(client_fd, data);
+            metrics_cache_append(data);
             free(data);
             data = NULL;
          }
@@ -1921,6 +1989,7 @@ connection_awaiting_information(int client_fd)
    {
       data = append(data, "\n");
       send_chunk(client_fd, data);
+      metrics_cache_append(data);
       free(data);
       data = NULL;
    }
@@ -2020,4 +2089,224 @@ append_ullong(char* orig, unsigned long long l)
    orig = append(orig, number);
 
    return orig;
+}
+
+/**
+ * Checks if the Prometheus cache configuration setting
+ * (`metrics_cache`) has a non-zero value, that means there
+ * are seconds to cache the response.
+ *
+ * @return true if there is a cache configuration,
+ *         false if no cache is active
+ */
+static bool
+is_metrics_cache_configured(void)
+{
+   struct configuration* config;
+
+   config = (struct configuration*)shmem;
+
+   // cannot have caching if not set metrics!
+   if (config->metrics == 0)
+   {
+      return false;
+   }
+
+   return config->metrics_cache_max_age != PGAGROAL_PROMETHEUS_CACHE_DISABLED;
+}
+
+/**
+ * Checks if the cache is still valid, and therefore can be
+ * used to serve as a response.
+ * A cache is considred valid if it has non-empty payload and
+ * a timestamp in the future.
+ *
+ * @return true if the cache is still valid
+ */
+static bool
+is_metrics_cache_valid(void)
+{
+   time_t now;
+
+   struct prometheus_cache* cache;
+
+   cache = (struct prometheus_cache*)prometheus_cache_shmem;
+
+   if (cache->valid_until == 0 || strlen(cache->data) == 0)
+   {
+      return false;
+   }
+
+   now = time(NULL);
+   return now <= cache->valid_until;
+}
+
+int
+pgagroal_init_prometheus_cache(size_t* p_size, void** p_shmem)
+{
+   struct prometheus_cache* cache;
+   struct configuration* config;
+   size_t cache_size = 0;
+   size_t struct_size = 0;
+
+   config = (struct configuration*)shmem;
+
+   // first of all, allocate the overall cache structure
+   cache_size = metrics_cache_size_to_alloc();
+   struct_size = sizeof(struct prometheus_cache);
+
+   if (pgagroal_create_shared_memory(struct_size + cache_size, config->hugepage, (void*) &cache))
+   {
+      goto error;
+   }
+
+   memset(cache, 0, struct_size + cache_size);
+   cache->valid_until = 0;
+   cache->size = cache_size;
+   atomic_init(&cache->lock, STATE_FREE);
+
+   // success! do the memory swap
+   *p_shmem = cache;
+   *p_size = cache_size + struct_size;
+   return 0;
+
+error:
+   // disable caching
+   config->metrics_cache_max_age = config->metrics_cache_max_size = PGAGROAL_PROMETHEUS_CACHE_DISABLED;
+   pgagroal_log_error("Cannot allocate shared memory for the Prometheus cache!");
+   *p_size = 0;
+   *p_shmem = NULL;
+
+   return 1;
+}
+
+/**
+ * Provides the size of the cache to allocate.
+ *
+ * It checks if the metrics cache is configured, and
+ * computers the right minimum value between the
+ * user configured requested size and the default
+ * cache size.
+ *
+ * @return the cache size to allocate
+ */
+static size_t
+metrics_cache_size_to_alloc(void)
+{
+   struct configuration* config;
+   size_t cache_size = 0;
+
+   config = (struct configuration*)shmem;
+
+   // which size to use ?
+   // either the configured (i.e., requested by user) if lower than the max size
+   // or the default value
+   if (is_metrics_cache_configured())
+   {
+      cache_size = config->metrics_cache_max_size > 0
+            ? MIN(config->metrics_cache_max_size, PROMETHEUS_MAX_CACHE_SIZE)
+            : PROMETHEUS_DEFAULT_CACHE_SIZE;
+   }
+
+   return cache_size;
+}
+
+/**
+ * Invalidates the cache.
+ *
+ * Requires the caller to hold the lock on the cache!
+ *
+ * Invalidating the cache means that the payload is zero-filled
+ * and that the valid_until field is set to zero too.
+ */
+static void
+metrics_cache_invalidate(void)
+{
+   struct prometheus_cache* cache;
+
+   cache = (struct prometheus_cache*)prometheus_cache_shmem;
+
+   memset(cache->data, 0, cache->size);
+   cache->valid_until = 0;
+}
+
+/**
+ * Appends data to the cache.
+ *
+ * Requires the caller to hold the lock on the cache!
+ *
+ * If the input data is empty, nothing happens.
+ * The data is appended only if the cache does not overflows, that
+ * means the current size of the cache plus the size of the data
+ * to append does not exceed the current cache size.
+ * If the cache overflows, the cache is flushed and marked
+ * as invalid.
+ * This makes safe to call this method along the workflow of
+ * building the Prometheus response.
+ *
+ * @param data the string to append to the cache
+ * @return true on success
+ */
+static bool
+metrics_cache_append(char* data)
+{
+   int origin_length = 0;
+   int append_length = 0;
+   struct prometheus_cache* cache;
+
+   cache = (struct prometheus_cache*)prometheus_cache_shmem;
+
+   if (!is_metrics_cache_configured())
+   {
+      return false;
+   }
+
+   origin_length = strlen(cache->data);
+   append_length = strlen(data);
+   // need to append the data to the cache
+   if (origin_length + append_length >= cache->size)
+   {
+      // cannot append new data, so invalidate cache
+      pgagroal_log_debug("Cannot append %d bytes to the Prometheus cache because it will overflow the size of %d bytes (currently at %d bytes). HINT: try adjusting `metrics_cache_max_size`",
+                         append_length,
+                         cache->size,
+                         origin_length);
+      metrics_cache_invalidate();
+      return false;
+   }
+
+   // append the data to the data field
+   memcpy(cache->data + origin_length, data, append_length);
+   cache->data[origin_length + append_length + 1] = '\0';
+   return true;
+}
+
+/**
+ * Finalizes the cache.
+ *
+ * Requires the caller to hold the lock on the cache!
+ *
+ * This method should be invoked when the cache is complete
+ * and therefore can be served.
+ *
+ * @return true if the cache has a validity
+ */
+static bool
+metrics_cache_finalize(void)
+{
+   struct configuration* config;
+   struct prometheus_cache* cache;
+   time_t now;
+
+   cache = (struct prometheus_cache*)prometheus_cache_shmem;
+   config = (struct configuration*)shmem;
+
+   if (!is_metrics_cache_configured())
+   {
+      return false;
+   }
+
+   now = time(NULL);
+   cache->valid_until = now + config->metrics_cache_max_age;
+   return cache->valid_until > now;
 }

--- a/src/libpgagroal/shmem.c
+++ b/src/libpgagroal/shmem.c
@@ -38,6 +38,7 @@
 void* shmem = NULL;
 void* pipeline_shmem = NULL;
 void* prometheus_shmem = NULL;
+void* prometheus_cache_shmem = NULL;
 
 int
 pgagroal_create_shared_memory(size_t size, unsigned char hp, void** shmem)

--- a/src/main.c
+++ b/src/main.c
@@ -308,6 +308,7 @@ main(int argc, char** argv)
    size_t shmem_size;
    size_t pipeline_shmem_size = 0;
    size_t prometheus_shmem_size = 0;
+   size_t prometheus_cache_shmem_size = 0;
    size_t tmp_size;
    struct configuration* config = NULL;
    int ret;
@@ -762,6 +763,15 @@ main(int argc, char** argv)
       exit(1);
    }
 
+   if (pgagroal_init_prometheus_cache(&prometheus_cache_shmem_size, &prometheus_cache_shmem))
+   {
+      printf("pgagroal: Error in creating and initializing prometheus cache shared memory\n");
+#ifdef HAVE_LINUX
+      sd_notifyf(0, "STATUS=Error in creating and initializing prometheus cache shared memory");
+#endif
+      exit(1);
+   }
+
    if (getrlimit(RLIMIT_NOFILE, &flimit) == -1)
    {
       printf("pgagroal: Unable to find limit due to %s\n", strerror(errno));
@@ -1120,6 +1130,7 @@ main(int argc, char** argv)
 
    pgagroal_stop_logging();
    pgagroal_destroy_shared_memory(prometheus_shmem, prometheus_shmem_size);
+   pgagroal_destroy_shared_memory(prometheus_cache_shmem, prometheus_cache_shmem_size);
    pgagroal_destroy_shared_memory(shmem, shmem_size);
 
    return 0;


### PR DESCRIPTION
This commit refactors the way the Prometheus metrics are served in
order to provide the capability to cache the responses for a specified
amount of time.

Two new configuration settings have been introduced:
- `metrics_cache_max_age`, expressed in seconds, defines for how long
a cached response can be served without having to compute a new one
set of metrics. This parameter is required for the caching machinery
to be enabled.
- `metrics_cache_max_size` allows the user to avoid caching of
responses greater than the expressed value in bytes.

In any case, a cache response is tied to 1MegaByte, by a value set in
the source code.

If the cache overflows the 1MB memory limit, it is immediatly marked
as invalid, that is the system is not going to serve the cached
result. However, as soon as a new Prometheus request arrives, the
cache will be re-filled from scratch, so if the current answer is
lower than 1MB and lower than the optional `metrics_cache_max_size`,
the response will be cached.
Whenever an overflow of the cache happens, the user is warned. Due to
the nature the cache is populated, the user could see more than one
single advice in logs (at level DEBUG).

The cache is built as a shared memory segment (see #256 and in
particular
<https://github.com/agroal/pgagroal/pull/256#issuecomment-1150239298>).
The cache is implemented by means of the `struct prometheus_cache`
that has a dynamically allocated (`mmap()`) segment to handle the
payload. This means that the `metrics_cache_max_size` parameter will
drive the amount of memory dynamically allocated to be used as a cache.

New static utility functions have been added:
- `metrics_cache_append(char* data)` that appends the data to the
cache in the case it is safe to do it, that is no overflow in the
cache size. In case the data to append makes the cache to overflow,
the cache is invalidated;
- `metrics_cache_finalize(void)` set the timestamp for the cache
vlidation.
- `metrics_cache_invalidate(void)` set the cache as invalid by
zero-filling the data. Used for example when an overflow is detected.
- `metrics_cache_size_to_alloc(void)` computes the size, in bytes,
required for the cache payload allocation. The size is set to the
default, or `metrics_cache_max_size` if configured and in any case
nothing more than the max size of 1MB.

New "public" utility function:
- `pgagroal_init_prometheus_cache()` will initialize the cache shared
memory according to the user configuration and the result of
`metrics_cache_size_to_alloc()`.

The `metrics_page()` method has been refactored to check if the cache
is valid, in such case the response is served directly out of
cache. If the cache is not valid, the function gets the cache lock and
invokes several times the append function (in inner method
calls). Last, it finalizes the cache and release the lock.

If the optional configuration parameter `metrics_cache_max_size`
changes, the system does not reallocate memory, rather it issue a
warning about the need for a restart.

The documentation has been updated to reflect changes.

Close #219