### PR TITLE
[#388] Add `conf ls` to get the configuration file locations

### DIFF
--- a/contrib/shell_comp/pgagroal_comp.bash
+++ b/contrib/shell_comp/pgagroal_comp.bash
@@ -25,7 +25,7 @@ pgagroal_cli_completions()
                 COMPREPLY+=($(compgen -W "server prometheus" "${COMP_WORDS[2]}"))
                 ;;
 	    conf)
-		COMPREPLY+=($(compgen -W "reload get set" "${COMP_WORDS[2]}"))
+		COMPREPLY+=($(compgen -W "reload get set ls" "${COMP_WORDS[2]}"))
 		;;
 	    status)
 		COMPREPLY+=($(compgen -W "details" "${COMP_WORDS[2]}"))

--- a/contrib/shell_comp/pgagroal_comp.zsh
+++ b/contrib/shell_comp/pgagroal_comp.zsh
@@ -40,7 +40,7 @@ function _pgagroal_cli_conf()
 {
     local line
     _arguments -C \
-               "1: :(reload get set)" \
+               "1: :(reload get set ls)" \
                "*::arg:->args"
 }
 

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -184,7 +184,8 @@ Manages the configuration of the running instance.
 This command requires one subcommand, that can be:
 - `reload` issue a reload of the configuration, applying at runtime any changes from the configuration files;
 - `get` provides a configuration parameter value;
-- `set` modifies a configuration parameter at runtime.
+- `set` modifies a configuration parameter at runtime;
+- `ls` prints where the configuration files are located.
 
 Command
 
@@ -205,7 +206,7 @@ pgagroal-cli conf set max_connections 25
 
 The details about how to get and set values at run-time are explained in the following.
 
-### conf get
+#### conf get
 Given a configuration setting name, provides the current value for such setting.
 
 The configuration setting name must be the same as the one used in the configuration files.
@@ -256,7 +257,7 @@ If the parameter name specified is not found or invalid, the program `pgagroal-c
 
 
 
-### conf set
+#### conf set
 Allows the setting of a configuration parameter at run-time, if possible.
 
 Examples
@@ -303,7 +304,20 @@ WARN  1 settings cannot be applied
 DEBUG pgagroal_management_write_config_set: unable to apply changes to <max_connections> -> <100>
 ```
 
+#### conf ls
 
+The command `conf ls` provides information about the location of the configuration files.
+As an example:
+
+```
+Main Configuration file:   /etc/pgagroal/pgagroal.conf
+HBA file:                  /etc/pgagroal/pgagroal_hba.conf
+Limit file:                /etc/pgagroal/pgagroal_databases.conf
+Frontend users file:       /etc/pgagroal/pgagroal_frontend_users.conf
+Admins file:               /etc/pgagroal/pgagroal_admins.conf
+Superuser file:
+Users file:                /etc/pgagroal/pgagroal_users.conf
+```
 
 ### clear
 Resets different parts of the pooler. It accepts an operational mode:

--- a/src/include/management.h
+++ b/src/include/management.h
@@ -61,6 +61,7 @@ extern "C" {
 #define MANAGEMENT_REMOVE_FD          19
 #define MANAGEMENT_CONFIG_GET         20
 #define MANAGEMENT_CONFIG_SET         21
+#define MANAGEMENT_CONFIG_LS          22
 
 /**
  * Read the management header
@@ -385,6 +386,60 @@ pgagroal_management_config_set(SSL* ssl, int socket, char* config_key, char* con
  */
 int
 pgagroal_management_write_config_set(int socket, char* config_key, char* config_value);
+
+/**
+ * Entry point for managing the `conf ls` command that
+ * will list all the configuration files used by the running
+ * daemon.
+ *
+ * @param ssl the SSL handler
+ * @param fd the socket file descriptor
+ * @returns 0 on success
+ */
+int
+pgagroal_management_conf_ls(SSL* ssl, int fd);
+
+/**
+ * Reads out of the socket the list of configuration
+ * files and prints them out to the standard output.
+ *
+ * The order of the read paths is:
+ * - configuration path
+ * - HBA path
+ * - limit path
+ * - frontend users path
+ * - admins path
+ * - Superusers path
+ * - users path
+ *
+ * @param socket the file descriptor of the open socket
+ * @param ssl the SSL handler
+ * @returns 0 on success
+ */
+int
+pgagroal_management_read_conf_ls(SSL* ssl, int socket);
+
+/**
+ * The management function responsible for sending
+ * the configuration paths into the socket.
+ *
+ * The function sends every path following the path length,
+ * that must be limited to MAX_PATH size.
+ *
+ * The order of the sent paths is:
+ * - configuration path
+ * - HBA path
+ * - limit path
+ * - frontend users path
+ * - admins path
+ * - Superusers path
+ * - users path
+ *
+ * @params socket the file descriptor of the open socket
+ * @returns 0 on success
+ */
+int
+pgagroal_management_write_conf_ls(int socket);
 
 #ifdef __cplusplus
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1496,6 +1496,10 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
          pgagroal_log_debug("pgagroal: Management isalive");
          pgagroal_management_write_isalive(client_fd, config->gracefully);
          break;
+      case MANAGEMENT_CONFIG_LS:
+         pgagroal_log_debug("pgagroal: Management conf ls");
+         pgagroal_management_write_conf_ls(client_fd);
+         break;
       case MANAGEMENT_RESET:
          pgagroal_log_debug("pgagroal: Management reset");
          pgagroal_prometheus_reset();


### PR DESCRIPTION
Introducing the command `conf ls` to `pgagroal-cli` that prints out where the configuration files are located.
A new management key, action and three new management methods have been added to implement the logic.
The idea is that, once the action is required, the management prints on the socket every single `struct configuration*` path variables, and then the management read method reads back in the same order to the same list of values to be printed on the output screen.

In order to achieve this, two new static functions have been added to the managemenet in order to write and read from the socket a single path. A path is written with a size and the following path, assuming it will never be larger than MAX_PATH or an error will be thrown. In the case a path is NULL or empty, an empty string will be written on the socket and so the final result is that the entry will be printed as empty in the command output.

Documentation updated.

Shell completions updated.

Fixes also a few log_trace in the cli application.

Close #388