### PR TITLE
[#322] OpenBSD and FreeBSD configuration files

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -66,8 +66,8 @@ add_custom_command(
 #
 # Install configuration and documentation
 #
-install(FILES etc/pgagroal.conf DESTINATION etc/pgagroal)
-install(FILES etc/pgagroal_hba.conf DESTINATION etc/pgagroal)
+install(FILES etc/pgagroal.conf DESTINATION share/doc/pgagroal/etc)
+install(FILES etc/pgagroal_hba.conf DESTINATION share/doc/pgagroal/etc)
 
 install(DIRECTORY . DESTINATION share/doc/pgagroal FILES_MATCHING PATTERN "*.md" PATTERN "etc" EXCLUDE PATTERN "images" EXCLUDE PATTERN "man" EXCLUDE)
 install(DIRECTORY images/ DESTINATION share/doc/pgagroal/images FILES_MATCHING PATTERN "*.png")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,8 @@ else()
 
   if (${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
     add_compile_options(-DHAVE_OPENBSD)
+  elseif (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+     add_compile_options(-DHAVE_FREEBSD)
   endif()
 
   #

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -49,10 +49,10 @@ extern "C" {
 
 #define MAIN_UDS ".s.pgagroal"
 
-#ifdef HAVE_LINUX
-    #define PGAGROAL_DEFAULT_CONFIGURATION_PATH "/etc/pgagroal/"
+#ifdef HAVE_FREEBSD
+    #define PGAGROAL_DEFAULT_CONFIGURATION_PATH "/usr/local/etc/pgagroal/"
 #else
-   #define PGAGROAL_DEFAULT_CONFIGURATION_PATH "/usr/local/etc/pgagroal/"
+    #define PGAGROAL_DEFAULT_CONFIGURATION_PATH "/etc/pgagroal/"
 #endif
 
 #define PGAGROAL_DEFAULT_CONF_FILE PGAGROAL_DEFAULT_CONFIGURATION_PATH "pgagroal.conf"


### PR DESCRIPTION
Change the cmake configuration to use `/usr/local/etc` as the folder
for the configuration files only when the system detected is FreeBSD.

Also change the macros in the source header to use `/usr/local/etc`
only when FreeBSD is detected.

Last, this installs configuration files only if they are not already
present at the time of build.

Close #322