### PR TITLE
[#291] Shell completions for `pgagroal-cli` and `pgagroal-admin`

### DIFF
--- a/contrib/shell_comp/pgagroal_comp.bash
+++ b/contrib/shell_comp/pgagroal_comp.bash
@@ -1,0 +1,28 @@
+#/usr/bin/env bash
+
+# COMP_WORDS contains
+# at index 0 the executable name (pgagroal-cli)
+# at index 1 the command name (e.g., flush-all)
+pgagroal_cli_completions()
+{
+
+    if [ "${#COMP_WORDS[@]}" == "2" ]; then
+        # main completion: the user has specified nothing at all
+        # or a single word, that is a command
+        COMPREPLY=($(compgen -W "flush-idle flush-gracefully flush-all is-alive enable disable stop gracefully status details switch-to reload reset reset-server" "${COMP_WORDS[1]}"))
+    fi
+}
+
+
+pgagroal_admin_completions()
+{
+    if [ "${#COMP_WORDS[@]}" == "2" ]; then
+        # main completion: the user has specified nothing at all
+        # or a single word, that is a command
+        COMPREPLY=($(compgen -W "master-key add-user update user remove-user list-users" "${COMP_WORDS[1]}"))
+    fi
+}
+
+# install the completion functions
+complete -F pgagroal_cli_completions pgagroal-cli
+complete -F pgagroal_admin_completions pgagroal-admin

--- a/contrib/shell_comp/pgagroal_comp.zsh
+++ b/contrib/shell_comp/pgagroal_comp.zsh
@@ -1,0 +1,19 @@
+#compdef _pgagroal_cli pgagroal-cli
+#compdef _pgagroal_admin pgagroal-admin
+
+
+function _pgagroal_cli()
+{
+    local line
+    _arguments -C \
+               "1: :(flush-idle flush-all flush-gracefully is-alive enable disable stop gracefully status details switch-to reload reset reset-server)" \
+               "*::arg:->args"
+}
+
+function _pgagroal_admin()
+{
+    local line
+    _arguments -C \
+               "1: :(master-key add-user update user remove-user list-users)" \
+               "*::arg:->args"
+}

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -253,3 +253,9 @@ Example
 ```
 pgagroal-cli reset-server primary
 ```
+
+
+## Shell completions
+
+There is a minimal shell completion support for `pgagroal-cli`.
+Please refer to the [Install pgagroal](https://github.com/pgagroal/pgagroal/blob/main/doc/tutorial/01_install.md) tutorial for detailed information about how to enable and use shell completions.

--- a/doc/tutorial/01_install.md
+++ b/doc/tutorial/01_install.md
@@ -205,3 +205,46 @@ You will not need to specify any command line flag for files that have the stand
 - `/etc/pgagroal/pgagroal_frontend_users.conf` (split security user remapping)
 
 **In the case you named the configuration files differently or in a different folder, you need to specify them on the command line!**
+
+
+
+## Shell completion
+
+There is a minimal shell completion support for `pgagroal-cli` and `pgagroal-admin`. If you are running such commands from a Bash or Zsh, you can take some advantage of command completion.
+
+
+### Installing command completions in Bash
+
+There is a completion script into `contrib/shell_comp/pgagroal_comp.bash` that can be used
+to help you complete the command line while you are typing.
+
+It is required to source the script into your current shell, for instance
+by doing:
+
+``` shell
+source contrib/shell_comp/pgagroal_comp.bash
+```
+
+At this point, the completions should be active, so you can type the name of one the commands between `pgagroal-cli` and `pgagroal-admin` and hit `<TAB>` to help the command line completion.
+
+### Installing the command completions on Zsh
+
+In order to enable completion into `zsh` you first need to have `compinit` loaded;
+ensure your `.zshrc` file contains the following lines:
+
+``` shell
+autoload -U compinit
+compinit
+```
+
+and add the sourcing of the `contrib/shell_comp/pgagroal_comp.zsh` file into your `~/.zshrc~
+also associating the `_pgagroal_cli` function to completion by means of `compdef`:
+
+``` shell
+source contrib/shell_comp/pgagroal_comp.zsh
+compdef _pgagroal_cli    pgagroal-cli
+compdef _pgagroal_admin  pgagroal-admin
+```
+
+If you want completions only for one command, e.g., `pgagroal-admin`, remove the `compdef` line that references the command you don't want to have automatic completion.
+At this point, digit the name of a `pgagroal-cli` or `pgagroal-admin` command and hit `<TAB>` to trigger the completion system.


### PR DESCRIPTION
This commit introduces builtin shell functions to provide minimal
command line completion for `pgagroal-cli` and `pgagroal-admin`.

A new directory `contrib/shell_comp` has been added, and within that
the files `pgagroal_comp.<shell>` are placed.
In particular:
- `pgagroal_comp.bash` provides completion for the Bash shell;
- `pgagroal_comp.zsh` provides the same completion for the Zsh shell.

Documentation updated to explain how to use such completions.

Close #291