### PR TITLE
[#263] Use a macro to perform the process-sleep.

### DIFF
--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -132,6 +132,47 @@ extern "C" {
       __typeof__ (b) _b = (b);  \
       _a < _b ? _a : _b; })
 
+/*
+ * Common piece of code to perform a sleeping.
+ *
+ * @param zzz the amount of time to
+ * sleep, expressed as nanoseconds.
+ *
+ * Example
+   SLEEP(5000000L)
+ *
+ */
+#define SLEEP(zzz)                  \
+   {                                \
+      struct timespec ts_private;   \
+      ts_private.tv_sec = 0;        \
+      ts_private.tv_nsec = zzz;     \
+      nanosleep(&ts_private, NULL); \
+   }
+
+/*
+ * Commonly used block of code to sleep
+ * for a specified amount of time and
+ * then jump back to a specified label.
+ *
+ * @param zzz how much time to sleep (as long nanoseconds)
+ * @param goto_to the label to which jump to
+ *
+ * Example:
+ *
+     ...
+     else
+       SLEEP_AND_GOTO(100000L,retru)
+ */
+#define SLEEP_AND_GOTO(zzz, goto_to)    \
+   {                                    \
+      struct timespec ts_private;       \
+      ts_private.tv_sec = 0;            \
+      ts_private.tv_nsec = zzz;         \
+      nanosleep(&ts_private, NULL);     \
+      goto goto_to;                     \
+   }
+
 /**
  * The shared memory segment
  */

--- a/src/libpgagroal/logging.c
+++ b/src/libpgagroal/logging.c
@@ -402,15 +402,7 @@ retry:
          atomic_store(&config->log_lock, STATE_FREE);
       }
       else
-      {
-         /* Sleep for 1ms */
-         struct timespec ts;
-         ts.tv_sec = 0;
-         ts.tv_nsec = 1000000L;
-         nanosleep(&ts, NULL);
-
-         goto retry;
-      }
+        SLEEP_AND_GOTO(1000000L,retry)
    }
 }
 
@@ -496,14 +488,6 @@ retry:
          atomic_store(&config->log_lock, STATE_FREE);
       }
       else
-      {
-         /* Sleep for 1ms */
-         struct timespec ts;
-         ts.tv_sec = 0;
-         ts.tv_nsec = 1000000L;
-         nanosleep(&ts, NULL);
-
-         goto retry;
-      }
+        SLEEP_AND_GOTO(1000000L,retry)
    }
 }

--- a/src/libpgagroal/management.c
+++ b/src/libpgagroal/management.c
@@ -1281,11 +1281,7 @@ read:
    }
    else if (r < needs)
    {
-      /* Sleep for 10ms */
-      struct timespec ts;
-      ts.tv_sec = 0;
-      ts.tv_nsec = 10000000L;
-      nanosleep(&ts, NULL);
+      SLEEP(10000000L)
 
       pgagroal_log_trace("Got: %ld, needs: %ld", r, needs);
 

--- a/src/libpgagroal/message.c
+++ b/src/libpgagroal/message.c
@@ -1278,7 +1278,6 @@ ssl_read_message(SSL* ssl, int timeout, struct message** msg)
             case SSL_ERROR_ZERO_RETURN:
                if (timeout > 0)
                {
-                  struct timespec ts;
 
                   if (difftime(time(NULL), start_time) >= timeout)
                   {
@@ -1286,9 +1285,8 @@ ssl_read_message(SSL* ssl, int timeout, struct message** msg)
                   }
 
                   /* Sleep for 100ms */
-                  ts.tv_sec = 0;
-                  ts.tv_nsec = 100000000L;
-                  nanosleep(&ts, NULL);
+                  SLEEP(100000000L)
+
                }
             case SSL_ERROR_WANT_READ:
             case SSL_ERROR_WANT_WRITE:

--- a/src/libpgagroal/pipeline_transaction.c
+++ b/src/libpgagroal/pipeline_transaction.c
@@ -144,10 +144,7 @@ transaction_start(struct ev_loop* loop, struct worker_io* w)
    if (is_new)
    {
       /* Sleep for 5ms */
-      struct timespec ts;
-      ts.tv_sec = 0;
-      ts.tv_nsec = 5000000L;
-      nanosleep(&ts, NULL);
+      SLEEP(5000000L)
    }
 
    return;

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -289,12 +289,8 @@ retry:
 retry2:
       if (config->blocking_timeout > 0)
       {
-
          /* Sleep for 500ms */
-         struct timespec ts;
-         ts.tv_sec = 0;
-         ts.tv_nsec = 500000000L;
-         nanosleep(&ts, NULL);
+         SLEEP(500000000L)
 
          double diff = difftime(time(NULL), start_time);
          if (diff >= (double)config->blocking_timeout)
@@ -334,15 +330,9 @@ retry2:
             }
          }
          else
-         {
             /* Sleep for 1000 nanos */
-            struct timespec ts;
-            ts.tv_sec = 0;
-            ts.tv_nsec = 1000L;
-            nanosleep(&ts, NULL);
+            SLEEP_AND_GOTO(1000L,start)
 
-            goto start;
-         }
       }
    }
 

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -1653,15 +1653,8 @@ retry:
       if (difftime(time(NULL), start_time) < config->authentication_timeout)
       {
          if (pgagroal_socket_isvalid(client_fd))
-         {
             /* Sleep for 100ms */
-            struct timespec ts;
-            ts.tv_sec = 0;
-            ts.tv_nsec = 100000000L;
-            nanosleep(&ts, NULL);
-
-            goto retry;
-         }
+            SLEEP_AND_GOTO(100000000L,retry)
       }
    }
 
@@ -1742,15 +1735,9 @@ retry:
       if (difftime(time(NULL), start_time) < config->authentication_timeout)
       {
          if (pgagroal_socket_isvalid(client_fd))
-         {
             /* Sleep for 100ms */
-            struct timespec ts;
-            ts.tv_sec = 0;
-            ts.tv_nsec = 100000000L;
-            nanosleep(&ts, NULL);
+            SLEEP_AND_GOTO(100000000L,retry)
 
-            goto retry;
-         }
       }
    }
 
@@ -1875,15 +1862,9 @@ retry:
       if (difftime(time(NULL), start_time) < config->authentication_timeout)
       {
          if (pgagroal_socket_isvalid(client_fd))
-         {
             /* Sleep for 100ms */
-            struct timespec ts;
-            ts.tv_sec = 0;
-            ts.tv_nsec = 100000000L;
-            nanosleep(&ts, NULL);
+            SLEEP_AND_GOTO(100000000L,retry)
 
-            goto retry;
-         }
       }
    }
 
@@ -4809,10 +4790,7 @@ retry:
       {
 
          /* Sleep for 100ms */
-         struct timespec ts;
-         ts.tv_sec = 0;
-         ts.tv_nsec = 100000000L;
-         nanosleep(&ts, NULL);
+         SLEEP(100000000L)
 
          double diff = difftime(time(NULL), start_time);
          if (diff >= (double)config->blocking_timeout)
@@ -5421,15 +5399,9 @@ retry:
       if (difftime(time(NULL), start_time) < config->authentication_timeout)
       {
          if (pgagroal_socket_isvalid(client_fd))
-         {
             /* Sleep for 100ms */
-            struct timespec ts;
-            ts.tv_sec = 0;
-            ts.tv_nsec = 100000000L;
-            nanosleep(&ts, NULL);
+            SLEEP_AND_GOTO(100000000L,retry)
 
-            goto retry;
-         }
       }
    }
 
@@ -5545,15 +5517,9 @@ retry:
       if (difftime(time(NULL), start_time) < config->authentication_timeout)
       {
          if (pgagroal_socket_isvalid(client_fd))
-         {
             /* Sleep for 100ms */
-            struct timespec ts;
-            ts.tv_sec = 0;
-            ts.tv_nsec = 100000000L;
-            nanosleep(&ts, NULL);
+            SLEEP_AND_GOTO(100000000L,retry)
 
-            goto retry;
-         }
       }
    }
 


### PR DESCRIPTION
Introduces two macros:
- `SLEEP` to perform a nanosleep call with the specified amount of
time expressed as nanoseconds;
- `SLEEP_AND_GOTO` does the same of the above but adds also a `goto`
to the specified label.

Example of usage:

      SLEEP_AND_GOTO(1000000L,retry)

is the same as

      {
         /* Sleep for 1ms */
         struct timespec ts;
         ts.tv_sec = 0;
         ts.tv_nsec = 1000000L;
         nanosleep(&ts, NULL);

         goto retry;
     }

Close #263