### PR TITLE
[#282] Reduce code duplication while reading configuration.

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -96,6 +96,7 @@ usage(void)
    printf("\n");
    printf("Options:\n");
    printf("  -c, --config CONFIG_FILE Set the path to the pgagroal.conf file\n");
+   printf("                           Default: %s\n", PGAGROAL_DEFAULT_CONF_FILE);
    printf("  -h, --host HOST          Set the host name\n");
    printf("  -p, --port PORT          Set the port number\n");
    printf("  -U, --user USERNAME      Set the user name\n");
@@ -285,7 +286,7 @@ main(int argc, char** argv)
    }
    else
    {
-      ret = pgagroal_read_configuration(shmem, "/etc/pgagroal/pgagroal.conf", false);
+      ret = pgagroal_read_configuration(shmem, PGAGROAL_DEFAULT_CONF_FILE, false);
       if (ret)
       {
          if (!remote_connection)
@@ -296,7 +297,7 @@ main(int argc, char** argv)
       }
       else
       {
-         configuration_path = "/etc/pgagroal/pgagroal.conf";
+         configuration_path = PGAGROAL_DEFAULT_CONF_FILE;
 
          if (logfile)
          {

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -48,13 +48,20 @@ extern "C" {
 
 #define MAIN_UDS ".s.pgagroal"
 
-#define PGAGROAL_DEFAULT_CONF_FILE "/etc/pgagroal/pgagroal.conf"
-#define PGAGROAL_DEFAULT_HBA_FILE "/etc/pgagroal/pgagroal_hba.conf"
-#define PGAGROAL_DEFAULT_LIMIT_FILE "/etc/pgagroal/pgagroal_databases.conf"
-#define PGAGROAL_DEFAULT_USERS_FILE "/etc/pgagroal/pgagroal_users.conf"
-#define PGAGROAL_DEFAULT_FRONTEND_USERS_FILE "/etc/pgagroal/pgagroal_frontend_users.conf"
-#define PGAGROAL_DEFAULT_ADMINS_FILE "/etc/pgagroal/pgagroal_admins.conf"
-#define PGAGROAL_DEFAULT_SUPERUSER_FILE "/etc/pgagroal/pgagroal_superuser.conf"
+#ifdef HAVE_LINUX
+    #define PGAGROAL_DEFAULT_CONFIGURATION_PATH "/etc/pgagroal/"
+#else
+   #define PGAGROAL_DEFAULT_CONFIGURATION_PATH "/usr/local/etc/pgagroal/"
+#endif
+
+#define PGAGROAL_DEFAULT_CONF_FILE PGAGROAL_DEFAULT_CONFIGURATION_PATH "pgagroal.conf"
+#define PGAGROAL_DEFAULT_HBA_FILE  PGAGROAL_DEFAULT_CONFIGURATION_PATH "pgagroal_hba.conf"
+#define PGAGROAL_DEFAULT_LIMIT_FILE PGAGROAL_DEFAULT_CONFIGURATION_PATH "pgagroal_databases.conf"
+#define PGAGROAL_DEFAULT_USERS_FILE PGAGROAL_DEFAULT_CONFIGURATION_PATH "pgagroal_users.conf"
+#define PGAGROAL_DEFAULT_FRONTEND_USERS_FILE PGAGROAL_DEFAULT_CONFIGURATION_PATH "pgagroal_frontend_users.conf"
+#define PGAGROAL_DEFAULT_ADMINS_FILE PGAGROAL_DEFAULT_CONFIGURATION_PATH "pgagroal_admins.conf"
+#define PGAGROAL_DEFAULT_SUPERUSER_FILE PGAGROAL_DEFAULT_CONFIGURATION_PATH "pgagroal_superuser.conf"
+
 
 #define MAX_BUFFER_SIZE      65535
 #define DEFAULT_BUFFER_SIZE  65535

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -48,6 +48,14 @@ extern "C" {
 
 #define MAIN_UDS ".s.pgagroal"
 
+#define PGAGROAL_DEFAULT_CONF_FILE "/etc/pgagroal/pgagroal.conf"
+#define PGAGROAL_DEFAULT_HBA_FILE "/etc/pgagroal/pgagroal_hba.conf"
+#define PGAGROAL_DEFAULT_LIMIT_FILE "/etc/pgagroal/pgagroal_databases.conf"
+#define PGAGROAL_DEFAULT_USERS_FILE "/etc/pgagroal/pgagroal_users.conf"
+#define PGAGROAL_DEFAULT_FRONTEND_USERS_FILE "/etc/pgagroal/pgagroal_frontend_users.conf"
+#define PGAGROAL_DEFAULT_ADMINS_FILE "/etc/pgagroal/pgagroal_admins.conf"
+#define PGAGROAL_DEFAULT_SUPERUSER_FILE "/etc/pgagroal/pgagroal_superuser.conf"
+
 #define MAX_BUFFER_SIZE      65535
 #define DEFAULT_BUFFER_SIZE  65535
 #define SECURITY_BUFFER_SIZE   512


### PR DESCRIPTION
This commit introduces a few constants to indicate the default files
`pgagroal` is going to read the configuration from when the user does
not specify anything else on the command line.

All the constants have the name `PGAGROAL_DEFAULT_<what>_FILE`, like
for example `PGAGROAL_DEFAULT_CONF_FILE` and
`PGAGROAL_DEFAULT_HBA_FILE`.

The idea is to give priority to what the user has specified on the
command line, and then if nothing has been specfiied, use the default
file path. This was already done, but in a more verbose way.

This commit uniforms the error checking for all the cases, when the
file has been specified or it is the default one, so that for
instance, the default file is checked against the same type of
troubles the user could have introduced into custom files.

The online help has been updated to indicate where the default file
for every option is located.

The command line tool `pgagroal-cli` has been adjusted to use the new
constants and get a coherent online help.

Close #282