### PR TITLE
feat: support all openssl errors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ Will Leinweber <will@bitfission.com>
 Junduo Dong <andj4cn@gmail.com>
 Luca Ferrari <fluca1978@gmail.com>
 Nikita Bugrovsky <nbugrovs@redhat.com>
+Lawrence Wu <lawrence910426@gmail.com>

--- a/src/libpgagroal/message.c
+++ b/src/libpgagroal/message.c
@@ -1275,6 +1275,8 @@ ssl_read_message(SSL* ssl, int timeout, struct message** msg)
          err = SSL_get_error(ssl, numbytes);
          switch (err)
          {
+            case SSL_ERROR_NONE: 
+               break;
             case SSL_ERROR_ZERO_RETURN:
                if (timeout > 0)
                {
@@ -1369,6 +1371,8 @@ ssl_write_message(SSL* ssl, struct message* msg)
 
          switch (err)
          {
+            case SSL_ERROR_NONE: 
+               break;
             case SSL_ERROR_ZERO_RETURN:
             case SSL_ERROR_WANT_READ:
             case SSL_ERROR_WANT_WRITE:


### PR DESCRIPTION
The switch case does not contain all possible erros defined in [openssl manual](https://www.openssl.org/docs/man1.1.1/man3/SSL_get_error.html). Although ignoring `SSL_ERROR_NONE` is a clever approach and would not cause any side effects, this might be misleading to programmers from other languages.

Despite adding a new line might looks redundant, it actually enhances the readibility and maintainibility. I hope this minor change helps!