### PR TITLE
[#296][#297] Improve configuration error management

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -7,11 +7,16 @@ The configuration of `pgagroal` is split into sections using the `[` and `]` cha
 The main section, called `[pgagroal]`, is where you configure the overall properties
 of the connection pool.
 
-Other sections doesn't have any requirements to their naming so you can give them
+The other sections configure each one server. There can be no more than `64` server sections, therefore
+no more than `64` servers configured as backends.
+Server sections don't have any requirements to their naming so you can give them
 meaningful names like `[primary]` for the primary [PostgreSQL](https://www.postgresql.org)
 instance.
 
-All properties are in the format `key = value`.
+In any case, it is not possible to have duplicated sections, that means section names must be unique within
+the configuration file.
+
+All properties within a section are in the format `key = value`.
 
 The characters `#` and `;` can be used for comments. A line is totally ignored if the
 very first non-space character is a comment one, but it is possible to put a comment at the end of a line.
@@ -32,6 +37,9 @@ pipeline = 'performance' # no need to quote since it does not contain any spaces
 See a more complete [sample](./etc/pgagroal.conf) configuration for running `pgagroal` on `localhost`.
 
 ## [pgagroal]
+
+This section is mandatory and the pooler will refuse to start if the configuration file does not specify one and opnly one. Usually this section is place on top of the configuration file, but its position within the file does not really matter.
+The available keys and their accepted values are reported in the table below.
 
 | Property | Default | Unit | Required | Description |
 |----------|---------|------|----------|-------------|
@@ -88,6 +96,9 @@ __Danger zone__
 
 ## Server section
 
+Each section with a name different from `pgagroal` will be treated as an host section.
+There can be up to `64` host sections, each with an unique name and different combination of `host` and `port` settings, otherwise the pooler will complain about duplicated server configuration.
+
 | Property | Default | Unit | Required | Description |
 |----------|---------|------|----------|-------------|
 | host | | String | Yes | The address of the PostgreSQL instance |
@@ -122,6 +133,8 @@ host    all      all   all      all
 
 Remote management users needs to have their database set to `admin` in order for the entry to be considered.
 
+There could be up to `64` HBA entries in the configuration file.
+
 # pgagroal_databases configuration
 
 The `pgagroal_databases` configuration defines limits for a database or a user or both. The limits are the number
@@ -147,12 +160,17 @@ mydb       myuser  all
 | INITIAL_SIZE | No | Specifies the initial pool size for the entry. `all` for `MAX_SIZE` connections. Default is 0 |
 | MIN_SIZE | No | Specifies the minimum pool size for the entry. `all` for `MAX_SIZE` connections. Default is 0 |
 
+
+There can be up to `64` entries in the configuration file.
+
 # pgagroal_users configuration
 
 The `pgagroal_users` configuration defines the users known to the system. This file is created and managed through
 the `pgagroal-admin` tool.
 
 The configuration is loaded from either the path specified by the `-u` flag or `/etc/pgagroal/pgagroal_users.conf`.
+
+There can be up to `64` users known to `pgagroal`.
 
 # pgagroal_frontend_users configuration
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -262,9 +262,14 @@ main(int argc, char** argv)
    if (configuration_path != NULL)
    {
       ret = pgagroal_read_configuration(shmem, configuration_path, false);
-      if (ret)
+      if (ret == PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND)
       {
-         printf("pgagroal-cli: Configuration not found: %s\n", configuration_path);
+         printf("pgagroal-cli: Configuration not found: <%s>\n", configuration_path);
+         exit(1);
+      }
+      else if (ret == PGAGROAL_CONFIGURATION_STATUS_FILE_TOO_BIG)
+      {
+         printf("pgagroal-cli: Too many sections in the configuration file <%s>\n", configuration_path);
          exit(1);
       }
 
@@ -287,7 +292,7 @@ main(int argc, char** argv)
    else
    {
       ret = pgagroal_read_configuration(shmem, PGAGROAL_DEFAULT_CONF_FILE, false);
-      if (ret)
+      if (ret != PGAGROAL_CONFIGURATION_STATUS_OK)
       {
          if (!remote_connection)
          {

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -42,6 +42,17 @@ extern "C" {
 #define PGAGROAL_MAIN_INI_SECTION "pgagroal"
 
 /**
+ * Status that pgagroal_read_configuration() could provide.
+ * Use only negative values for errors, since a positive return
+ * value will indicate the number of problems within sections.
+ */
+#define PGAGROAL_CONFIGURATION_STATUS_OK 0
+#define PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND -1
+#define PGAGROAL_CONFIGURATION_STATUS_FILE_TOO_BIG -2
+#define PGAGROAL_CONFIGURATION_STATUS_KO -3
+#define PGAGROAL_CONFIGURATION_STATUS_CANNOT_DECRYPT -4
+
+/**
  * Initialize the configuration structure
  * @param shmem The shared memory segment
  * @return 0 upon success, otherwise 1
@@ -55,7 +66,12 @@ pgagroal_init_configuration(void* shmem);
  * @param filename The file name
  * @param emitWarnings true if unknown parameters have to
  *        reported on stderr
- * @return 0 upon success, otherwise 1
+ * @return 0 (i.e, PGAGROAL_CONFIGURATION_STATUS_OK) upon success, otherwise
+ *         - PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND if the file does not exists
+ *         - PGAGROAL_CONFIGURATION_STATUS_FILE_TOO_BIG  if the file contains too many sections
+ *         - a positive value to indicate how many errors (with regard to sections) have been found
+ *         - PGAGROAL_CONFIGURATION_STATUS_KO if the file has generic errors, most notably it lacks
+ *           a [pgagroal] section
  */
 int
 pgagroal_read_configuration(void* shmem, char* filename, bool emitWarnings);
@@ -74,7 +90,9 @@ pgagroal_validate_configuration(void* shmem, bool has_unix_socket, bool has_main
  * Read the HBA configuration from a file
  * @param shmem The shared memory segment
  * @param filename The file name
- * @return 0 upon success, otherwise 1
+ * @return 0 (i.e, PGAGROAL_CONFIGURATION_STATUS_OK) upon success, otherwise
+ *         - PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND if the file does not exists
+ *         - PGAGROAL_CONFIGURATION_STATUS_FILE_TOO_BIG  if the file contains too many entries
  */
 int
 pgagroal_read_hba_configuration(void* shmem, char* filename);
@@ -91,7 +109,9 @@ pgagroal_validate_hba_configuration(void* shmem);
  * Read the LIMIT configuration from a file
  * @param shmem The shared memory segment
  * @param filename The file name
- * @return 0 upon success, otherwise 1
+ * @return 0 (i.e, PGAGROAL_CONFIGURATION_STATUS_OK) upon success, otherwise
+ *         - PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND if the file does not exists
+ *         - PGAGROAL_CONFIGURATION_STATUS_FILE_TOO_BIG  if the file contains too many limits
  */
 int
 pgagroal_read_limit_configuration(void* shmem, char* filename);
@@ -108,7 +128,13 @@ pgagroal_validate_limit_configuration(void* shmem);
  * Read the USERS configuration from a file
  * @param shmem The shared memory segment
  * @param filename The file name
- * @return 0 upon success, otherwise 1
+ * @return 0 (i.e, PGAGROAL_CONFIGURATION_STATUS_OK) upon success, otherwise
+ *         - PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND if the file does not exists
+ *         - PGAGROAL_CONFIGURATION_STATUS_FILE_TOO_BIG  if the file contains too many users
+ *           (i.e., more users than the number defined in the limits)
+ *         - PGAGROAL_CONFIGURATION_STATUS_KO if the file has some problem (e.g., cannot be decrypted)
+ *         - PGAGROAL_CONFIGURATION_STATUS_CANNOT_DECRYPT to indicate a problem reading the content of the file
+
  */
 int
 pgagroal_read_users_configuration(void* shmem, char* filename);
@@ -125,7 +151,12 @@ pgagroal_validate_users_configuration(void* shmem);
  * Read the FRONTEND USERS configuration from a file
  * @param shmem The shared memory segment
  * @param filename The file name
- * @return 0 upon success, otherwise 1
+ * @return 0 (i.e, PGAGROAL_CONFIGURATION_STATUS_OK) upon success, otherwise
+ *         - PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND if the file does not exists
+ *         - PGAGROAL_CONFIGURATION_STATUS_FILE_TOO_BIG  if the file contains too many users
+ *           (i.e., more users than the number defined in the limits)
+ *         - PGAGROAL_CONFIGURATION_STATUS_KO if the file has some problem (e.g., cannot be decrypted)
+ *         - PGAGROAL_CONFIGURATION_STATUS_CANNOT_DECRYPT to indicate a problem reading the content of the file
  */
 int
 pgagroal_read_frontend_users_configuration(void* shmem, char* filename);
@@ -142,7 +173,12 @@ pgagroal_validate_frontend_users_configuration(void* shmem);
  * Read the ADMINS configuration from a file
  * @param shmem The shared memory segment
  * @param filename The file name
- * @return 0 upon success, otherwise 1
+ * @return 0 (i.e, PGAGROAL_CONFIGURATION_STATUS_OK) upon success, otherwise
+ *         - PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND if the file does not exists
+ *         - PGAGROAL_CONFIGURATION_STATUS_FILE_TOO_BIG  if the file contains too many users
+ *           (i.e., more users than the number defined in the limits)
+ *         - PGAGROAL_CONFIGURATION_STATUS_KO if the file has some problem (e.g., cannot be decrypted)
+ *         - PGAGROAL_CONFIGURATION_STATUS_CANNOT_DECRYPT to indicate a problem reading the content of the file
  */
 int
 pgagroal_read_admins_configuration(void* shmem, char* filename);
@@ -159,7 +195,11 @@ pgagroal_validate_admins_configuration(void* shmem);
  * Read the superuser from a file
  * @param shmem The shared memory segment
  * @param filename The file name
- * @return 0 upon success, otherwise 1
+ * @return 0 (i.e, PGAGROAL_CONFIGURATION_STATUS_OK) upon success, otherwise
+ *         - PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND if the file does not exists
+ *         - PGAGROAL_CONFIGURATION_STATUS_FILE_TOO_BIG  if the file entry is to big
+ *         - PGAGROAL_CONFIGURATION_STATUS_KO if the file has some problem (e.g., cannot be decrypted)
+ *         - PGAGROAL_CONFIGURATION_STATUS_CANNOT_DECRYPT to indicate a problem reading the content of the file
  */
 int
 pgagroal_read_superuser_configuration(void* shmem, char* filename);


### PR DESCRIPTION
This commit introduces a check for `pgagroal.conf` to avoid duplicated
sections.
A new structure, named `struct config_section` has been introduced to
handle the parsing of every section in the configuration file. The aim
of the struct is to temporarily store the line number and the name of
the section as the parsing goes on.
At the end of parsing, all the found sections are compared to see if
there are duplicates.

The function `pgagroal_read_configuration()` has been refactored so
that it returns a negative value in the case of file problem (e.g.,
file not found or too many sections within the file), or a positive
value to indicate how many duplicated sections have been found.

Several constants have been defined:
- PGAGROAL_CONFIGURATION_STATUS_FILE_TOO_BIG if the file contains
too much sections or users or entries, (e.g., for sections if it
overflows  NUMBER_OF_SERVERS + 1);
- PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND to indicate that the
file does not exists;
- PGAGROAL_CONFIGURATION_STATUS_CANNOT_DECRYPT to indicate a mastre
key problem;
- PGAGROAL_CONFIGURATION_STATUS_KO to indicate a generic error;
- PGAGROAL_CONFIGURATION_STATUS_OK to indicated everything is fine.

The `main` function has been refactored too to adapt to the new return
values and to provide better descriptive messages to the user. In
particular a new temporary variable `message` is now used to format a
coherent error message between the application output and the systemd
notification.

Documentation updated to better explain limits on the number of
sections. Also, place brief documentation to explain every
configuration file limits.

Moreover, when validating the main configuration, there is a nested
loop to check against duplicated servers, i.e., servers that have the
very same endpoint (host and port). The check relies on
`is_same_server' and therefore it has all the limitation that the
latter has, most notably it does not performs a DNS lookup, so at the
moment the usage of same servers with different hostnames cannot be
detected.
The detection of duplicated server is especially useful to allow
`switch-to` and the failover to not perform useless operations.

Since now there are constants to define the return values for
different error conditions in the configuration parsing, the `main`
and the `pgagroal-cli` have been refactored to use such return values
in a more readable and useful way.

Documentation of the functions have been updated.

Functions that read the configuration have different return values
depending on the particular error that occured. However, the error
paths are all alike, and it changes only the return value.

Since calling `free(3)` on a NULL pointer has no effect at all, it is
safe to merge all the error paths in a single one and keep track only
of the return value to emit.

This improves code readability.

Close #296.
Close #297