### PR TITLE
[#291] Make the version number comparable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,14 @@ add_compile_options(-D_GNU_SOURCE)
 add_compile_options(-Wno-deprecated)
 add_compile_options(-Wno-deprecated-declarations)
 
+#
+# version number and string management
+#
+add_compile_options(-DPGAGROAL_MAJOR_VERSION=${VERSION_MAJOR})
+add_compile_options(-DPGAGROAL_MINOR_VERSION=${VERSION_MINOR})
+add_compile_options(-DPGAGROAL_PATCH_VERSION=${VERSION_PATCH})
+add_compile_options(-DPGAGROAL_VERSION="${VERSION_STRING}")
+
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")

--- a/src/admin.c
+++ b/src/admin.c
@@ -70,14 +70,14 @@ static char* generate_password(int pwd_length);
 static void
 version(void)
 {
-   printf("pgagroal-admin %s\n", VERSION);
+   printf("pgagroal-admin %s\n", PGAGROAL_VERSION);
    exit(1);
 }
 
 static void
 usage(void)
 {
-   printf("pgagroal-admin %s\n", VERSION);
+   printf("pgagroal-admin %s\n", PGAGROAL_VERSION);
    printf("  Administration utility for pgagroal\n");
    printf("\n");
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -80,14 +80,14 @@ static int reload(SSL* ssl, int socket);
 static void
 version(void)
 {
-   printf("pgagroal-cli %s\n", VERSION);
+   printf("pgagroal-cli %s\n", PGAGROAL_VERSION);
    exit(1);
 }
 
 static void
 usage(void)
 {
-   printf("pgagroal-cli %s\n", VERSION);
+   printf("pgagroal-cli %s\n", PGAGROAL_VERSION);
    printf("  Command line utility for pgagroal\n");
    printf("\n");
 

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -41,8 +41,6 @@ extern "C" {
 #include <sys/types.h>
 #include <openssl/ssl.h>
 
-#define VERSION "1.5.0"
-
 #define PGAGROAL_HOMEPAGE "https://agroal.github.io/pgagroal/"
 #define PGAGROAL_ISSUES "https://github.com/agroal/pgagroal/issues"
 

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -287,6 +287,43 @@ pgagroal_set_proc_title(int argc, char** argv, char* s1, char* s2);
 void
 pgagroal_set_connection_proc_title(int argc, char** argv, struct connection* connection);
 
+/**
+ * Provide the application version number as a unique value composed of the three
+ * specified parts. For example, when invoked with (1,5,0) it returns 10500.
+ * Every part of the number must be between 0 and 99, and the function
+ * applies a restriction on the values. For example passing 1 or 101 as one of the part
+ * will produce the same result.
+ *
+ * @param major the major version number
+ * @param minor the minor version number
+ * @param patch the patch level
+ * @returns a number made by (patch + minor * 100 + major * 10000 )
+ */
+unsigned int
+pgagroal_version_as_number(unsigned int major, unsigned int minor, unsigned int patch);
+
+/**
+ * Provides the current version number of the application.
+ * It relies on `pgagroal_version_as_number` and invokes it with the
+ * predefined constants.
+ *
+ * @returns the current version number
+ */
+unsigned int
+pgagroal_version_number(void);
+
+/**
+ * Checks if the currently running version number is
+ * greater or equal than the specied one.
+ *
+ * @param major the major version number
+ * @param minor the minor version number
+ * @param patch the patch level
+ * @returns true if the current version is greater or equal to the specified one
+ */
+bool
+pgagroal_version_ge(unsigned int major, unsigned int minor, unsigned int patch);
+
 #ifdef DEBUG
 
 /**

--- a/src/libpgagroal/utils.c
+++ b/src/libpgagroal/utils.c
@@ -837,6 +837,35 @@ pgagroal_set_connection_proc_title(int argc, char** argv, struct connection* con
    pgagroal_set_proc_title(argc, argv, info, connection->database);
 }
 
+unsigned int
+pgagroal_version_as_number(unsigned int major, unsigned int minor, unsigned int patch)
+{
+   return (patch % 100)
+          + (minor % 100) * 100
+          + (major % 100) * 10000;
+}
+
+unsigned int
+pgagroal_version_number(void)
+{
+   return pgagroal_version_as_number(PGAGROAL_MAJOR_VERSION,
+                                     PGAGROAL_MINOR_VERSION,
+                                     PGAGROAL_PATCH_VERSION);
+}
+
+bool
+pgagroal_version_ge(unsigned int major, unsigned int minor, unsigned int patch)
+{
+   if (pgagroal_version_number() >= pgagroal_version_as_number(major, minor, patch))
+   {
+      return true;
+   }
+   else
+   {
+      return false;
+   }
+}
+
 #ifdef DEBUG
 
 int

--- a/src/main.c
+++ b/src/main.c
@@ -252,14 +252,14 @@ shutdown_management(void)
 static void
 version(void)
 {
-   printf("pgagroal %s\n", VERSION);
+   printf("pgagroal %s\n", PGAGROAL_VERSION);
    exit(1);
 }
 
 static void
 usage(void)
 {
-   printf("pgagroal %s\n", VERSION);
+   printf("pgagroal %s\n", PGAGROAL_VERSION);
    printf("  High-performance connection pool for PostgreSQL\n");
    printf("\n");
 
@@ -1039,7 +1039,10 @@ read_superuser_path:
       start_management();
    }
 
-   pgagroal_log_info("pgagroal: started on %s:%d", config->host, config->port);
+   pgagroal_log_info("pgagroal: %s started on %s:%d",
+                     PGAGROAL_VERSION,
+                     config->host,
+                     config->port);
    for (int i = 0; i < main_fds_length; i++)
    {
       pgagroal_log_debug("Socket: %d", *(main_fds + i));


### PR DESCRIPTION
Three new constants are introduced here:
- PGAGROAL_MAJOR_VERSION (number)
- PGAGROAL_MINOR_VERSION (number)
- PGAGROAL_PATCH_VERSION (number)
- PGAGROAL_VERSION       (string)

that represent, as integer literals and string composition,
the parts of the version number.
The values are copied from the variables in the `CmakeLists.txt` file
that creates the building flow, so changing the values in a single
place changes and propagates the changes all over the source code.

A few utility functions have been introduced to compose the three
constant into a unique number that can be used to compare the version
currently running, so that features and/or message can be targeted as
conditionals.

Introduced functions are:
- pgagroal_version_as_number() returns an unique sortable version
number. For example, version 1.5.0 is returned as 15000, version 1.6.2
as 16002, and so on;
- pgagroal_version_number() returns the currently running version
number, that is invokes pgagroal_version_as_number() with the
predefined constants.

The `pgagroal_version_as_number()` accepts individual values, while
`pgagroal_version_number()` provides the currently running version
number. The idea is that, thanks to both the functions, it is possible
to check for a feature that depends on a version in a way like the
following one:

   if (pgagroal_version_numer() >=
             pgagroal_version_as_number(2,1,0))
       // version is greater than 2.1.0 !

The utility function `pgagroal_version_ge()` does exactly the above:
it accepts the three parts of a version number and checks if the
currently running version is greater or equal (hence, 'ge') of the
specified triplet, so that the above piece of code becomes:

   if (pgagroal_version_ge(2,1,0))
     // version greater or equal 2.1.0

Close #292
See #253, #289, #290, #293