### PR TITLE
[#253] Refactor commands in `pgagroal-cli`

### DIFF
--- a/contrib/shell_comp/pgagroal_comp.bash
+++ b/contrib/shell_comp/pgagroal_comp.bash
@@ -2,16 +2,37 @@
 
 # COMP_WORDS contains
 # at index 0 the executable name (pgagroal-cli)
-# at index 1 the command name (e.g., flush-all)
+# at index 1 the command name (e.g., flush)
+# at index 2, if required, the subcommand name (e.g., all)
 pgagroal_cli_completions()
 {
 
     if [ "${#COMP_WORDS[@]}" == "2" ]; then
         # main completion: the user has specified nothing at all
         # or a single word, that is a command
-        COMPREPLY=($(compgen -W "flush-idle flush-gracefully flush-all is-alive enable disable stop gracefully status details switch-to reload reset reset-server config-get config-set" "${COMP_WORDS[1]}"))
+        COMPREPLY=($(compgen -W "flush is-alive enable disable shutdown status details switch-to conf clear" "${COMP_WORDS[1]}"))
+    else
+        # the user has specified something else
+        # subcommand required?
+        case ${COMP_WORDS[1]} in
+            flush)
+                COMPREPLY+=($(compgen -W "gracefully idle all" "${COMP_WORDS[2]}"))
+                ;;
+            shutdown)
+                COMPREPLY+=($(compgen -W "gracefully immediate cancel" "${COMP_WORDS[2]}"))
+                ;;
+            clear)
+                COMPREPLY+=($(compgen -W "server prometheus" "${COMP_WORDS[2]}"))
+                ;;
+	    conf)
+		COMPREPLY+=($(compgen -W "reload get set" "${COMP_WORDS[2]}"))
+		;;
+        esac
     fi
+
+
 }
+
 
 
 pgagroal_admin_completions()
@@ -19,9 +40,20 @@ pgagroal_admin_completions()
     if [ "${#COMP_WORDS[@]}" == "2" ]; then
         # main completion: the user has specified nothing at all
         # or a single word, that is a command
-        COMPREPLY=($(compgen -W "master-key add-user update-user remove-user list-users" "${COMP_WORDS[1]}"))
+        COMPREPLY=($(compgen -W "master-key user" "${COMP_WORDS[1]}"))
+    else
+        # the user has specified something else
+        # subcommand required?
+        case ${COMP_WORDS[1]} in
+            user)
+                COMPREPLY+=($(compgen -W "add del edit ls" "${COMP_WORDS[2]}"))
+                ;;
+        esac
     fi
 }
+
+
+
 
 # install the completion functions
 complete -F pgagroal_cli_completions pgagroal-cli

--- a/contrib/shell_comp/pgagroal_comp.zsh
+++ b/contrib/shell_comp/pgagroal_comp.zsh
@@ -6,14 +6,75 @@ function _pgagroal_cli()
 {
     local line
     _arguments -C \
-               "1: :(flush-idle flush-all flush-gracefully is-alive enable disable stop gracefully status details switch-to reload reset reset-server config-get config-set)" \
+               "1: :(flush is-alive enable disable shutdown status details switch-to conf clear)" \
+               "*::arg:->args"
+
+    case $line[1] in
+        flush)
+            _pgagroal_cli_flush
+            ;;
+        shutdown)
+            _pgagroal_cli_shutdown
+            ;;
+        clear)
+            _pgagroal_cli_clear
+            ;;
+	conf)
+	    _pgagroal_cli_conf
+	    ;;
+    esac
+}
+
+function _pgagroal_cli_flush()
+{
+    local line
+    _arguments -C \
+               "1: :(gracefully idle all)" \
                "*::arg:->args"
 }
+
+function _pgagroal_cli_conf()
+{
+    local line
+    _arguments -C \
+               "1: :(reload get set)" \
+               "*::arg:->args"
+}
+
+function _pgagroal_cli_shutdown()
+{
+    local line
+    _arguments -C \
+               "1: :(gracefully immediate cancel)" \
+               "*::arg:->args"
+}
+
+function _pgagroal_cli_clear()
+{
+    local line
+    _arguments -C \
+               "1: :(server prometheus)" \
+               "*::arg:->args"
+}
+
 
 function _pgagroal_admin()
 {
     local line
     _arguments -C \
-               "1: :(master-key add-user update-user remove-user list-users)" \
+               "1: :(master-key user)" \
+               "*::arg:->args"
+
+    case $line[1] in
+        user)
+            _pgagroal_admin_user
+            ;;
+    esac
+}
+
+function _pgagroal_admin_user()
+{
+    _arguments -C \
+               "1: :(add del edit ls)" \
                "*::arg:->args"
 }

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,0 +1,87 @@
+# `pgagroal-admin` user guide
+
+`pgagroal-admin` is a command line interface to manage users known
+to the `pgagroal` connection pooler.
+The executable accepts a set of options, as well as a command to execute.
+If no command is provided, the program will show the help screen.
+
+The `pgagroal-admin` utility has the following synopsis:
+
+```
+pgagroal-admin [ OPTIONS ] [ COMMAND ]
+```
+
+
+## Options
+
+Available options are the following ones:
+
+```
+  -f, --file FILE         Set the path to a user file
+  -U, --user USER         Set the user name
+  -P, --password PASSWORD Set the password for the user
+  -g, --generate          Generate a password
+  -l, --length            Password length
+  -V, --version           Display version information
+  -?, --help              Display help
+
+```
+
+Options can be specified either in short or long form, in any position of the command line.
+
+The `-f` option is mandatory for every operation that involves user management. If no
+user file is specified, `pgagroal-admin` will silently use the default one (`pgagroal_users.conf`).
+
+## Commands
+
+### user
+The `user` command allows the management of the users known to the connection pooler.
+The command accepts the following subcommands:
+- `add` to add a new user to the system;
+- `del` to remove an existing user from the system;
+- `edit` to change the credentials of an existing user;
+- `ls` to list all known users within the system.
+
+The command will edit the `pgagroal_users.conf` file or any file specified by means of the `-f` option flag.
+
+Unless the command is run with the `-U` and/or `-P` flags, the execution will be interactive.
+
+Examples:
+
+``` shell
+pgagroal-admin user add -U simon -P secret
+pgagroal-admin user del -U simon
+
+```
+
+## master-key
+
+The `master-key` command allows the definition of a password to protect the vault of the users,
+that is the "container" for users' credentials.
+
+
+## Deprecated commands
+
+The following commands have been deprecated and will be removed
+in later releases of `pgagroal`.
+For each command, this is the corresponding current mapping
+to the working command:
+
+- `add-user` is now `user add`;
+- `remove-user` is now `user del`;
+- `update-user` is now `user edit`;
+- `list-users` is now `user ls`.
+
+Whenever you use a deprecated command, the `pgagroal-admin` will print on standard error a warning message.
+If you don't want to get any warning about deprecated commands, you
+can redirect the `stderr` to `/dev/null` or any other location with:
+
+```
+pgagroal-admin user-add -U luca -P strongPassword 2>/dev/null
+```
+
+
+## Shell completion
+
+There is a minimal shell completion support for `pgagroal-admin`.
+See the [Install pgagroal](https://github.com/pgagroal/pgagroal/blob/main/doc/tutorial/01_install.md) for more details.

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -1,8 +1,21 @@
-# pgagroal-cli user guide
+# `pgagroal-cli` user guide
+
+`pgagroal-cli` is a command line interface to interact with `pgagroal`.
+The executable accepts a set of options, as well as a command to execute.
+If no command is provided, the program will show the help screen.
+
+The `pgagroal-cli` utility has the following synopsis:
 
 ```
-pgagroal-cli [ -c CONFIG_FILE ] [ COMMAND ]
+pgagroal-cli [ OPTIONS ] [ COMMAND ]
+```
 
+
+## Options
+
+Available options are the following ones:
+
+```
 -c, --config CONFIG_FILE Set the path to the pgagroal.conf file
 -h, --host HOST          Set the host name
 -p, --port PORT          Set the port number
@@ -12,65 +25,41 @@ pgagroal-cli [ -c CONFIG_FILE ] [ COMMAND ]
 -v, --verbose            Output text string of result
 -V, --version            Display version information
 -?, --help               Display help
+
 ```
 
-Commands are described in the following sections.
-Several commands work against an optional specified database.
-It is possible to specify *all database* at once by means of the special string `*` (take care of shell expansion!).
-If no database name is specified, the command is automatically run against all databases (i.e., as if `*` has been specified).
+Options can be specified either in short or long form, in any position of the command line.
 
-## flush-idle
-Flush idle connections.
-Without any argument, or with `*` as only argument,
-works against all configured databases.
+## Commands
+
+### flush
+The `flush` command performs a connection flushing.
+It accepts a *mode* to operate the actual flushing:
+- `gracefully` (the default if not specified), flush connections when possible;
+- `idle` to flush only connections in state *idle*;
+- `all` to flush all the connections (**use with caution!**).
+
+The command accepts a database name, that if provided, restricts the scope of
+`flush` only to connections related to such database.
+If no database is provided, the `flush` command is operated against all databases.
+
 
 Command
 
 ```
-pgagroal-cli flush-idle [*|<database>]
+pgagroal-cli flush [gracefully|idle|all] [*|<database>]
 ```
 
-Example
+Examples
 
 ```
-pgagroal-cli flush-idle
+pgagroal-cli flush           # pgagroal-cli flush gracefully '*'
+pgagroal-cli flush idle      # pgagroal-cli flush idle '*'
+pgagroal-cli flush all       # pgagroal-cli flush all '*'
+pgagroal-cli flush pgbench   # pgagroal-cli flush gracefully pgbench
 ```
 
-## flush-gracefully
-Flush all connections gracefully.
-Without any argument, or with `*` as only argument,
-works against all configured databases.
-
-Command
-
-```
-pgagroal-cli flush-gracefully [*|<database>]
-```
-
-Example
-
-```
-pgagroal-cli flush-gracefully
-```
-
-## flush-all
-Flush all connections. **USE WITH CAUTION !**
-Without any argument, or with `*` as only argument,
-works against all configured databases.
-
-Command
-
-```
-pgagroal-cli flush-all [*|<database>]
-```
-
-Example
-
-```
-pgagroal-cli flush-all mydb
-```
-
-## is-alive
+### is-alive
 Is pgagroal alive
 
 Command
@@ -85,10 +74,8 @@ Example
 pgagroal-cli is-alive
 ```
 
-## enable
-Enables the specified database.
-Without any argument, or with `*` as only argument,
-works against all configured databases.
+### enable
+Enables a database (or all databases).
 
 Command
 
@@ -102,11 +89,8 @@ Example
 pgagroal-cli enable
 ```
 
-## disable
-Disables a database specified by its name.
-Without any argument, or with `*` as only argument,
-works against all configured databases.
-
+### disable
+Disables a database (or all databases).
 
 Command
 
@@ -120,52 +104,33 @@ Example
 pgagroal-cli disable
 ```
 
-## gracefully
-Stop pgagroal gracefully
+### shutdown
+The `shutdown` command is used to stop the connection pooler.
+It supports the following operating modes:
+- `gracefully` (the default) closes the pooler as soon as no active connections are running;
+- `immediate` force an immediate stop.
+
+If the `gracefully` mode is requested, chances are the system will take some time to
+perform the effective shutdown, and therefore it is possible to abort the request
+issuing another `shutdown` command with the mode `cancel`.
+
 
 Command
 
 ```
-pgagroal-cli gracefully
+pgagroal-cli shutdown [gracefully|immediate|cancel]
 ```
 
-Example
+Examples
 
 ```
-pgagroal-cli gracefully
+pgagroal-cli shutdown   # pgagroal-cli shutdown gracefully
+...
+pgagroal-cli shutdown cancel  # stops the above command
 ```
 
-## stop
-Stop pgagroal
 
-Command
-
-```
-pgagroal-cli stop
-```
-
-Example
-
-```
-pgagroal-cli stop
-```
-
-## cancel-shutdown
-Cancel the graceful shutdown
-
-Command
-
-```
-pgagroal-cli cancel-shutdown
-```
-
-Example
-
-```
-pgagroal-cli cancel-shutdown
-```
-
-## status
+### status
 Status of pgagroal
 
 Command
@@ -180,7 +145,7 @@ Example
 pgagroal-cli status
 ```
 
-## details
+### details
 Detailed status of pgagroal
 
 Command
@@ -195,8 +160,8 @@ Example
 pgagroal-cli details
 ```
 
-## switch-to
-Switch to another primary
+### switch-to
+Switch to another primary server.
 
 Command
 
@@ -210,51 +175,33 @@ Example
 pgagroal-cli switch-to replica
 ```
 
-## reload
-Reload the configuration
+### conf
+Manages the configuration of the running instance.
+This command requires one subcommand, that can be:
+- `reload` issue a reload of the configuration, applying at runtime any changes from the configuration files;
+- `get` provides a configuration parameter value;
+- `set` modifies a configuration parameter at runtime.
 
 Command
 
 ```
-pgagroal-cli reload
+pgagroal-cli conf <what>
 ```
 
-Example
+Examples
 
 ```
-pgagroal-cli reload
-```
+pgagroal-cli conf reload
 
-## reset
-Reset the Prometheus statistics
-Command
+pgagroal-cli conf get max_connections
 
-```
-pgagroal-cli reset
-```
-
-Example
+pgagroal-cli conf set max_connections 25
 
 ```
-pgagroal-cli reset
-```
 
-## reset-server
-Reset the state of a server
+The details about how to get and set values at run-time are explained in the following.
 
-Command
-
-```
-pgagroal-cli reset-server <server>
-```
-
-Example
-
-```
-pgagroal-cli reset-server primary
-```
-
-## config-get
+### conf get
 Given a configuration setting name, provides the current value for such setting.
 
 The configuration setting name must be the same as the one used in the configuration files.
@@ -278,13 +225,13 @@ the form `section.context.key` where:
 
 Examples
 ```
-pgagroal-cli config-get pipeline
+pgagroal-cli conf get pipeline
 performance
 
-pgagroal-cli config-get limit.pgbench.max_size
+pgagroal-cli conf get limit.pgbench.max_size
 2
 
-pgagroal-cli config-get server.venkman.primary
+pgagroal-cli conf get server.venkman.primary
 off
 
 ```
@@ -296,7 +243,7 @@ The `server.venkman.primary` searches for the configuration parameter `primary` 
 If the `--verbose` option is specified, a descriptive string of the configuration parameter is printed as *name = value*:
 
 ```
-pgagroal-cli config-get max_connections --verbose
+pgagroal-cli conf get max_connections --verbose
 max_connections = 4
 Success (0)
 ```
@@ -304,29 +251,30 @@ Success (0)
 If the parameter name specified is not found or invalid, the program `pgagroal-cli` exit normally without printing any value.
 
 
-## config-set
+
+### conf set
 Allows the setting of a configuration parameter at run-time, if possible.
 
 Examples
 ```
-pgagroal-cli config-set log_level debug
-pgagroal-cli config-set server.venkman.port 6432
-pgagroal config-set limit.pgbench.max_size 2
+pgagroal-cli conf set log_level debug
+pgagroal-cli conf set server.venkman.port 6432
+pgagroal conf set limit.pgbench.max_size 2
 ```
 
-The syntax for setting parameters is the same as for the command `config-get`, therefore parameters are organized into namespaces:
+The syntax for setting parameters is the same as for the command `conf get`, therefore parameters are organized into namespaces:
 - `main` (optional) is the main pgagroal configuration namespace, for example `main.log_level` or simply `log_level`;
 - `server` is the namespace referred to a specific server. It has to be followed by the name of the server and the name of the parameter to change, in a dotted notation, like `server.venkman.port`;
 - `limit` is the namespace referred to a specific limit entry, followed by the name of the username used in the limit entry.
 
-When executed, the `config-set` command returns the run-time setting of the specified parameter: if such parameter is equal to the value supplied, the change has been applied, otherwise it means that the old setting has been kept.
+When executed, the `conf set` command returns the run-time setting of the specified parameter: if such parameter is equal to the value supplied, the change has been applied, otherwise it means that the old setting has been kept.
 The `--verbose` flag can be used to understand if the change has been applied:
 
 ```
-$ pgagroal-cli config-set log_level debug
+$ pgagroal-cli conf set log_level debug
 debug
 
-$ pgagroal-cli config-set log_level debug --verbose
+$ pgagroal-cli conf set log_level debug --verbose
 log_level = debug
 pgagroal-cli: Success (0)
 ```
@@ -334,15 +282,15 @@ pgagroal-cli: Success (0)
 When a setting modification cannot be applied, the system returns the "old" setting value and, if `--verbose` is specified, the error indication:
 
 ```
-$ pgagroal-cli config-set max_connections 100
+$ pgagroal-cli conf set max_connections 100
 40
 
-$ pgagroal-cli config-set max_connections 100 --verbose
+$ pgagroal-cli conf set max_connections 100 --verbose
 max_connections = 40
 pgagroal-cli: Error (2)
 ```
 
-When a `config-set` cannot be applied, the system will report in the logs an indication about the problem. With regard to the previous example, the system reports in the logs something like the following (depending on your `log_level`):
+When a `conf set` cannot be applied, the system will report in the logs an indication about the problem. With regard to the previous example, the system reports in the logs something like the following (depending on your `log_level`):
 
 ```
 DEBUG Trying to change main configuration setting <max_connections> to <100>
@@ -350,6 +298,62 @@ INFO  Restart required for max_connections - Existing 40 New 100
 WARN  1 settings cannot be applied
 DEBUG pgagroal_management_write_config_set: unable to apply changes to <max_connections> -> <100>
 ```
+
+
+
+### clear
+Resets different parts of the pooler. It accepts an operational mode:
+- `prometheus` resets the metrics provided without altering the pooler status;
+- `server` resets the specified server status.
+
+
+```
+pgagroal-cli clear [prometheus|server <server>]
+```
+
+Examples
+
+```
+pgagroal-cli clear spengler            # pgagroal-cli clear server spengler
+pgagroal-cli clear prometheus
+```
+
+
+## Deprecated commands
+
+The following commands have been deprecated and will be removed
+in later releases of `pgagroal`.
+For each command, this is the corresponding current mapping
+to the working command:
+
+- `flush-idle` is equivalent to `flush idle`;
+- `flush-all` is equivalent to `flush all`;
+- `flush-gracefully` is equivalent to `flush gracefully` or simply `flush`;
+- `stop` is equivalent to `shutdown immediate`;
+- `gracefully` is equivalent to `shutdown gracefully` or simply `shutdown`;
+- `reset` is equivalent to `clear prometheus`;
+- `reset-server` is equivalent to `clear server` or simply `clear`;
+- `config-get` and `config-set` are respectively `conf get` and `conf set`;
+- `reload` is equivalent to `conf reload`.
+
+
+Whenever you use a deprecated command, the `pgagroal-cli` will print on standard error a warning message.
+For example:
+
+```
+pgagroal-cli reset-server
+
+WARN: command <reset-server> has been deprecated by <clear server> since version 1.6.x
+```
+
+If you don't want to get any warning about deprecated commands, you
+can redirect the `stderr` to `/dev/null` or any other location with:
+
+```
+pgagroal-cli reset-server 2>/dev/null
+```
+
+
 
 
 ## Shell completions

--- a/doc/tutorial/01_install.md
+++ b/doc/tutorial/01_install.md
@@ -134,7 +134,8 @@ As the `pgagroal` operating system user, add a master key to protect the `pgagro
 
 ```
 pgagroal-admin master-key
-pgagroal-admin -f /etc/pgagroal/pgagroal_users.conf -U myuser -P mypassword add-user
+
+pgagroal-admin -f /etc/pgagroal/pgagroal_users.conf -U myuser -P mypassword user add
 ```
 
 **You have to choose a password for the master key - remember it!**

--- a/doc/tutorial/02_prefill.md
+++ b/doc/tutorial/02_prefill.md
@@ -51,7 +51,7 @@ In order to apply changes to the prefill configuration, you need to restart `pga
 You can do so by stopping it and then re-launch the daemon, as `pgagroal` operating system user:
 
 ```
-pgagroal-cli -c /etc/pgagroal/pgagroal.conf stop
+pgagroal-cli -c /etc/pgagroal/pgagroal.conf shutdown
 pgagroal -c /etc/pgagroal/pgagroal.conf -a /etc/pgagroal/pgagroal_hba.conf -u /etc/pgagroal/pgagroal_users.conf -l /etc/pgagroal/pgagroal_databases.conf
 ```
 

--- a/doc/tutorial/03_remote_management.md
+++ b/doc/tutorial/03_remote_management.md
@@ -57,7 +57,7 @@ The above will create the `admin` username with the `admin1234` password.
 In order to make the changes available, and therefore activate the remote management, you have to restart `pgagroal`, for example by issuing the following commands from the `pgagroal` operatng system user:
 
 ```
-pgagroal-cli -c /etc/pgagroal/pgagroal.conf stop
+pgagroal-cli -c /etc/pgagroal/pgagroal.conf shutdown
 pgagroal -c /etc/pgagroal/pgagroal.conf -a /etc/pgagroal/pgagroal_hba.conf -u /etc/pgagroal/pgagroal_users.conf -A /etc/pgagroal/pgagroal_admins.conf
 ```
 

--- a/doc/tutorial/04_prometheus.md
+++ b/doc/tutorial/04_prometheus.md
@@ -39,7 +39,7 @@ In order to apply changes, you need to restart `pgagroal`, therefore run the fol
 as the `pgagroal` operating system user:
 
 ```
-pgagroal-cli -c /etc/pgagroal/pgagroal.conf stop
+pgagroal-cli -c /etc/pgagroal/pgagroal.conf shutdown
 pgagroal -c /etc/pgagroal/pgagroal.conf -a /etc/pgagroal/pgagroal_hba.conf
 ```
 

--- a/doc/tutorial/05_split_security.md
+++ b/doc/tutorial/05_split_security.md
@@ -27,7 +27,7 @@ As an example, consider the user `myuser` created in the [Installing pgagroal tu
 To achieve this, as `pgagroal` operating system run the following command:
 
 ```
-pgagroal-admin -f /etc/pgagroal/pgagroal_frontend_users.conf -U myuser -P application_password add-user
+pgagroal-admin -f /etc/pgagroal/pgagroal_frontend_users.conf -U myuser -P application_password user add
 ```
 
 (`pgagroal` user)
@@ -39,7 +39,7 @@ You will need a password mapping for each user defined in the `pgagroal_users.co
 In order to apply changes, you need to restart `pgagroal`, so as the `pgagroal` operating system user do:
 
 ```
-pgagroal-cli -c /etc/pgagroal/pgagroal.conf stop
+pgagroal-cli -c /etc/pgagroal/pgagroal.conf shutdown
 pgagroal -c /etc/pgagroal/pgagroal.conf -a /etc/pgagroal/pgagroal_hba.conf -u /etc/pgagroal/pgagroal_users.conf -F /etc/pgagroal/pgagroal_frontend_users.conf
 ```
 

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -4011,10 +4011,10 @@ pgagroal_apply_main_configuration(struct configuration* config,
    }
    else if (key_in_section("max_connection_age", section, key, true, &unknown))
    {
-       if (as_int(value, &config->max_connection_age))
-       {
-           unknown = true;
-       }
+      if (as_int(value, &config->max_connection_age))
+      {
+         unknown = true;
+      }
    }
    else if (key_in_section("validation", section, key, true, &unknown))
    {


### PR DESCRIPTION
Now `pgagroal-cli` has a set of "logically" grouped commands and
subcommands. For example, all the commands related to shutting down
the pooler are under the `shutdown` command, that can operate with
subcommands like `gracefully`, `immediate` or `cancel`.

In order to provide this capability, two new functions have been
introduced:
- `parse_command()` accepts the command line and seek for a command,
possibly its subcommand, and an optional "value" (often the database
or server name).
- `parse_deprecated_command()` does pretty much the same thing but
against the old command. Thanks to this, old commands can still work
and the user will be warned about their deprecation, but the interface
of `pgagroal-cli` is not broken.

Both functions requires to know the offset at which start seeking for
a command, and that depends on the number of options already parsed
via `getopt_long()`. Since the `&option_index` is valued only for long
options, I decided to use the `optind` global value, see
getopt_long(3).
This value is initialized with the "next thing" to seek on the command
line, i.e., the next index on `argv`.

In the case the command accepts an optional database name, the
database value is automatically set to '*' (all databases) in case the
database name is not found on the command line.
Therefore:
   pgagroal-cli flush idle
is equivalent to
   pgagroal-cli flush idle '*'

On the other hand, commands that require a server name get the value
automatically set to "\0" (an invalid server name) in order to "block"
other pieces of code. Moroever, if the server has not been specified,
the command is automatically set to "unknown" so that the help screen
is shown.

The `pgagroal-cli` has a set of `pgagroal_log_trace()` calls whenever
a command is "parsed", so that it is possible to quickly follow the
command line parsing.

Also, since the `pgagroal-cli` exists if no command line arguments
have been specified, the safety check aboutt `argc > 0` around the
command line parsing have been removed.

In the case the user specified an unknown command, she is warned on
stdout before printing the `usage()` help screen.

Deprecated commands are notified to the user via a warning message,
printed on stderr, that provides some hints about the correct usage of
the new command.

Documentation has been updated and improved.
A specific documentation section about deprecated
commands have been introduced.

Close #253