### PR TITLE
[#386] Help screen in `pgagroal-cli` has dots on newlines

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -133,9 +133,9 @@ usage(void)
    printf("                           The subcommand <action> can be:\n");
    printf("                           - 'reload' to issue a configuration reload;\n");
    printf("                           - 'get' to obtain information about a runtime configuration value;\n");
-   printf("                                   conf get <parameter_name>\n.");
+   printf("                                   conf get <parameter_name>\n");
    printf("                           - 'set' to modify a configuration value;\n");
-   printf("                                   conf set <parameter_name> <parameter_value>\n.");
+   printf("                                   conf set <parameter_name> <parameter_value>\n");
    printf("  clear <what>             Resets either the Prometheus statistics or the specified server.\n");
    printf("                           <what> can be\n");
    printf("                           - 'server' (default) followed by a server name\n");


### PR DESCRIPTION
There were a couple of dots after a "\n" in the help screen. Removed the dots, since they can be confused in the output with the command argument.

Close #386