### PR TITLE
[#215] Process title length

### DIFF
--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -254,6 +254,20 @@ pgagroal_base64_decode(char* encoded, size_t encoded_length, char** raw, int* ra
 void
 pgagroal_set_proc_title(int argc, char** argv, char* s1, char* s2);
 
+/**
+ * Sets the process title for a given connection.
+ *
+ * Uses `pgagroal_set_proc_title` to build an information string
+ * with the form
+ *    user@host:port/database
+ *
+ * @param argc the number of arguments
+ * @param argv command line arguments
+ * @param connection the struct connection pointer for the established connection.
+ */
+void
+pgagroal_set_connection_proc_title(int argc, char** argv, struct connection* connection);
+
 #ifdef DEBUG
 
 /**

--- a/src/libpgagroal/worker.c
+++ b/src/libpgagroal/worker.c
@@ -106,7 +106,7 @@ pgagroal_worker(int client_fd, char* address, char** argv)
       pgagroal_prometheus_client_active_add();
 
       pgagroal_pool_status();
-      pgagroal_set_proc_title(1, argv, config->connections[slot].username, config->connections[slot].database);
+      pgagroal_set_connection_proc_title(1, argv, &config->connections[slot]);
 
       if (config->pipeline == PIPELINE_PERFORMANCE)
       {


### PR DESCRIPTION
This is a brute force approach to set the process title with the
appropriate length.
The idea is to compute the size of the process title as it has been
requested, and set it to the computed size.

This works on Rocky Linux release 8.6 (Green Obsidian).

It could break some aggressive security-enforced environments.

See #215