### PR TITLE
Darwin support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
     - master
 
 jobs:
-  build:
+  build-linux:
 
     runs-on: ubuntu-latest
     
@@ -46,3 +46,45 @@ jobs:
     - name: CLANG/make
       run: make
       working-directory: /home/runner/work/pgagroal/pgagroal/build/
+
+
+
+  build-macos:
+
+    runs-on: macos-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Homebrew
+      run: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+    - name: Update system
+      run: brew update
+    - name: Install openssl
+      run: brew install openssl
+    - name: Install libev
+      run: brew install libev
+    - name: Install rst2man
+      run: brew install docutils
+    - name: Install clang
+      run: brew install llvm
+    - name: GCC/mkdir
+      run: mkdir build
+      working-directory: /Users/runner/work/pgagroal/pgagroal/
+    - name: GCC/cmake
+      run: export CC=/usr/bin/gcc && export OPENSSL_ROOT_DIR=`brew --prefix openssl` && cmake -DCMAKE_BUILD_TYPE=Debug ..
+      working-directory: /Users/runner/work/pgagroal/pgagroal/build/
+    - name: GCC/make
+      run: make
+      working-directory: /Users/runner/work/pgagroal/pgagroal/build/
+    - name: rm -Rf
+      run: rm -Rf build/
+      working-directory: /Users/runner/work/pgagroal/pgagroal/
+    - name: CLANG/mkdir
+      run: mkdir build
+      working-directory: /Users/runner/work/pgagroal/pgagroal/
+    - name: CLANG/cmake
+      run: export CC=/usr/bin/clang && export OPENSSL_ROOT_DIR=`brew --prefix openssl` && cmake -DCMAKE_BUILD_TYPE=Debug ..
+      working-directory: /Users/runner/work/pgagroal/pgagroal/build/
+    - name: CLANG/make
+      run: make
+      working-directory: /Users/runner/work/pgagroal/pgagroal/build/

--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Junduo Dong <andj4cn@gmail.com>
 Luca Ferrari <fluca1978@gmail.com>
 Nikita Bugrovsky <nbugrovs@redhat.com>
 Lawrence Wu <lawrence910426@gmail.com>
+Yongting You <2010youy01@gmail.com>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ message(STATUS "pgagroal ${VERSION_STRING}")
 
 include(CheckCCompilerFlag)
 include(CheckCSourceCompiles)
+include(CheckLinkerFlag)
 include(FindPackageHandleStandardArgs)
 include(GNUInstallDirs)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,48 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   )
 
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+  find_program(HOMEBREW_EXECUTABLE brew)
+  if(EXISTS ${HOMEBREW_EXECUTABLE})
+    execute_process(
+      COMMAND ${HOMEBREW_EXECUTABLE} --prefix
+      OUTPUT_VARIABLE HOMEBREW_PREFIX
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    message(STATUS "Homebrew found at ${HOMEBREW_PREFIX}")
+  endif()
 
+  #
+  # Detecting OpenSSL
+  #
+  execute_process(
+    COMMAND ${HOMEBREW_EXECUTABLE} --prefix openssl
+    OUTPUT_VARIABLE HOMEBREW_OPENSSL
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(DEFINED HOMEBREW_OPENSSL)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${HOMEBREW_OPENSSL}/include")
+  else()
+    message(FATAL_ERROR "Homebrew's OpenSSL needed")
+  endif()
+
+  add_compile_options(-D_DARWIN_C_SOURCE)
+  add_compile_options(-DHAVE_OSX)
+
+  #
+  # Include directories
+  #
+  include_directories(
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${LIBEV_INCLUDE_DIRS}
+    ${OPENSSL_INCLUDE_DIRS}
+  )
+
+  #
+  # Library directories
+  #
+  link_libraries(
+    ${LIBEV_LIBRARIES}
+    ${OPENSSL_LIBRARIES}
+  )
 else()
 
   add_compile_options(-D_XOPEN_SOURCE=700)
@@ -137,14 +178,15 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
     endif()
   endif()
 
-  check_c_compiler_flag(-Wl,-z,relro HAS_RELRO)
-  if (HAS_RELRO)
+  check_c_compiler_flag(-Wl,arg HAS_LINKER)
+  check_linker_flag(C "-z relro" LINKER_HAS_RELRO)
+  if (HAS_LINKER AND LINKER_HAS_RELRO)
     set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,relro")
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,relro")
   endif()
 
-  check_c_compiler_flag(-Wl,-z,now HAS_NOW)
-  if (HAS_NOW)
+  check_linker_flag(C "-z now" LINKER_HAS_NOW)
+  if (HAS_LINKER AND LINKER_HAS_NOW)
     set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,now")
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,now")
   endif()
@@ -199,14 +241,15 @@ if (CMAKE_BUILD_TYPE MATCHES Release OR CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
     endif()
   endif()
 
-  check_c_compiler_flag(-Wl,-z,relro HAS_RELRO)
-  if (HAS_RELRO)
+  check_c_compiler_flag(-Wl,arg HAS_LINKER)
+  check_linker_flag(C "-z relro" LINKER_HAS_RELRO)
+  if (HAS_LINKER AND HAS_RELRO)
     set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,relro")
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,relro")
   endif()
 
-  check_c_compiler_flag(-Wl,-z,now HAS_NOW)
-  if (HAS_NOW)
+  check_linker_flag(C "-z now" LINKER_HAS_NOW)
+  if (HAS_LINKER AND LINKER_HAS_NOW)
     set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,now")
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,now")
   endif()

--- a/src/libpgagroal/utils.c
+++ b/src/libpgagroal/utils.c
@@ -54,7 +54,7 @@
 #endif
 
 extern char** environ;
-#ifdef HAVE_LINUX
+#if defined(HAVE_LINUX) || defined(HAVE_OSX)
 static bool env_changed = false;
 static int max_process_title_size = 0;
 #endif
@@ -719,7 +719,7 @@ error:
 void
 pgagroal_set_proc_title(int argc, char** argv, char* s1, char* s2)
 {
-#ifdef HAVE_LINUX
+#if defined(HAVE_LINUX) || defined(HAVE_OSX)
    char title[MAX_PROCESS_TITLE_LENGTH];
    size_t size;
    char** env = environ;

--- a/src/main.c
+++ b/src/main.c
@@ -841,9 +841,9 @@ read_superuser_path:
 #ifdef HAVE_LINUX
       sd_notifyf(0,
                  "STATUS=max_connections is larger than the file descriptor limit (%ld available)",
-                 flimit.rlim_cur - 30);
+                 (long)(flimit.rlim_cur - 30));
 #endif
-      errx(1, "max_connections is larger than the file descriptor limit (%ld available)", flimit.rlim_cur - 30);
+      errx(1, "max_connections is larger than the file descriptor limit (%ld available)", (long)(flimit.rlim_cur - 30));
    }
 
    if (daemon)


### PR DESCRIPTION
For issue https://github.com/agroal/pgagroal/issues/325
This is an awesome project! I (and possibly other contributors) would like to do development on MacOS X, so I'm trying to make it build on MacOS X.
This patch is currently separated into small commits for review, and will be squashed later if it's possible to merge.

## Commits
### [Fix linker in cmake.](https://github.com/agroal/pgagroal/commit/f6257afee85d8fb8ca81f0319fd0288c6433a29e)
The semantics of `check_c_compiler_flag(-Wl,-z,relro HAS_RELRO)` is to check if you pass `-Wl -z relro` to the compiler and if it will throw an error, the compiler will simply pass it to the linker and didn't actually check if linker will throw an error for `-z relro` option.  e.g. I tested `check_c_compiler_flag(-Wl,random,var FOO)` and `FOO` is set to true, so the current implementation might have false positive and make the project's cmake fail on MacOS X. Detail also discussed at https://github.com/agroal/pgagroal/issues/325#issuecomment-1470825193
### [find OpenSSL and headers on Darwin](https://github.com/agroal/pgagroal/commit/6e8744d3ab9d9d1dcb3d337a00dfc3fd3b57468e)
Setup include path for OpenSSL otherwise `openssl/ssl.h` can't be found when compiling.
Defined `_DARWIN_C_SOURCE` to locate system headers
Fixed `pgagroal_set_proc_title` under MacOS X, I tested it using `ps`, and works fine.
### [fix rlim_t type print issue.](https://github.com/agroal/pgagroal/commit/d7f7e8ac877496bb695ab49237bdef12681b3889)
`rlim_t` type seems might be either 4 bytes or 8 bytes on different architectures, and its 8 byte size in MacOS X caused problem.
```
 error: format specifies type 'long' but the argument has type 'unsigned long long' [-Werror,-Wformat]
      errx(1, "max_connections is larger than the file descriptor limit (%ld available)", flimit.rlim_cur - 30);
                                                                         ~~~              ^~~~~~~~~~~~~~~~~~~~
                                                                         %llu
```
 Check size at compile time seems hard to do, and since pgagroal is currently deployed ok and might be only used for development under MacOS X, here just simply did type casting to fix the error.
### [Darwin CI setup and formatting.](https://github.com/agroal/pgagroal/commit/8a11fc5f6988e69892de47e3905f5f960d19c317)
CI, AUTHOR file, and several formatting issues caught by [uncrustify.sh](https://github.com/agroal/pgagroal/blob/master/uncrustify.sh)

## Testing
Deployed on local machine `Darwin Kernel Version 19.6.0`, run several simple queries through `pgagroal` proxy, and tested the concurrent connection using `pgbench`, no error reported.