### PR TITLE
[#292] Provide application version as a numeric value too

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,15 @@ add_compile_options(-D_GNU_SOURCE)
 add_compile_options(-Wno-deprecated)
 add_compile_options(-Wno-deprecated-declarations)
 
+#
+# version number and string representation
+# the numeric value is computed as
+#   patch + minor * 1000 + major * 10000
+#
+add_compile_options(-DPGAGROAL_VERSION="1.5.0")
+add_compile_options(-DPGAGROAL_VERSION_NUM=15000)
+
+
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")

--- a/src/admin.c
+++ b/src/admin.c
@@ -70,14 +70,14 @@ static char* generate_password(int pwd_length);
 static void
 version(void)
 {
-   printf("pgagroal-admin %s\n", VERSION);
+   printf("pgagroal-admin %s\n", PGAGROAL_VERSION);
    exit(1);
 }
 
 static void
 usage(void)
 {
-   printf("pgagroal-admin %s\n", VERSION);
+   printf("pgagroal-admin %s\n", PGAGROAL_VERSION);
    printf("  Administration utility for pgagroal\n");
    printf("\n");
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -80,14 +80,14 @@ static int reload(SSL* ssl, int socket);
 static void
 version(void)
 {
-   printf("pgagroal-cli %s\n", VERSION);
+   printf("pgagroal-cli %s\n", PGAGROAL_VERSION);
    exit(1);
 }
 
 static void
 usage(void)
 {
-   printf("pgagroal-cli %s\n", VERSION);
+   printf("pgagroal-cli %s\n", PGAGROAL_VERSION);
    printf("  Command line utility for pgagroal\n");
    printf("\n");
 

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -41,8 +41,6 @@ extern "C" {
 #include <sys/types.h>
 #include <openssl/ssl.h>
 
-#define VERSION "1.5.0"
-
 #define PGAGROAL_HOMEPAGE "https://agroal.github.io/pgagroal/"
 #define PGAGROAL_ISSUES "https://github.com/agroal/pgagroal/issues"
 

--- a/src/main.c
+++ b/src/main.c
@@ -252,14 +252,14 @@ shutdown_management(void)
 static void
 version(void)
 {
-   printf("pgagroal %s\n", VERSION);
+   printf("pgagroal %s\n", PGAGROAL_VERSION);
    exit(1);
 }
 
 static void
 usage(void)
 {
-   printf("pgagroal %s\n", VERSION);
+   printf("pgagroal %s\n", PGAGROAL_VERSION);
    printf("  High-performance connection pool for PostgreSQL\n");
    printf("\n");
 
@@ -1039,7 +1039,7 @@ read_superuser_path:
       start_management();
    }
 
-   pgagroal_log_info("pgagroal: started on %s:%d", config->host, config->port);
+   pgagroal_log_info("pgagroal: v%s started on %s:%d", PGAGROAL_VERSION, config->host, config->port);
    for (int i = 0; i < main_fds_length; i++)
    {
       pgagroal_log_debug("Socket: %d", *(main_fds + i));


### PR DESCRIPTION
This commit introduces two compile time macros:
- PGAGROAL_VERSION is a string and contains the application version
that will be shown in various application messages.
- PGAGROAL_VERSION_NUM is a numeric value that can be used to compare
the running version with another number, so for example to limit
features or messages.

`PGAGROAL_VERSION` replaces the `VERSION` macro that was defined in
the main header file.

Moreover, the message printed at level INFO when booting the pooler
has been enhanced to show also the version that is starting, like for
instance:
    pgagroal: v1.5.0 started on *:5432

See #253, #289, #290

Close #292