### PR TITLE
[#285] Introduce `update_process_title` setting

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -77,6 +77,7 @@ See a more complete [sample](./etc/pgagroal.conf) configuration for running `pga
 | tracker | off | Bool | No | Track connection lifecycle |
 | track_prepared_statements | off | Bool | No | Track prepared statements (transaction pooling) |
 | pidfile | | String | No | Path to the PID file. If omitted, automatically set to `unix_socket_dir`/pgagroal.`port`.pid |
+| update_process_title | `verbose` | No | The behavior for updating the operating system process title, mainly related to connection processes. Allowed settings are: `never` (or `off`), does not update the process title; `strict` to set the process title without overriding the existing initial process title length; `minimal` to set the process title to `username/database`; `verbose` (or `full`) to set the process title to `user@host:port/database`. Please note that `strict` and `minimal` are honored only on those systems that do not provide a native way to set the process title (e.g., Linux). On other systems, there is no difference between `strict` and `minimal` and the assumed behaviour is `minimal` even if `strict` is used. `never` and `verbose` are always honored, on every system. On Linux systems the process title is always trimmed to 255 characters, while on system that provide a natve way to set the process title it can be longer. |
 
 __Danger zone__
 

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -62,6 +62,7 @@ extern "C" {
 #define PGAGROAL_DEFAULT_ADMINS_FILE PGAGROAL_DEFAULT_CONFIGURATION_PATH "pgagroal_admins.conf"
 #define PGAGROAL_DEFAULT_SUPERUSER_FILE PGAGROAL_DEFAULT_CONFIGURATION_PATH "pgagroal_superuser.conf"
 
+#define MAX_PROCESS_TITLE_LENGTH 256
 
 #define MAX_BUFFER_SIZE      65535
 #define DEFAULT_BUFFER_SIZE  65535
@@ -133,6 +134,11 @@ extern "C" {
 #define HUGEPAGE_OFF 0
 #define HUGEPAGE_TRY 1
 #define HUGEPAGE_ON  2
+
+#define UPDATE_PROCESS_TITLE_NEVER 0
+#define UPDATE_PROCESS_TITLE_STRICT 1
+#define UPDATE_PROCESS_TITLE_MINIMAL 2
+#define UPDATE_PROCESS_TITLE_VERBOSE 3
 
 #define likely(x)    __builtin_expect (!!(x), 1)
 #define unlikely(x)  __builtin_expect (!!(x), 0)
@@ -398,6 +404,8 @@ struct configuration
    unsigned int log_rotation_age;     /**< minutes for log rotation */
    char log_line_prefix[MISC_LENGTH]; /**< The logging prefix */
    atomic_schar log_lock;             /**< The logging lock */
+
+   unsigned int update_process_title;  /**< Behaviour for updating the process title */
 
    bool authquery; /**< Is authentication query enabled */
 

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -245,7 +245,22 @@ int
 pgagroal_base64_decode(char* encoded, size_t encoded_length, char** raw, int* raw_length);
 
 /**
- * Set process title
+ * Set process title.
+ *
+ * The function will autonomously check the update policy set
+ * via the configuration option `update_process_title` and
+ * will do nothing if the setting is `never`.
+ * In the case the policy is set to `strict`, the process title
+ * will not overflow the initial command line length (i.e., strlen(argv[*]))
+ * otherwise it will do its best to set the title to the desired string.
+ *
+ * The policies `strict` and `minimal` will be honored only on Linux platforms
+ * where a native call to set the process title is not available.
+ *
+ *
+ * The resulting process title will be set to either `s1` or `s1/s2` if there
+ * both strings and the length is allowed by the policy.
+ *
  * @param argc The number of arguments
  * @param argv The argv pointer
  * @param s1 The first string
@@ -260,6 +275,10 @@ pgagroal_set_proc_title(int argc, char** argv, char* s1, char* s2);
  * Uses `pgagroal_set_proc_title` to build an information string
  * with the form
  *    user@host:port/database
+ *
+ * This means that all the policies honored by the latter function and
+ * set via the `update_process_title` configuration paramter will be
+ * honored.
  *
  * @param argc the number of arguments
  * @param argv command line arguments

--- a/src/libpgagroal/worker.c
+++ b/src/libpgagroal/worker.c
@@ -106,7 +106,19 @@ pgagroal_worker(int client_fd, char* address, char** argv)
       pgagroal_prometheus_client_active_add();
 
       pgagroal_pool_status();
-      pgagroal_set_connection_proc_title(1, argv, &config->connections[slot]);
+
+      // do we have to update the process title?
+      switch (config->update_process_title)
+      {
+         case UPDATE_PROCESS_TITLE_MINIMAL:
+         case UPDATE_PROCESS_TITLE_STRICT:
+            // pgagroal_set_proc_title will check the policy
+            pgagroal_set_proc_title(1, argv, config->connections[slot].username, config->connections[slot].database);
+            break;
+         case UPDATE_PROCESS_TITLE_VERBOSE:
+            pgagroal_set_connection_proc_title(1, argv, &config->connections[slot]);
+            break;
+      }
 
       if (config->pipeline == PIPELINE_PERFORMANCE)
       {


### PR DESCRIPTION
This commit adds the `update_process_title` configuration setting.
Values for such setting are:
- `never` or `off`, means the user does not want to update the process
title at all;
- `strict` (used on Linux and systems that do no provide a native call
to update the process title) allows for changing the process title
without overflowing the length of the initial command line;
- `minimal` sets the process title to `user/database` even if this
exceeds the initial command line length;
- `verbose` sets the process title to `user@host:port/database` even
if this overflows the initial command line length.

By default the setting is configured as `verbose`, but this could
break some aggressively secured environments, where no native way to
set the process title is provided.

The `pgagroal_set_proc_title` function has been refactored so that, if
the update policy is set to `never` the process title will never be
updated. This can be confusing because even the "main" process will
not have a title update.
Likely, if the policy is `strict`, the function will never try to
overflow the initial command line length.

On those systems that do provide a native way to set the process
title, there is no difference between `strict` and `minimal` and the
`minmal` policy is always adopted.

Documentation updated.

Close #285