### PR TITLE
[#303] Allows for 'B' suffix in multiletter size specification.

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -40,13 +40,13 @@ See a more complete [sample](./etc/pgagroal.conf) configuration for running `pga
 | unix_socket_dir | | String | Yes | The Unix Domain Socket location |
 | metrics | 0 | Int | No | The metrics port (disable = 0) |
 | metrics_cache_max_age | 0 | String | No | The number of seconds to keep in cache a Prometheus (metrics) response. If set to zero, the caching will be disabled. Can be a string with a suffix, like `2m` to indicate 2 minutes |
-| metrics_cache_max_size | 256k | String | No | The maximum amount of data to keep in cache when serving Prometheus responses. Changes require restart. This parameter determines the size of memory allocated for the cache even if `metrics_cache_max_age` or `metrics` are disabled. Its value, however, it taken into account only if `metrics_cache_max_age` is set to a non-zero value. |
+| metrics_cache_max_size | 256k | String | No | The maximum amount of data to keep in cache when serving Prometheus responses. Changes require restart. This parameter determines the size of memory allocated for the cache even if `metrics_cache_max_age` or `metrics` are disabled. Its value, however, is taken into account only if `metrics_cache_max_age` is set to a non-zero value. Supports suffixes: 'B' (bytes), the default if omitted, 'K' or 'KB' (kilobytes), 'M' or 'MB' (megabytes), 'G' or 'GB' (gigabytes).|
 | management | 0 | Int | No | The remote management port (disable = 0) |
 | log_type | console | String | No | The logging type (console, file, syslog) |
 | log_level | info | String | No | The logging level (fatal, error, warn, info, debug, debug1 thru debug5). Debug level greater than 5 will be set to `debug5`. Not recognized values will make the log_level be `info` |
 | log_path | pgagroal.log | String | No | The log file location. Can be a strftime(3) compatible string. |
 | log_rotation_age | 0 | String | No | The age that will trigger a log file rotation. If expressed as a positive number, is managed as seconds. Supports suffixes: 'S' (seconds, the default), 'M' (minutes), 'H' (hours), 'D' (days), 'W' (weeks). A value of `0` disables. |
-| log_rotation_size | 0 | String | No | The size of the log file that will trigger a log rotation. Supports suffixes: 'B' (bytes), the default if omitted, 'K' (kilobytes), 'M' (megabytes), 'G' (gigabytes). A value of `0` disables. |
+| log_rotation_size | 0 | String | No | The size of the log file that will trigger a log rotation. Supports suffixes: 'B' (bytes), the default if omitted, 'K' or 'KB' (kilobytes), 'M' or 'MB' (megabytes), 'G' or 'GB' (gigabytes). A value of `0` (with or without suffix) disables. |
 | log_line_prefix | %Y-%m-%d %H:%M:%S | String | No | A strftime(3) compatible string to use as prefix for every log line. Must be quoted if contains spaces. |
 | log_mode | append | String | No | Append to or create the log file (append, create) |
 | log_connections | `off` | Bool | No | Log connects |

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -3054,11 +3054,14 @@ error:
  * Converts a "size string" into the number of bytes.
  *
  * Valid strings have one of the suffixes:
+ * - b for bytes (default)
  * - k for kilobytes
  * - m for megabytes
  * - g for gigabytes
  *
  * The default is expressed always as bytes.
+ * Uppercase letters work too.
+ * If no suffix is specified, the value is expressed as bytes.
  *
  * @param str the string to parse (e.g., "2M")
  * @param bytes the value to set as result of the parsing stage
@@ -3090,8 +3093,15 @@ as_bytes(char* str, unsigned int* bytes, unsigned int default_bytes)
       }
       else if (isalpha(str[i]) && multiplier_set)
       {
-         // another non-digit char not allowed
-         goto error;
+         // allow a 'B' suffix on a multiplier
+         // like for instance 'MB', but don't allow it
+         // for bytes themselves ('BB')
+         if (multiplier == 1
+             || (str[i] != 'b' && str[i] != 'B'))
+         {
+            // another non-digit char not allowed
+            goto error;
+         }
       }
       else if (isalpha(str[i]) && !multiplier_set)
       {


### PR DESCRIPTION
Allows the `as_bytes` function to parse also compound suffixes like
`MB` for megabytes.

Documentation updated.

Close #303