### PR TITLE
[#356] A better way of handling limit inconsistencies

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -150,6 +150,7 @@ The configuration is loaded from either the path specified by the `-l` flag or `
 # DATABASE USER    MAX_SIZE INITIAL_SIZE MIN_SIZE
 #
 mydb       myuser  all
+anotherdb  userB   10           5       3
 ```
 
 | Column | Required | Description |
@@ -162,6 +163,8 @@ mydb       myuser  all
 
 
 There can be up to `64` entries in the configuration file.
+
+In the case a limit entry has incoherent values, for example `initial_size` smaller than `min_size`, the system will try to automatically adjust the settings on the fly, reporting messages in the logs.
 
 # pgagroal_users configuration
 

--- a/doc/tutorial/02_prefill.md
+++ b/doc/tutorial/02_prefill.md
@@ -42,6 +42,7 @@ an initial connection size of 1 and a minimum connection size of 0 for the `myus
 
 The file must be owned by the operating system user `pgagroal`.
 
+The `max_size` value is mandatory, while the `initial_size` and `min_size` are optional and if not explicitly set are assumed to be `0`.
 See [the `pgagroal_databases.conf` file documentation](https://github.com/agroal/pgagroal/blob/master/doc/CONFIGURATION.md#pgagroal_databases-configuration) for more details.
 
 ## Restart pgagroal


### PR DESCRIPTION
This commit uniforms the code handling misconfigurations of limit entries into the database file.
The `max`size` is the only mandatory argument in the entry, so it drives all the others.
Now `extract_limit()` sets to zero `initial_size` and `min_size` if not specified.
When validating the limit entries, the system checks if the optional arguments have inconsistencies and, only at that point, adjusts either `min_size` or `initial_size` according to the `max_size` (that is left unchanged).
The system now clearly reports in the logs the problems, so that the user can either accept the adjustment or understand when and what the problem is.
As an example, given the following configuration:

```
$ cat /etc/pgagroal/pgagroal_databases.conf
...
pgbench pgbench 2 1  1  # ok
pgbench pgbench 5 7 1   # out of range
pgbench pgbench 7 2 9   # out of range
pgbench pgbench 5       # ok
pgbench pgbench 7 0 4   # ok
pgbench pgbench 7 0 14  # max < min
```

The logs will report:

```
WARN  configuration.c:1341 initial_size greater than max_size for limit entry 2 (/etc/pgagroal/pgagroal_databases.conf:12)
INFO  configuration.c:1344 adjusting initial_size from 7 to 5 (max_size) for limit entry 2 (/etc/pgagroal/pgagroal_databases.conf:12)
WARN  configuration.c:1332 initial_size smaller than min_size for limit entry 3 (/etc/pgagroal/pgagroal_databases.conf:13)
INFO  configuration.c:1335 adjusting initial_size from 2 to 9 (min_size) for limit entry 3 (/etc/pgagroal/pgagroal_databases.conf:13)
WARN  configuration.c:1341 initial_size greater than max_size for limit entry 3 (/etc/pgagroal/pgagroal_databases.conf:13)
INFO  configuration.c:1344 adjusting initial_size from 9 to 7 (max_size) for limit entry 3 (/etc/pgagroal/pgagroal_databases.conf:13)
WARN  configuration.c:1350 max_size smaller than min_size for limit entry 3 (/etc/pgagroal/pgagroal_databases.conf:13)
INFO  configuration.c:1353 adjusting min_size from 9 to 7 (max_size) for limit entry 3 (/etc/pgagroal/pgagroal_databases.conf:13)
WARN  configuration.c:1350 max_size smaller than min_size for limit entry 6 (/etc/pgagroal/pgagroal_databases.conf:16)
INFO  configuration.c:1353 adjusting min_size from 14 to 7 (max_size)
for limit entry 6 (/etc/pgagroal/pgagroal_databases.conf:16)
```

Every adjusted entry is reported twice: one at WARN log level to indicate the problem, and one at INFO level to indicate the action that `pgagroal` took.

The documentation has been updated to clearly indicate that the optional values are automatically set to zero and that the system could change the settings on the fly.

Close #356