### PR TITLE
[#316] Use `err(3)`

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -43,6 +43,7 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <err.h>
 
 #define DEFAULT_PASSWORD_LENGTH 64
 #define MIN_PASSWORD_LENGTH 8
@@ -169,8 +170,7 @@ main(int argc, char** argv)
 
    if (getuid() == 0)
    {
-      printf("pgagroal: Using the root account is not allowed\n");
-      exit(1);
+      errx(1, "Using the root account is not allowed");
    }
 
    if (argc > 0)
@@ -200,8 +200,7 @@ main(int argc, char** argv)
       {
          if (master_key(password, generate_pwd, pwd_length))
          {
-            printf("Error for master key\n");
-            exit_code = 1;
+            errx(1, "Error for master key");
          }
       }
       else if (action == ACTION_ADD_USER)
@@ -210,14 +209,12 @@ main(int argc, char** argv)
          {
             if (add_user(file_path, username, password, generate_pwd, pwd_length))
             {
-               printf("Error for add-user\n");
-               exit_code = 1;
+               errx(1, "Error for add-user");
             }
          }
          else
          {
-            printf("Missing file argument\n");
-            exit_code = 1;
+            errx(1, "Missing file argument");
          }
       }
       else if (action == ACTION_UPDATE_USER)
@@ -226,14 +223,12 @@ main(int argc, char** argv)
          {
             if (update_user(file_path, username, password, generate_pwd, pwd_length))
             {
-               printf("Error for update-user\n");
-               exit_code = 1;
+               errx(1, "Error for update-user");
             }
          }
          else
          {
-            printf("Missing file argument\n");
-            exit_code = 1;
+            errx(1, "Missing file argument");
          }
       }
       else if (action == ACTION_REMOVE_USER)
@@ -242,14 +237,12 @@ main(int argc, char** argv)
          {
             if (remove_user(file_path, username))
             {
-               printf("Error for remove-user\n");
-               exit_code = 1;
+               errx(1, "Error for remove-user");
             }
          }
          else
          {
-            printf("Missing file argument\n");
-            exit_code = 1;
+            errx(1, "Missing file argument");
          }
       }
       else if (action == ACTION_LIST_USERS)
@@ -258,14 +251,12 @@ main(int argc, char** argv)
          {
             if (list_users(file_path))
             {
-               printf("Error for list-users\n");
-               exit_code = 1;
+               errx(1, "Error for list-users");
             }
          }
          else
          {
-            printf("Missing file argument\n");
-            exit_code = 1;
+            errx(1, "Missing file argument");
          }
       }
    }

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -48,6 +48,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <err.h>
 #ifdef HAVE_LINUX
 #include <systemd/sd-daemon.h>
 #endif
@@ -208,9 +209,9 @@ pgagroal_read_configuration(void* shm, char* filename, bool emitWarnings)
             // check we don't overflow the number of available sections
             if (idx_sections >= NUMBER_OF_SERVERS + 1)
             {
-               fprintf(stderr, "Max number of sections (%d) in configuration file <%s> reached!\n",
-                       NUMBER_OF_SERVERS + 1,
-                       filename);
+               warnx("Max number of sections (%d) in configuration file <%s> reached!",
+                     NUMBER_OF_SERVERS + 1,
+                     filename);
                return PGAGROAL_CONFIGURATION_STATUS_FILE_TOO_BIG;
             }
 
@@ -639,20 +640,20 @@ pgagroal_read_configuration(void* shm, char* filename, bool emitWarnings)
                   // otherwise it is outside of a section at all
                   if (strlen(section) > 0)
                   {
-                     fprintf(stderr, "Unknown key <%s> with value <%s> in section [%s] (line %d of file <%s>)\n",
-                             key,
-                             value,
-                             section,
-                             lineno,
-                             filename);
+                     warnx("Unknown key <%s> with value <%s> in section [%s] (line %d of file <%s>)",
+                           key,
+                           value,
+                           section,
+                           lineno,
+                           filename);
                   }
                   else
                   {
-                     fprintf(stderr, "Key <%s> with value <%s> out of any section (line %d of file <%s>)\n",
-                             key,
-                             value,
-                             lineno,
-                             filename);
+                     warnx("Key <%s> with value <%s> out of any section (line %d of file <%s>)",
+                           key,
+                           value,
+                           lineno,
+                           filename);
                   }
                }
 
@@ -677,9 +678,9 @@ pgagroal_read_configuration(void* shm, char* filename, bool emitWarnings)
    // check there is at least one main section
    if (!has_main_section)
    {
-      fprintf(stderr, "No main configuration section [%s] found in file <%s>\n",
-              PGAGROAL_MAIN_INI_SECTION,
-              filename);
+      warnx("No main configuration section [%s] found in file <%s>",
+            PGAGROAL_MAIN_INI_SECTION,
+            filename);
       return PGAGROAL_CONFIGURATION_STATUS_KO;
    }
 
@@ -699,12 +700,12 @@ pgagroal_read_configuration(void* shm, char* filename, bool emitWarnings)
          if (!strncmp(sections[i].name, sections[j].name, LINE_LENGTH))
          {
             // cannot log here ...
-            fprintf(stderr, "%s section [%s] duplicated at lines %d and %d of file <%s>\n",
-                    sections[i].main ? "Main" : "Server",
-                    sections[i].name,
-                    sections[i].lineno,
-                    sections[j].lineno,
-                    filename);
+            warnx("%s section [%s] duplicated at lines %d and %d of file <%s>",
+                  sections[i].main ? "Main" : "Server",
+                  sections[i].name,
+                  sections[i].lineno,
+                  sections[j].lineno,
+                  filename);
             return_value++;    // this is an error condition!
          }
       }


### PR DESCRIPTION
Whenever in the code there is a `printf` + `exit` or similar piece of
code, use `err(3)` functions instead.
This brings coherency, removes the need for the extra new line, the
program name and provides automatic expansion of errors when needed.

This also changes the `create_pidfile` static function so that it
terminates the current program (main) if the pid file cannot be
created. To emphasize this, the function has been renamed to
`create_pidfile_or_exit`. Also the `remove_pidfile` changed to emit a
warning if the pid file cannot be removed

Close #316