### PR TITLE
enh: use `calloc(3)` instead of `malloc(3)` and `memset(3)`

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -916,8 +916,12 @@ generate_password(int pwd_length)
 
    s = pwd_length + 1;
 
-   pwd = malloc(s);
-   memset(pwd, 0, s);
+   pwd = calloc(1, s);
+   if(pwd == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while generating password");
+      return NULL;
+   }
 
    srand((unsigned)time(&t));
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -845,8 +845,10 @@ config_get(SSL* ssl, int socket, char* config_key, bool verbose)
    }
    else
    {
-      buffer = malloc(MISC_LENGTH);
-      memset(buffer, 0, MISC_LENGTH);
+      buffer = calloc(1, MISC_LENGTH);
+      if(buffer == NULL){
+         goto error;
+      }
       if (pgagroal_management_read_config_get(socket, &buffer))
       {
          free(buffer);

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -2050,8 +2050,11 @@ extract_key_value(char* str, char** key, char** value)
 
    if (c < length)
    {
-      k = malloc(c + 1);
-      memset(k, 0, c + 1);
+      k = calloc(1, c + 1);
+      if (k == NULL)
+      {
+         goto error;
+      }
       memcpy(k, str, c);
       *key = k;
 
@@ -2105,8 +2108,11 @@ extract_key_value(char* str, char** key, char** value)
 
       if (c <= length)
       {
-         v = malloc((c - offset) + 1);
-         memset(v, 0, (c - offset) + 1);
+         v = calloc(1, (c - offset) + 1);
+         if (v == NULL)
+         {
+            goto error;
+         }
          memcpy(v, str + offset, (c - offset));
          *value = v;
          return 0;
@@ -2202,8 +2208,11 @@ as_logging_level(char* str)
       if (strlen(str) > strlen("debug"))
       {
          size = strlen(str) - strlen("debug");
-         debug_value = (char*)malloc(size + 1);
-         memset(debug_value, 0, size + 1);
+         debug_value = (char*)calloc(1, size + 1);
+         if (debug_value == NULL)
+         {
+            return PGAGROAL_LOGGING_LEVEL_FATAL;
+         }
          memcpy(debug_value, str + 5, size);
          if (as_int(debug_value, &debug_level))
          {
@@ -2501,8 +2510,11 @@ extract_value(char* str, int offset, char** value)
       {
          to = offset;
 
-         v = malloc(to - from + 1);
-         memset(v, 0, to - from + 1);
+         v = calloc(1, to - from + 1);
+         if (v == NULL)
+         {
+            return -1;
+         }
          memcpy(v, str + from, to - from);
          *value = v;
 
@@ -2628,7 +2640,6 @@ transfer_configuration(struct configuration* config, struct configuration* reloa
    // does make sense to check for remote connections? Because in the case the Unix socket dir
    // changes the pgagroal-cli probably will not be able to connect in any case!
    restart_string("unix_socket_dir", config->unix_socket_dir, reload->unix_socket_dir, false);
-
 
    /* su_connection */
 

--- a/src/libpgagroal/logging.c
+++ b/src/libpgagroal/logging.c
@@ -402,7 +402,9 @@ retry:
          atomic_store(&config->log_lock, STATE_FREE);
       }
       else
-        SLEEP_AND_GOTO(1000000L,retry)
+      {
+         SLEEP_AND_GOTO(1000000L, retry)
+      }
    }
 }
 
@@ -488,6 +490,8 @@ retry:
          atomic_store(&config->log_lock, STATE_FREE);
       }
       else
-        SLEEP_AND_GOTO(1000000L,retry)
+      {
+         SLEEP_AND_GOTO(1000000L, retry)
+      }
    }
 }

--- a/src/libpgagroal/management.c
+++ b/src/libpgagroal/management.c
@@ -108,8 +108,11 @@ pgagroal_management_read_payload(int socket, signed char id, int* payload_i, cha
          iov[0].iov_base = &buf2[0];
          iov[0].iov_len = sizeof(buf2);
 
-         cmptr = malloc(CMSG_SPACE(sizeof(int)));
-         memset(cmptr, 0, CMSG_SPACE(sizeof(int)));
+         cmptr = calloc(1, CMSG_SPACE(sizeof(int)));
+         if (cmptr == NULL)
+         {
+            goto error;
+         }
          cmptr->cmsg_len = CMSG_LEN(sizeof(int));
          cmptr->cmsg_level = SOL_SOCKET;
          cmptr->cmsg_type = SCM_RIGHTS;
@@ -148,8 +151,11 @@ pgagroal_management_read_payload(int socket, signed char id, int* payload_i, cha
          }
          size = pgagroal_read_int32(&buf4);
 
-         s = malloc(size + 1);
-         memset(s, 0, size + 1);
+         s = calloc(1, size + 1);
+         if (s == NULL)
+         {
+            goto error;
+         }
          if (read_complete(NULL, socket, s, size))
          {
             goto error;
@@ -174,8 +180,11 @@ pgagroal_management_read_payload(int socket, signed char id, int* payload_i, cha
          }
          *payload_i = pgagroal_read_int32(&buf4);
 
-         s = malloc(*payload_i + 1);
-         memset(s, 0, *payload_i + 1);
+         s = calloc(1, *payload_i + 1);
+         if (s == NULL)
+         {
+            goto error;
+         }
          if (read_complete(NULL, socket, s, *payload_i))
          {
             goto error;
@@ -184,8 +193,11 @@ pgagroal_management_read_payload(int socket, signed char id, int* payload_i, cha
          break;
       case MANAGEMENT_RESET_SERVER:
       case MANAGEMENT_SWITCH_TO:
-         s = malloc(MISC_LENGTH);
-         memset(s, 0, MISC_LENGTH);
+         s = calloc(1, MISC_LENGTH);
+         if (s == NULL)
+         {
+            goto error;
+         }
          if (read_complete(NULL, socket, s, MISC_LENGTH))
          {
             goto error;
@@ -250,8 +262,12 @@ pgagroal_management_transfer_connection(int32_t slot)
    iov[0].iov_base = &buf2[0];
    iov[0].iov_len = sizeof(buf2);
 
-   cmptr = malloc(CMSG_SPACE(sizeof(int)));
-   memset(cmptr, 0, CMSG_SPACE(sizeof(int)));
+   cmptr = calloc(1, CMSG_SPACE(sizeof(int)));
+   if (cmptr == NULL)
+   {
+      goto error;
+   }
+
    cmptr->cmsg_level = SOL_SOCKET;
    cmptr->cmsg_type = SCM_RIGHTS;
    cmptr->cmsg_len = CMSG_LEN(sizeof(int));

--- a/src/libpgagroal/memory.c
+++ b/src/libpgagroal/memory.c
@@ -71,20 +71,17 @@ pgagroal_memory_size(size_t size)
 {
    pgagroal_memory_destroy();
 
-   message = (struct message*)malloc(sizeof(struct message));
+   message = (struct message*)calloc(1, sizeof(struct message));
    if (message == NULL)
    {
       goto error;
    }
 
-   data = malloc(size);
+   data = calloc(1, size);
    if (data == NULL)
    {
       goto error;
    }
-
-   memset(message, 0, sizeof(struct message));
-   memset(data, 0, size);
 
    message->kind = 0;
    message->length = 0;

--- a/src/libpgagroal/message.c
+++ b/src/libpgagroal/message.c
@@ -111,7 +111,18 @@ pgagroal_create_message(void* data, ssize_t length, struct message** msg)
    struct message* copy = NULL;
 
    copy = (struct message*)malloc(sizeof(struct message));
+   if (copy == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating message");
+      return MESSAGE_STATUS_ERROR;
+   }
    copy->data = malloc(length);
+   if (copy->data == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating message");
+      free(copy);
+      return MESSAGE_STATUS_ERROR;
+   }
 
    copy->kind = pgagroal_read_byte(data);
    copy->length = length;
@@ -140,7 +151,19 @@ pgagroal_copy_message(struct message* msg)
 #endif
 
    copy = (struct message*)malloc(sizeof(struct message));
+   if (copy == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while copying message");
+      return NULL;
+   }
+
    copy->data = malloc(msg->length);
+   if (copy->data == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while copying message");
+      free(copy);
+      return NULL;
+   }
 
    copy->kind = msg->kind;
    copy->length = msg->length;
@@ -714,9 +737,18 @@ pgagroal_create_auth_password_response(char* password, struct message** msg)
    size = 6 + strlen(password);
 
    m = (struct message*)malloc(sizeof(struct message));
-   m->data = malloc(size);
-
-   memset(m->data, 0, size);
+   if (m == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating auth_password_response");
+      return MESSAGE_STATUS_ERROR;
+   }
+   m->data = calloc(1, size);
+   if (m->data == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating auth_password_response");
+      free(m);
+      return MESSAGE_STATUS_ERROR;
+   }
 
    m->kind = 'p';
    m->length = size;
@@ -768,9 +800,18 @@ pgagroal_create_auth_md5_response(char* md5, struct message** msg)
    size = 1 + 4 + strlen(md5) + 1;
 
    m = (struct message*)malloc(sizeof(struct message));
-   m->data = malloc(size);
-
-   memset(m->data, 0, size);
+   if (m == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating auth_md5_response");
+      return MESSAGE_STATUS_ERROR;
+   }
+   m->data = calloc(1, size);
+   if (m->data == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating auth_md5_response");
+      free(m);
+      return MESSAGE_STATUS_ERROR;
+   }
 
    m->kind = 'p';
    m->length = size;
@@ -819,9 +860,18 @@ pgagroal_create_auth_scram256_response(char* nounce, struct message** msg)
    size = 1 + 4 + 13 + 4 + 9 + strlen(nounce);
 
    m = (struct message*)malloc(sizeof(struct message));
-   m->data = malloc(size);
-
-   memset(m->data, 0, size);
+   if (m == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating auth_scram256_response");
+      return MESSAGE_STATUS_ERROR;
+   }
+   m->data = calloc(1, size);
+   if (m->data == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating auth_scram256_response");
+      free(m);
+      return MESSAGE_STATUS_ERROR;
+   }
 
    m->kind = 'p';
    m->length = size;
@@ -846,9 +896,19 @@ pgagroal_create_auth_scram256_continue(char* cn, char* sn, char* salt, struct me
    size = 1 + 4 + 4 + 2 + strlen(cn) + strlen(sn) + 3 + strlen(salt) + 7;
 
    m = (struct message*)malloc(sizeof(struct message));
-   m->data = malloc(size);
+   if (m == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating auth_scram256_continue");
+      return MESSAGE_STATUS_ERROR;
+   }
+   m->data = calloc(1, size);
 
-   memset(m->data, 0, size);
+   if (m->data == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating auth_scram256_continue");
+      free(m);
+      return MESSAGE_STATUS_ERROR;
+   }
 
    m->kind = 'R';
    m->length = size;
@@ -877,9 +937,19 @@ pgagroal_create_auth_scram256_continue_response(char* wp, char* p, struct messag
    size = 1 + 4 + strlen(wp) + 3 + strlen(p);
 
    m = (struct message*)malloc(sizeof(struct message));
-   m->data = malloc(size);
+   if (m == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating auth_scram256_continue_response");
+      return MESSAGE_STATUS_ERROR;
+   }
 
-   memset(m->data, 0, size);
+   m->data = calloc(1, size);
+   if (m->data == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating auth_scram256_continue_response");
+      free(m);
+      return MESSAGE_STATUS_ERROR;
+   }
 
    m->kind = 'p';
    m->length = size;
@@ -904,9 +974,18 @@ pgagroal_create_auth_scram256_final(char* ss, struct message** msg)
    size = 1 + 4 + 4 + 2 + strlen(ss);
 
    m = (struct message*)malloc(sizeof(struct message));
-   m->data = malloc(size);
-
-   memset(m->data, 0, size);
+   if (m == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating auth_scram256_final");
+      return MESSAGE_STATUS_ERROR;
+   }
+   m->data = calloc(1, size);
+   if (m->data == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating auth_scram256_final");
+      free(m);
+      return MESSAGE_STATUS_ERROR;
+   }
 
    m->kind = 'R';
    m->length = size;
@@ -956,9 +1035,18 @@ pgagroal_create_ssl_message(struct message** msg)
    size = 8;
 
    m = (struct message*)malloc(sizeof(struct message));
-   m->data = malloc(size);
-
-   memset(m->data, 0, size);
+   if (m == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating ssl_message");
+      return MESSAGE_STATUS_ERROR;
+   }
+   m->data = calloc(1, size);
+   if (m->data == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating ssl_message");
+      free(m);
+      return MESSAGE_STATUS_ERROR;
+   }
 
    m->kind = 0;
    m->length = size;
@@ -984,9 +1072,18 @@ pgagroal_create_startup_message(char* username, char* database, struct message**
    size = 4 + 4 + 4 + 1 + us + 1 + 8 + 1 + ds + 1 + 17 + 9 + 1;
 
    m = (struct message*)malloc(sizeof(struct message));
-   m->data = malloc(size);
-
-   memset(m->data, 0, size);
+   if (m == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating startup_message");
+      return MESSAGE_STATUS_ERROR;
+   }
+   m->data = calloc(1, size);
+   if (m->data == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating startup_message");
+      free(m);
+      return MESSAGE_STATUS_ERROR;
+   }
 
    m->kind = 0;
    m->length = size;
@@ -1014,9 +1111,18 @@ pgagroal_create_cancel_request_message(int pid, int secret, struct message** msg
    size = 16;
 
    m = (struct message*)malloc(sizeof(struct message));
-   m->data = malloc(size);
-
-   memset(m->data, 0, size);
+   if (m == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating cancel_request_message");
+      return MESSAGE_STATUS_ERROR;
+   }
+   m->data = calloc(1, size);
+   if (m == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating cancel_request_message");
+      free(m);
+      return MESSAGE_STATUS_ERROR;
+   }
 
    m->kind = 0;
    m->length = size;
@@ -1275,7 +1381,7 @@ ssl_read_message(SSL* ssl, int timeout, struct message** msg)
          err = SSL_get_error(ssl, numbytes);
          switch (err)
          {
-            case SSL_ERROR_NONE: 
+            case SSL_ERROR_NONE:
                break;
             case SSL_ERROR_ZERO_RETURN:
                if (timeout > 0)
@@ -1371,7 +1477,7 @@ ssl_write_message(SSL* ssl, struct message* msg)
 
          switch (err)
          {
-            case SSL_ERROR_NONE: 
+            case SSL_ERROR_NONE:
                break;
             case SSL_ERROR_ZERO_RETURN:
             case SSL_ERROR_WANT_READ:

--- a/src/libpgagroal/network.c
+++ b/src/libpgagroal/network.c
@@ -570,8 +570,12 @@ bind_host(const char* hostname, int port, int** fds, int* length)
    index = 0;
    size = 0;
 
-   sport = malloc(5);
-   memset(sport, 0, 5);
+   sport = calloc(1, 5);
+   if (sport == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while binding host");
+      return 1;
+   }
    sprintf(sport, "%d", port);
 
    /* Find all SOCK_STREAM addresses */
@@ -594,8 +598,12 @@ bind_host(const char* hostname, int port, int** fds, int* length)
       size++;
    }
 
-   result = malloc(size * sizeof(int));
-   memset(result, 0, size * sizeof(int));
+   result = calloc(1, size * sizeof(int));
+   if (sport == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while binding host");
+      return 1;
+   }
 
    /* Loop through all the results and bind to the first we can */
    for (addr = servinfo; addr != NULL; addr = addr->ai_next)

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -330,8 +330,10 @@ retry2:
             }
          }
          else
-            /* Sleep for 1000 nanos */
-            SLEEP_AND_GOTO(1000L,start)
+         /* Sleep for 1000 nanos */
+         {
+            SLEEP_AND_GOTO(1000L, start)
+         }
 
       }
    }

--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -2066,8 +2066,12 @@ send_chunk(int client_fd, char* data)
 
    memset(&msg, 0, sizeof(struct message));
 
-   m = malloc(20);
-   memset(m, 0, 20);
+   m = calloc(1, 20);
+   if (m == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while binding host");
+      return MESSAGE_STATUS_ERROR;
+   }
 
    sprintf(m, "%lX\r\n", strlen(data));
 

--- a/src/libpgagroal/utils.c
+++ b/src/libpgagroal/utils.c
@@ -108,8 +108,7 @@ pgagroal_extract_username_database(struct message* msg, char** username, char** 
       end++;
       if (c == 0)
       {
-         array[counter] = (char*)malloc(end - start);
-         memset(array[counter], 0, end - start);
+         array[counter] = (char*)calloc(1, end - start);
          memcpy(array[counter], msg->data + start, end - start);
 
          start = end;
@@ -122,8 +121,7 @@ pgagroal_extract_username_database(struct message* msg, char** username, char** 
       if (!strcmp(array[i], "user"))
       {
          size = strlen(array[i + 1]) + 1;
-         un = malloc(size);
-         memset(un, 0, size);
+         un = calloc(1, size);
          memcpy(un, array[i + 1], size);
 
          *username = un;
@@ -131,8 +129,7 @@ pgagroal_extract_username_database(struct message* msg, char** username, char** 
       else if (!strcmp(array[i], "database"))
       {
          size = strlen(array[i + 1]) + 1;
-         db = malloc(size);
-         memset(db, 0, size);
+         db = calloc(1, size);
          memcpy(db, array[i + 1], size);
 
          *database = db;
@@ -140,8 +137,7 @@ pgagroal_extract_username_database(struct message* msg, char** username, char** 
       else if (!strcmp(array[i], "application_name"))
       {
          size = strlen(array[i + 1]) + 1;
-         an = malloc(size);
-         memset(an, 0, size);
+         an = calloc(1, size);
          memcpy(an, array[i + 1], size);
 
          *appname = an;
@@ -230,8 +226,7 @@ pgagroal_extract_error_message(struct message* msg, char** error)
 
          if (type == 'M')
          {
-            result = (char*)malloc(strlen(s) + 1);
-            memset(result, 0, strlen(s) + 1);
+            result = (char*)calloc(1, strlen(s) + 1);
             memcpy(result, s, strlen(s));
 
             *error = result;
@@ -616,8 +611,7 @@ pgagroal_get_password(void)
 
    tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
 
-   result = malloc(strlen(p) + 1);
-   memset(result, 0, strlen(p) + 1);
+   result = calloc(1, strlen(p) + 1);
 
    memcpy(result, &p, strlen(p));
 
@@ -653,8 +647,7 @@ pgagroal_base64_encode(char* raw, int raw_length, char** encoded)
    BUF_MEM_grow(mem_bio_mem_ptr, (*mem_bio_mem_ptr).length + 1);
    (*mem_bio_mem_ptr).data[(*mem_bio_mem_ptr).length] = '\0';
 
-   r = malloc(strlen((*mem_bio_mem_ptr).data) + 1);
-   memset(r, 0, strlen((*mem_bio_mem_ptr).data) + 1);
+   r = calloc(1, strlen((*mem_bio_mem_ptr).data) + 1);
    memcpy(r, (*mem_bio_mem_ptr).data, strlen((*mem_bio_mem_ptr).data));
 
    BUF_MEM_free(mem_bio_mem_ptr);
@@ -685,8 +678,7 @@ pgagroal_base64_decode(char* encoded, size_t encoded_length, char** raw, int* ra
    }
 
    size = (encoded_length * 3) / 4 + 1;
-   decoded = malloc(size);
-   memset(decoded, 0, size);
+   decoded = calloc(1, size);
 
    b64_bio = BIO_new(BIO_f_base64());
    mem_bio = BIO_new(BIO_s_mem());
@@ -751,14 +743,12 @@ pgagroal_set_proc_title(int argc, char** argv, char* s1, char* s2)
       for (int i = 0; env[i] != NULL; i++)
       {
          size = strlen(env[i]);
-         environ[i] = (char*)malloc(size + 1);
+         environ[i] = (char*)calloc(1, size + 1);
 
          if (environ[i] == NULL)
          {
             return;
          }
-
-         memset(environ[i], 0, size + 1);
          memcpy(environ[i], env[i], size);
       }
       environ[es] = NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -1293,8 +1293,11 @@ accept_main_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
    }
    else
    {
-      char* addr = malloc(strlen(address) + 1);
-      memset(addr, 0, strlen(address) + 1);
+      char* addr = calloc(1, strlen(address) + 1);
+      if(addr == NULL){
+         pgagroal_log_fatal("Cannot allocate memory for client address");
+         return;
+      }
       memcpy(addr, address, strlen(address));
 
       ev_loop_fork(loop);
@@ -1695,8 +1698,11 @@ accept_management_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
 
    if (!fork())
    {
-      char* addr = malloc(strlen(address) + 1);
-      memset(addr, 0, strlen(address) + 1);
+      char* addr = calloc(1, strlen(address) + 1);
+      if(addr == NULL){
+         pgagroal_log_fatal("Couldn't allocate address");
+         return;
+      }
       memcpy(addr, address, strlen(address));
 
       ev_loop_fork(loop);


### PR DESCRIPTION
This PR solves https://github.com/agroal/pgagroal/issues/312 and #190 
`calloc(3)` documentation: https://linux.die.net/man/3/calloc