### PR TITLE
[#382] Remove extra line in deprecated command warning.

### DIFF
--- a/src/libpgagroal/utils.c
+++ b/src/libpgagroal/utils.c
@@ -1061,7 +1061,7 @@ parse_deprecated_command(int argc,
    if (deprecated_by
        && pgagroal_version_ge(deprecated_since_major, deprecated_since_minor, 0))
    {
-      warnx("command <%s> has been deprecated by <%s> since version %d.%d\n",
+      warnx("command <%s> has been deprecated by <%s> since version %d.%d",
             command, deprecated_by, deprecated_since_major, deprecated_since_minor);
    }
 


### PR DESCRIPTION
Removes an extra new line at the end of a warning message about a deprecated command.

Close #382