### PR TITLE
[#280] Improve tutorials

### DIFF
--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -244,6 +244,15 @@ Next steps in improving pgagroal's configuration could be
 
 See [Configuration](./CONFIGURATION.md) for more information on these subjects.
 
+## Tutorials
+
+There are a few short tutorials available to help you better understand and configure `pgagroal`:
+- [Installing pgagroal](https://github.com/pgagroal/pgagroal/blob/main/doc/tutorial/01_install.md)
+- [Enabling prefill](https://github.com/agroal/pgagroal/blob/master/doc/tutorial/02_prefill.md)
+- [Enabling remote management](https://github.com/agroal/pgagroal/blob/master/doc/tutorial/03_remote_management.md)
+- [Enabling Prometheus metrics](https://github.com/agroal/pgagroal/blob/master/doc/tutorial/04_prometheus.md)
+- [Enabling split security](https://github.com/agroal/pgagroal/blob/master/doc/tutorial/05_split_security.md)
+
 ## Closing
 
 The [pgagroal](https://github.com/agroal/pgagroal) community hopes that you find

--- a/doc/tutorial/02_prefill.md
+++ b/doc/tutorial/02_prefill.md
@@ -1,37 +1,74 @@
 # Enable prefill for pgagroal
 
-This tutorial will show you how to do enable prefill for pgagroal
+This tutorial will show you how to do enable *prefill* for `pgagroal`.
+The prefill is the capability to activate connections against a specific database
+even if no one has been actively requested by a user or an application. This allows the pooler
+to serve a connection faster once it is effectively requested, since the connection is already
+established.
+
+Prefill is done by making `pgagroal` to open the specified amount of connections to a specific database with a specific username, therefore you need to know credentials used on the PostgreSQL side.
 
 ## Preface
 
-This tutorial assumes that you have an installation of PostgreSQL 10+ and pgagroal.
+This tutorial assumes that you have already an installation of PostgreSQL 10 (or higher) and `pgagroal`.
 
-See [Install pgagroal](https://github.com/pgagroal/pgagroal/blob/main/doc/tutorial/01_install.md)
-for more detail.
+In particular, this tutorial refers to the configuration done in [Install pgagroal](https://github.com/pgagroal/pgagroal/blob/main/doc/tutorial/01_install.md).
+
 
 ## Create prefill configuration
 
-Create the `pgagroal_databases.conf` configuration
+Prefill is instrumented by the `pgagroal_databases.conf` configuration file, where you need
+to list databases, usernames, and limits.
+Every username/database pair has to be specified on a separated line.
+The limits are assumed as:
+- *max number of allowed connections* for that username/database
+- *initial number of connections*, that is the effective prefill;
+- *minimum number of connections* to always keep open for the pair username/database.
+
+Assuming you want to configure the prefill for the `mydb` database with the `mysuer` username,
+you have to edit the file `/etc/pgagroal/pgagroal_databases.conf` with your editor of choice
+or using `cat` from the command line, as follows:
 
 ```
+cd /etc/pgagroal
 cat > pgagroal_databases.conf
 mydb   myuser   2   1   0
 ```
 
-and press `Ctrl-D`
+and press `Ctrl-D` to save the file.
 
 This will create a configuration where `mydb` will have a maximum connection size of 2,
 an initial connection size of 1 and a minimum connection size of 0 for the `myuser` user.
 
-(`pgagroal` user)
+The file must be owned by the operating system user `pgagroal`.
+
+See [the `pgagroal_databases.conf` file documentation](https://github.com/agroal/pgagroal/blob/master/doc/CONFIGURATION.md#pgagroal_databases-configuration) for more details.
 
 ## Restart pgagroal
 
-Stop pgagroal and start it again with
+In order to apply changes to the prefill configuration, you need to restart `pgagroal`.
+You can do so by stopping it and then re-launch the daemon, as `pgagroal` operating system user:
 
 ```
-pgagroal-cli -c pgagroal.conf stop
-pgagroal -c pgagroal.conf -a pgagroal_hba.conf -u pgagroal_users.conf -l pgagroal_databases.conf
+pgagroal-cli -c /etc/pgagroal/pgagroal.conf stop
+pgagroal -c /etc/pgagroal/pgagroal.conf -a /etc/pgagroal/pgagroal_hba.conf -u /etc/pgagroal/pgagroal_users.conf -l /etc/pgagroal/pgagroal_databases.conf
 ```
 
-(`pgagroal` user)
+Note that the limit file `pgagroal_databases.conf` has been specified by means of the `l` command line flag.
+If the file has the standard name `/etc/pgagroal/pgagroal_databases.conf`, you can omit it from the command line.
+
+
+## Check the prefill
+
+You can check the prefill by running, as the `pgagroal` operating system user, the `status` command:
+
+```
+pgagroal-cli status
+Status:              Running
+Active connections:  0
+Total connections:   1
+Max connections:     100
+
+```
+
+where the `Total connections` is set by the *initial* connection specified in the limit file.

--- a/doc/tutorial/03_remote_management.md
+++ b/doc/tutorial/03_remote_management.md
@@ -1,23 +1,34 @@
 # Remote administration for pgagroal
 
-This tutorial will show you how to do setup remote management for pgagroal.
+This tutorial will show you how to do setup remote management for `pgagroal`.
+
+`pgagroal` is managed via a command line tool named `pgagroal-cli`. Such tool
+connects via a local Unix socket if running on the same machine the pooler is
+running on, but it is possible to use `pgagroal-cli` from a different machine
+and make it to connect to the pooler machine via *remote management*.
 
 ## Preface
 
-This tutorial assumes that you have an installation of PostgreSQL 10+ and pgagroal.
+This tutorial assumes that you have already an installation of PostgreSQL 10 (or higher) and `pgagroal`.
 
-See [Install pgagroal](https://github.com/pgagroal/pgagroal/blob/main/doc/tutorial/01_install.md)
-for more detail.
+In particular, this tutorial refers to the configuration done in [Install pgagroal](https://github.com/pgagroal/pgagroal/blob/main/doc/tutorial/01_install.md).
 
-## Change the pgagroal configuration
 
-Change `pgagroal.conf` to add
+## Enable remote management
+
+On the pooler machine, you need to enable the remote management. In order to do so,
+add the `management` setting to the main `pgagroal.conf` configuration file.
+The value of setting is the number of a free TCP/IP port to which the remote
+management will connect to.
+
+With your editor of choice, edit the `/etc/pgagroal/pgagroal.conf` file and add the
+`management` option likely the following:
 
 ```
 management = 2347
 ```
 
-under the `[pgagroal]` setting, like
+under the `[pgagroal]` section, so that the configuration file looks like:
 
 ```
 [pgagroal]
@@ -25,33 +36,45 @@ under the `[pgagroal]` setting, like
 management = 2347
 ```
 
-(`pgagroal` user)
+See [the `pgagroal` configuration settings](https://github.com/agroal/pgagroal/blob/master/doc/CONFIGURATION.md#pgagroal) for more details.
 
-## Add pgagroal admin
+## Add remote admin user
+
+Remote management is done via a specific admin user, that has to be created within the pooler vault.
+As the `pgagroal` operating system user, run the following command:
 
 ```
+cd /etc/pgagroal
 pgagroal-admin -f pgagroal_admins.conf -U admin -P admin1234 add-user
 ```
 
-(`pgagroal` user)
+The above will create the `admin` username with the `admin1234` password.
+**We strongly encourage you to choose non trivial usernames and passwords!**
+
 
 ## Restart pgagroal
 
-Stop pgagroal and start it again with
+In order to make the changes available, and therefore activate the remote management, you have to restart `pgagroal`, for example by issuing the following commands from the `pgagroal` operatng system user:
 
 ```
-pgagroal-cli -c pgagroal.conf stop
-pgagroal -c pgagroal.conf -a pgagroal_hba.conf -u pgagroal_users.conf -A pgagroal_admins.conf
+pgagroal-cli -c /etc/pgagroal/pgagroal.conf stop
+pgagroal -c /etc/pgagroal/pgagroal.conf -a /etc/pgagroal/pgagroal_hba.conf -u /etc/pgagroal/pgagroal_users.conf -A /etc/pgagroal/pgagroal_admins.conf
 ```
 
-(`pgagroal` user)
+Please note the presence of the `-A` flag that indicates to the pooler which file use to authenticate remote management users.
+If the file has the standard name `/etc/pgagroal/pgagroal_admins.conf` you can omit it from the command line.
 
 ## Connect via remote administration interface
 
+In order to connect remotely, you need to specify at least the `-h` and `-p` flags on the `pgagroal-cli` command line. Such flags will tell `pgagroal-cli` to connect to a remote host. You can also specify the username you want to connect with by specifying the `-U` flag.
+So, to get the status of the pool remotely, you can issue:
+
 ```
-pgagroal-cli -h localhost -p 2347 -U admin details
+pgagroal-cli -h localhost -p 2347 -U admin status
 ```
 
-and use `admin1234` as the password
+and type the password `admin1234` when asked for it.
 
-(`pgagroal` user)
+If you don't specify the `-U` flag on the command line, you will be asked for a username too.
+
+Please note that the above example uses `localhost` as the remote host, but clearly you can specify any *real* remote host you want to manage.

--- a/doc/tutorial/04_prometheus.md
+++ b/doc/tutorial/04_prometheus.md
@@ -1,23 +1,27 @@
-# Prometheus metrics for pgagroal
+# Prometheus metrics for `pgagroal`
 
-This tutorial will show you how to do setup [Prometheus](https://prometheus.io/) metrics for pgagroal.
+This tutorial will show you how to do basic  [Prometheus](https://prometheus.io/){:target="_blank} setup  for `pgagroal`.
+
+`pgagroal` is able to provide a set of metrics about what it is happening within the pooler,
+so that a Prometheus instance can collect them and help you monitor the pooler.
 
 ## Preface
 
-This tutorial assumes that you have an installation of PostgreSQL 10+ and pgagroal.
+This tutorial assumes that you have already an installation of PostgreSQL 10 (or higher) and `pgagroal`.
 
-See [Install pgagroal](https://github.com/pgagroal/pgagroal/blob/main/doc/tutorial/01_install.md)
-for more detail.
+In particular, this tutorial refers to the configuration done in [Install pgagroal](https://github.com/pgagroal/pgagroal/blob/main/doc/tutorial/01_install.md).
 
 ## Change the pgagroal configuration
 
-Change `pgagroal.conf` to add
+In order to enable to export of the metrics, you need to add the `metrics` option in the main `pgagroal.conf` configuration. The value of this setting is the TCP/IP port number that Prometheus will use to grab the exported metrics.
+
+Add a line like the following to `/etc/pgagroal/pgagroal.conf` by editing such file with your editor of choice:
 
 ```
 metrics = 2346
 ```
 
-under the `[pgagroal]` setting, like
+Place it withingr the `[pgagroal]` section, like
 
 ```
 [pgagroal]
@@ -25,25 +29,33 @@ under the `[pgagroal]` setting, like
 metrics = 2346
 ```
 
-(`pgagroal` user)
+This will bind the TCP/IP port number `2346` to the metrics export.
+
+See [the `pgagroal` configuration settings](https://github.com/agroal/pgagroal/blob/master/doc/CONFIGURATION.md#pgagroal) with particular regard to `metrics`, `metrics_cache_max_age` and `metrics_cache_max_size` for more details.
 
 ## Restart pgagroal
 
-Stop pgagroal and start it again with
+In order to apply changes, you need to restart `pgagroal`, therefore run the following commands
+as the `pgagroal` operating system user:
 
 ```
-pgagroal-cli -c pgagroal.conf stop
-pgagroal -c pgagroal.conf -a pgagroal_hba.conf -u pgagroal_users.conf
+pgagroal-cli -c /etc/pgagroal/pgagroal.conf stop
+pgagroal -c /etc/pgagroal/pgagroal.conf -a /etc/pgagroal/pgagroal_hba.conf
 ```
 
-(`pgagroal` user)
+If you need to specify other configuration files, for example for remote management (see [the related tutorial](https://github.com/pgagroal/pgagroal/blob/main/doc/tutorial/03_remote_management.md)), add them on the `pgagroal~ command line.
+If the cofiguration files have standard names, you can omit them.
 
 ## Get Prometheus metrics
 
-You can now access the metrics via
+Once `pgagroal` is running you can access the metrics with a browser at the pooler address, specifying the `metrics` port number and routing to the `/metrics` page. For example, point your web browser at:
 
 ```
 http://localhost:2346/metrics
 ```
 
-(`pgagroal` user)
+It is also possible to get an explaination of what is the meaning of each metric by pointing your web browser at:
+
+```
+http://localhost:2346/
+```


### PR DESCRIPTION
This commit makes the tutorials more verbose.

All the tutorials have been expanded to better explain what the aim of
each feature/tutorial is. Moreover, every tutorial points to the other
pieces of the documentation where similar concepts have mentioned or
explained. There is also a more verbose explaination of which user to
use when running commands.
Last, all files have been set to a full path, with the advice that
"standard" file names can be omitted on the command line.

The installation tutorial has been split into two main parts:
- installing and configuring PostgreSQL
- instlling and configuring pgagroal.

The PostgreSQL version has been bumped to 14, and the PGDATA has been
set to a not-temporary directory.

Backlink from `GETTING STARTED` to the tutorials.

See #277, #274, #273, #272, #271

Close #280