### PR TITLE
[#355] Add line number field in various configuration structs

### DIFF
--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -237,6 +237,7 @@ struct server
    int port;               /**< The port of the server */
    bool tls;               /**< Use TLS if possible */
    atomic_schar state;     /**< The state of the server */
+   int lineno;             /**< The line number within the configuration file */
 } __attribute__ ((aligned (64)));
 
 /** @struct
@@ -275,6 +276,7 @@ struct hba
    char username[MAX_USERNAME_LENGTH]; /**< The user name */
    char address[MAX_ADDRESS_LENGTH];   /**< The address / mask */
    char method[MAX_ADDRESS_LENGTH];    /**< The access method */
+   int lineno;                        /**< The line number within the configuration file */
 } __attribute__ ((aligned (64)));
 
 /** @struct


### PR DESCRIPTION
Added a `lineno` field into structures `struct hba` and `struct server`.
This simplifies error reporting, since it is now possible to drive the user to the line number that is causing a problem.

Thanks to this, it is possible to provide better messages to the users about misconfigurations.
For example, if the user mispells an entry into the HBA file:

```
FATAL configuration.c:1162 Unknown HBA type: HOSTSS (/etc/pgagroal/pgagroal_hba.conf:7)
```

Changes to a few log/warn messages to become more easy to read.

Close #355