### PR TITLE
[#385][#390] JSON command output implementation for `pgagroal-cli`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       run: sudo apt update -y
     - name: Install libev
       run: sudo apt install -y libev4 libev-dev
+    - name: Install cJSON
+      run: sudo apt install -y libcjson1 libcjson-dev
     - name: Install systemd
       run: sudo apt install -y libsystemd-dev
     - name: Install rst2man
@@ -63,6 +65,8 @@ jobs:
       run: brew install openssl
     - name: Install libev
       run: brew install libev
+    - name: Install cJSON
+      run: brew install cjson
     - name: Install rst2man
       run: brew install docutils
     - name: Install clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,16 @@ else ()
   message(FATAL_ERROR "rst2man needed")
 endif()
 
+# search for cJSON library
+# <https://github.com/DaveGamble/cJSON>
+find_package(cJSON)
+if (cJSON_FOUND)
+  message(STATUS "cJSON found version ${CJSON_VERSION}")
+else ()
+  message(FATAL_ERROR "cJSON needed")
+endif()
+
+
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   find_package(Libatomic)
   if (LIBATOMIC_FOUND)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ See [Architecture](./doc/ARCHITECTURE.md) for the architecture of `pgagroal`.
 * [systemd](https://www.freedesktop.org/wiki/Software/systemd/)
 * [rst2man](https://docutils.sourceforge.io/)
 * [libatomic](https://gcc.gnu.org/wiki/Atomic)
+* [cJSON](https://github.com/DaveGamble/cJSON)
 
 On Rocky Linux (and similar) operating systems, the dependencies
 can be installed via `dnf(8)` as follows:
@@ -79,7 +80,8 @@ dnf install git gcc cmake make    \
             openssl openssl-devel \
 	    systemd systemd-devel \
 	    python3-docutils      \
-	    libatomic
+	    libatomic             \
+	    cjson cjson-devel
 ```
 
 Please note that, on Rocky Linux, in order to install the `python3-docutils`

--- a/cmake/FindcJSON.cmake
+++ b/cmake/FindcJSON.cmake
@@ -1,0 +1,51 @@
+# FindcJSON.cmake
+# Tries to find cJSON libraries on the system
+# (e.g., on Rocky Linux: cjson and cjson-devel)
+#
+# Inspired by <https://sources.debian.org/src/monado/21.0.0~dfsg1-1/cmake/FindcJSON.cmake/>
+#
+# If cJSON is found, sets the following variables:
+# - CJSON_INCLUDE_DIRS
+# - CJSON_LIBRARIES
+# - CJSON_VERSION
+#
+# In the header file cJSON.h the library version is specified as:
+# #define CJSON_VERSION_MAJOR 1
+# #define CJSON_VERSION_MINOR 7
+# #define CJSON_VERSION_PATCH 14
+
+
+find_path(
+    CJSON_INCLUDE_DIR
+    NAMES cjson/cJSON.h
+    PATH_SUFFIXES include)
+find_library(
+    CJSON_LIBRARY
+    NAMES cjson
+    PATH_SUFFIXES lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(cJSON REQUIRED_VARS CJSON_INCLUDE_DIR
+                                                      CJSON_LIBRARY)
+if(CJSON_FOUND)
+  # these variables are needed for the build
+  set( CJSON_INCLUDE_DIRS "${CJSON_INCLUDE_DIR}" )
+  set( CJSON_LIBRARIES    "${CJSON_LIBRARY}"     )
+
+  # try to get out the library version from the headers
+  file(STRINGS "${CJSON_INCLUDE_DIR}/cjson/cJSON.h"
+    CJSON_VERSION_MAJOR REGEX "^#define[ \t]+CJSON_VERSION_MAJOR[ \t]+[0-9]+")
+  file(STRINGS "${CJSON_INCLUDE_DIR}/cjson/cJSON.h"
+    CJSON_VERSION_MINOR REGEX "^#define[ \t]+CJSON_VERSION_MINOR[ \t]+[0-9]+")
+    file(STRINGS "${CJSON_INCLUDE_DIR}/cjson/cJSON.h"
+    CJSON_VERSION_PATCH REGEX "^#define[ \t]+CJSON_VERSION_PATCH[ \t]+[0-9]+")
+  string(REGEX REPLACE "[^0-9]+" "" CJSON_VERSION_MAJOR "${CJSON_VERSION_MAJOR}")
+  string(REGEX REPLACE "[^0-9]+" "" CJSON_VERSION_MINOR "${CJSON_VERSION_MINOR}")
+  string(REGEX REPLACE "[^0-9]+" "" CJSON_VERSION_PATCH "${CJSON_VERSION_PATCH}")
+  set(CJSON_VERSION "${CJSON_VERSION_MAJOR}.${CJSON_VERSION_MINOR}.${CJSON_VERSION_PATCH}")
+  unset(CJSON_VERSION_MINOR)
+  unset(CJSON_VERSION_MAJOR)
+  unset(CJSON_VERSION_PATCH)
+endif()
+
+mark_as_advanced( CJSON_INCLUDE_DIR CJSON_LIBRARY )  

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     ${LIBEV_INCLUDE_DIRS}
     ${OPENSSL_INCLUDE_DIR}
     ${SYSTEMD_INCLUDE_DIRS}
+    ${CJSON_INCLUDE_DIRS}
   )
 
   #
@@ -33,6 +34,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     ${OPENSSL_SSL_LIBRARY}
     ${SYSTEMD_LIBRARIES}
     ${LIBATOMIC_LIBRARY}
+    ${CJSON_LIBRARIES}
   )
 
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
@@ -69,6 +71,7 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${LIBEV_INCLUDE_DIRS}
     ${OPENSSL_INCLUDE_DIRS}
+    ${CJSON_INCLUDE_DIRS}
   )
 
   #
@@ -77,6 +80,7 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
   link_libraries(
     ${LIBEV_LIBRARIES}
     ${OPENSSL_LIBRARIES}
+    ${CJSON_LIBRARIES}
   )
 else()
 
@@ -98,6 +102,7 @@ else()
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${LIBEV_INCLUDE_DIRS}
     ${OPENSSL_INCLUDE_DIRS}
+    ${CJSON_INCLUDE_DIRS}
   )
 
   #
@@ -106,6 +111,7 @@ else()
   link_libraries(
     ${LIBEV_LIBRARIES}
     ${OPENSSL_LIBRARIES}
+    ${CJSON_LIBRARIES}
   )
 endif()
 
@@ -314,3 +320,4 @@ endif()
 target_link_libraries(pgagroal-admin-bin pgagroal)
 
 install(TARGETS pgagroal-admin-bin DESTINATION ${CMAKE_INSTALL_BINDIR})
+

--- a/src/include/json.h
+++ b/src/include/json.h
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2024 The pgagroal community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* pgagroal */
+#include <pgagroal.h>
+
+#include <cjson/cJSON.h>
+
+/**
+ * JSON related command tags, used to build and retrieve
+ * a JSON piece of information related to a single command
+ */
+#define JSON_TAG_COMMAND "command"
+#define JSON_TAG_COMMAND_NAME "name"
+#define JSON_TAG_COMMAND_STATUS "status"
+#define JSON_TAG_COMMAND_ERROR "error"
+#define JSON_TAG_COMMAND_OUTPUT "output"
+#define JSON_TAG_COMMAND_EXIT_STATUS "exit-status"
+
+#define JSON_TAG_APPLICATION_NAME "name"
+#define JSON_TAG_APPLICATION_VERSION_MAJOR "major"
+#define JSON_TAG_APPLICATION_VERSION_MINOR "minor"
+#define JSON_TAG_APPLICATION_VERSION_PATCH "patch"
+#define JSON_TAG_APPLICATION_VERSION "version"
+
+#define JSON_TAG_ARRAY_NAME "list"
+
+/**
+ * JSON pre-defined values
+ */
+#define JSON_STRING_SUCCESS "OK"
+#define JSON_STRING_ERROR   "KO"
+#define JSON_BOOL_SUCCESS   0
+#define JSON_BOOL_ERROR     1
+
+/**
+ * Utility method to create a new JSON object that wraps a
+ * single command. This method should be called to initialize the
+ * object and then the other specific methods that read the
+ * answer from pgagroal should populate the object accordingly.
+ *
+ * Moreover, an 'application' object is placed to indicate from
+ * where the command has been launched (i.e., which executable)
+ * and at which version.
+ *
+ * @param command_name the name of the command this object wraps
+ * an answer for
+ * @param success true if the command is supposed to be succesfull
+ * @returns the new JSON object to use and populate
+ * @param executable_name the name of the executable that is creating this
+ * response object
+ */
+cJSON*
+pgagroal_json_create_new_command_object(char* command_name, bool success, char* executable_name);
+
+/**
+ * Utility method to "jump" to the output JSON object wrapped into
+ * a command object.
+ *
+ * The "output" object is the one that every single method that reads
+ * back an answer from pgagroal has to populate in a specific
+ * way according to the data received from pgagroal.
+ *
+ * @param json the command object that wraps the command
+ * @returns the pointer to the output object of NULL in case of an error
+ */
+cJSON*
+pgagroal_json_extract_command_output_object(cJSON* json);
+
+/**
+ * Utility function to set a command JSON object as faulty, that
+ * means setting the 'error' and 'status' message accordingly.
+ *
+ * @param json the whole json object that must include the 'command'
+ * tag
+ * @param message the message to use to set the faulty diagnostic
+ * indication
+ *
+ * @param exit status
+ *
+ * @returns 0 on success
+ *
+ * Example:
+ * json_set_command_object_faulty( json, strerror( errno ) );
+ */
+int
+pgagroal_json_set_command_object_faulty(cJSON* json, char* message, int exit_status);
+
+/**
+ * Utility method to inspect if a JSON object that wraps a command
+ * is faulty, that means if it has the error flag set to true.
+ *
+ * @param json the json object to analyzer
+ * @returns the value of the error flag in the object, or false if
+ * the object is not valid
+ */
+bool
+pgagroal_json_is_command_object_faulty(cJSON* json);
+
+/**
+ * Utility method to extract the message related to the status
+ * of the command wrapped in the JSON object.
+ *
+ * @param json the JSON object to analyze
+ * #returns the status message or NULL in case the JSON object is not valid
+ */
+const char*
+pgagroal_json_get_command_object_status(cJSON* json);
+
+/**
+ * Utility method to check if a JSON object wraps a specific command name.
+ *
+ * @param json the JSON object to analyze
+ * @param command_name the name to search for
+ * @returns true if the command name matches, false otherwise and in case
+ * the JSON object is not valid or the command name is not valid
+ */
+bool
+pgagroal_json_is_command_name_equals_to(cJSON* json, char* command_name);
+
+/**
+ * Utility method to print out the JSON object
+ * on standard output.
+ *
+ * After the object has been printed, it is destroyed, so
+ * calling this method will make the pointer invalid
+ * and the jeon object cannot be used anymore.
+ *
+ * This should be the last method to be called
+ * when there is the need to print out the information
+ * contained in a json object.
+ *
+ * @param json the json object to print
+ */
+void
+pgagroal_json_print_and_free_json_object(cJSON* json);
+
+/**
+ * Utility function to get the exit status of a given command wrapped in a JSON object.
+ *
+ * @param json the json object
+ * @returns the exit status of the command
+ */
+int
+pgagroal_json_command_object_exit_status(cJSON* json);

--- a/src/include/management.h
+++ b/src/include/management.h
@@ -64,6 +64,18 @@ extern "C" {
 #define MANAGEMENT_CONFIG_LS          22
 
 /**
+ * Status for the 'ping' (i.e., is-alive) command
+ */
+#define PING_STATUS_RUNNING 1
+#define PING_STATUS_SHUTDOWN_GRACEFULLY 2
+
+/**
+ * Available command output formats
+ */
+#define COMMAND_OUTPUT_FORMAT_TEXT 'T'
+#define COMMAND_OUTPUT_FORMAT_JSON 'J'
+
+/**
  * Read the management header
  * @param socket The socket descriptor
  * @param id The resulting management identifier
@@ -179,10 +191,11 @@ pgagroal_management_status(SSL* ssl, int socket);
 /**
  * Management: Read status
  * @param socket The socket
+ * @param output_format a char describing the type of output (text or json)
  * @return 0 upon success, otherwise 1
  */
 int
-pgagroal_management_read_status(SSL* ssl, int socket);
+pgagroal_management_read_status(SSL* ssl, int socket, char output_format);
 
 /**
  * Management: Write status
@@ -205,10 +218,11 @@ pgagroal_management_details(SSL* ssl, int socket);
 /**
  * Management: Read details
  * @param socket The socket
+ * @param output_format the output format for this command (text, json)
  * @return 0 upon success, otherwise 1
  */
 int
-pgagroal_management_read_details(SSL* ssl, int socket);
+pgagroal_management_read_details(SSL* ssl, int socket, char output_format);
 
 /**
  * Management: Write details
@@ -233,7 +247,7 @@ pgagroal_management_isalive(SSL* ssl, int socket);
  * @return 0 upon success, otherwise 1
  */
 int
-pgagroal_management_read_isalive(SSL* ssl, int socket, int* status);
+pgagroal_management_read_isalive(SSL* ssl, int socket, int* status, char output_format);
 
 /**
  * Management: Write isalive
@@ -332,10 +346,14 @@ pgagroal_management_config_get(SSL* ssl, int socket, char* config_key);
  * @see pgagroal_management_read_payload
  *
  * @param ssl the socket file descriptor
+ * @param config_key the key to read (is used only to print in the output)
+ * @param verbose verbosity flag
+ * @param output_format the output format
+ * @param expected_value if set, a value that the configuration should match
  * @return 0 on success
  */
 int
-pgagroal_management_read_config_get(int socket, char** data);
+pgagroal_management_read_config_get(int socket, char* config_key, char* expected_value, bool verbose, char output_format);
 
 /**
  * Management operation: write the result of a config_get action on the socket.
@@ -414,10 +432,11 @@ pgagroal_management_conf_ls(SSL* ssl, int fd);
  *
  * @param socket the file descriptor of the open socket
  * @param ssl the SSL handler
+ * @param output_format the format to output the command result
  * @returns 0 on success
  */
 int
-pgagroal_management_read_conf_ls(SSL* ssl, int socket);
+pgagroal_management_read_conf_ls(SSL* ssl, int socket, char output_format);
 
 /**
  * The management function responsible for sending

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -494,6 +494,20 @@ parse_deprecated_command(int argc,
                          char* deprecated_by,
                          unsigned int deprecated_since_major,
                          unsigned int deprecated_since_minor);
+
+/**
+ * Given a server state, it returns a string that
+ * described the state in a human-readable form.
+ *
+ * If the state cannot be determined, the numeric
+ * form of the state is returned as a string.
+ *
+ * @param state the value of the sate for the server
+ * @returns the string representing the state
+ */
+char*
+pgagroal_server_state_as_string(signed char state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libpgagroal/json.c
+++ b/src/libpgagroal/json.c
@@ -1,0 +1,268 @@
+/*
+ * Copyright (C) 2024 The pgagroal community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* pgagroal */
+#include <pgagroal.h>
+#include <json.h>
+
+cJSON*
+pgagroal_json_create_new_command_object(char* command_name, bool success, char* executable_name)
+{
+   // root of the JSON structure
+   cJSON* json = cJSON_CreateObject();
+
+   if (!json)
+   {
+      goto error;
+   }
+
+   // the command structure
+   cJSON* command = cJSON_CreateObject();
+   if (!command)
+   {
+      goto error;
+   }
+
+   // insert meta-data about the command
+   cJSON_AddStringToObject(command, JSON_TAG_COMMAND_NAME, command_name);
+   cJSON_AddStringToObject(command, JSON_TAG_COMMAND_STATUS, success ? JSON_STRING_SUCCESS : JSON_STRING_ERROR);
+   cJSON_AddNumberToObject(command, JSON_TAG_COMMAND_ERROR, success ? JSON_BOOL_SUCCESS : JSON_BOOL_ERROR);
+   cJSON_AddNumberToObject(command, JSON_TAG_COMMAND_EXIT_STATUS, success ? 0 : EXIT_STATUS_DATA_ERROR);
+
+   // the output of the command, this has to be filled by the caller
+   cJSON* output = cJSON_CreateObject();
+   if (!output)
+   {
+      goto error;
+   }
+
+   cJSON_AddItemToObject(command, JSON_TAG_COMMAND_OUTPUT, output);
+
+   // who has launched the command ?
+   cJSON* application = cJSON_CreateObject();
+   if (!application)
+   {
+      goto error;
+   }
+
+   cJSON_AddStringToObject(application, JSON_TAG_APPLICATION_NAME, executable_name);
+   cJSON_AddNumberToObject(application, JSON_TAG_APPLICATION_VERSION_MAJOR, PGAGROAL_MAJOR_VERSION);
+   cJSON_AddNumberToObject(application, JSON_TAG_APPLICATION_VERSION_MINOR, PGAGROAL_MINOR_VERSION);
+   cJSON_AddNumberToObject(application, JSON_TAG_APPLICATION_VERSION_PATCH, PGAGROAL_PATCH_VERSION);
+   cJSON_AddStringToObject(application, JSON_TAG_APPLICATION_VERSION, PGAGROAL_VERSION);
+
+   // add objects to the whole json thing
+   cJSON_AddItemToObject(json, "command", command);
+   cJSON_AddItemToObject(json, "application", application);
+
+   return json;
+
+error:
+   if (json)
+   {
+      cJSON_Delete(json);
+   }
+
+   return NULL;
+
+}
+
+cJSON*
+pgagroal_json_extract_command_output_object(cJSON* json)
+{
+   cJSON* command = cJSON_GetObjectItemCaseSensitive(json, JSON_TAG_COMMAND);
+   if (!command)
+   {
+      goto error;
+   }
+
+   return cJSON_GetObjectItemCaseSensitive(command, JSON_TAG_COMMAND_OUTPUT);
+
+error:
+   return NULL;
+
+}
+
+bool
+pgagroal_json_is_command_name_equals_to(cJSON* json, char* command_name)
+{
+   if (!json || !command_name || strlen(command_name) <= 0)
+   {
+      goto error;
+   }
+
+   cJSON* command = cJSON_GetObjectItemCaseSensitive(json, JSON_TAG_COMMAND);
+   if (!command)
+   {
+      goto error;
+   }
+
+   cJSON* cName = cJSON_GetObjectItemCaseSensitive(command, JSON_TAG_COMMAND_NAME);
+   if (!cName || !cJSON_IsString(cName) || !cName->valuestring)
+   {
+      goto error;
+   }
+
+   return !strncmp(command_name,
+                   cName->valuestring,
+                   MISC_LENGTH);
+
+error:
+   return false;
+}
+
+int
+pgagroal_json_set_command_object_faulty(cJSON* json, char* message, int exit_status)
+{
+   if (!json)
+   {
+      goto error;
+   }
+
+   cJSON* command = cJSON_GetObjectItemCaseSensitive(json, JSON_TAG_COMMAND);
+   if (!command)
+   {
+      goto error;
+   }
+
+   cJSON* current = cJSON_GetObjectItemCaseSensitive(command, JSON_TAG_COMMAND_STATUS);
+   if (!current)
+   {
+      goto error;
+   }
+
+   cJSON_SetValuestring(current, message);
+
+   current = cJSON_GetObjectItemCaseSensitive(command, JSON_TAG_COMMAND_ERROR);
+   if (!current)
+   {
+      goto error;
+   }
+
+   cJSON_SetIntValue(current, JSON_BOOL_ERROR);   // cannot use cJSON_SetBoolValue unless cJSON >= 1.7.16
+
+   current = cJSON_GetObjectItemCaseSensitive(command, JSON_TAG_COMMAND_EXIT_STATUS);
+   if (!current)
+   {
+      goto error;
+   }
+
+   cJSON_SetIntValue(current, exit_status);
+
+   return 0;
+
+error:
+   return 1;
+
+}
+
+bool
+pgagroal_json_is_command_object_faulty(cJSON* json)
+{
+   if (!json)
+   {
+      goto error;
+   }
+
+   cJSON* command = cJSON_GetObjectItemCaseSensitive(json, JSON_TAG_COMMAND);
+   if (!command)
+   {
+      goto error;
+   }
+
+   cJSON* status = cJSON_GetObjectItemCaseSensitive(command, JSON_TAG_COMMAND_ERROR);
+   if (!status || !cJSON_IsNumber(status))
+   {
+      goto error;
+   }
+
+   return status->valueint == JSON_BOOL_SUCCESS ? false : true;
+
+error:
+   return false;
+
+}
+
+int
+pgagroal_json_command_object_exit_status(cJSON* json)
+{
+   if (!json)
+   {
+      goto error;
+   }
+
+   cJSON* command = cJSON_GetObjectItemCaseSensitive(json, JSON_TAG_COMMAND);
+   if (!command)
+   {
+      goto error;
+   }
+
+   cJSON* status = cJSON_GetObjectItemCaseSensitive(command, JSON_TAG_COMMAND_EXIT_STATUS);
+   if (!status || !cJSON_IsNumber(status))
+   {
+      goto error;
+   }
+
+   return status->valueint;
+
+error:
+   return EXIT_STATUS_DATA_ERROR;
+}
+
+const char*
+pgagroal_json_get_command_object_status(cJSON* json)
+{
+   if (!json)
+   {
+      goto error;
+   }
+
+   cJSON* command = cJSON_GetObjectItemCaseSensitive(json, JSON_TAG_COMMAND);
+   if (!command)
+   {
+      goto error;
+   }
+
+   cJSON* status = cJSON_GetObjectItemCaseSensitive(command, JSON_TAG_COMMAND_STATUS);
+   if (!cJSON_IsString(status) || (status->valuestring == NULL))
+   {
+      goto error;
+   }
+
+   return status->valuestring;
+error:
+   return NULL;
+
+}
+
+void
+pgagroal_json_print_and_free_json_object(cJSON* json)
+{
+   printf("%s\n", cJSON_Print(json));
+   cJSON_Delete(json);
+}

--- a/src/libpgagroal/utils.c
+++ b/src/libpgagroal/utils.c
@@ -1077,3 +1077,34 @@ parse_command_simple(int argc,
 {
    return parse_command(argc, argv, offset, command, subcommand, NULL, NULL, NULL, NULL);
 }
+
+/**
+ * Given a server state, it returns a string that
+ * described the state in a human-readable form.
+ *
+ * If the state cannot be determined, the numeric
+ * form of the state is returned as a string.
+ *
+ * @param state the value of the sate for the server
+ * @returns the string representing the state
+ */
+char*
+pgagroal_server_state_as_string(signed char state)
+{
+   char* buf;
+
+   switch (state)
+   {
+      case SERVER_NOTINIT:  return "Not init";
+      case SERVER_NOTINIT_PRIMARY: return "Not init (primary)";
+      case SERVER_PRIMARY: return "Primary";
+      case SERVER_REPLICA: return "Replica";
+      case SERVER_FAILOVER: return "Failover";
+      case SERVER_FAILED: return "Failed";
+      default:
+         buf = malloc(5);
+         memset(buf, 0, 5);
+         snprintf(buf, 5, "%d", state);
+         return buf;
+   }
+}


### PR DESCRIPTION
This commit introduces the capaiblity for `pgagroal-cli` to print out the command results in a JSON format.

A new dependency on the library 'cJSON' has been introduced; see <https://github.com/DaveGamble/cJSON>.

A new set of functions, named 'json_xxx' have been added in a separated file json.c (include file json.h) to handle JSON structures in a more consistent way.

Each function that manipulates a JSON object has been named with the 'json_' prefix. Each management function that reads data out of the protocol and creates or handles json data has been named with the prefix 'pgagroal_management_json_'.
A few functions with a prefix name 'pgagroal_management_json_print' are used to print out a JSON object as normal text.

Every command output, in the JSON format, is structured with a 'command' is the main object contained in the output, that in turns has different attributes:
- 'output' is an object that contains the command specific information (e.g., list of databases, messages, and so on);
- `error` a boolean that indicates if the command was in error or not;
- `status` a string that contains either 'OK' or an error message in the case the `error` flag is set;
- `exit-status` an integer value with the exit status of the command, 0 in case of success, a different value in case of failure.

The JSON object for a result includes also another object, named 'application', that can be used for introspection: such object describes which executable has launched the command (so far, only `pgagroal-cli`) and at which version.

In the 'output' object, every thing that has a list (e.g., connections, limits, databases, servers) will be wrapped into an object with the attributes 'list' and 'count': the former contains the details of every "thing", while the latter contains the count (i.e., the size of the array 'list' ).
Whenever possible, a 'state' string is placed to indicate the state of the single entry.

The command `status` and `status details` have been unified on the management side.
There is a single function that handles both the cases of reading the answer for the `status` or the `status details` commands. This has been done because `status details` includes the output of `status`. The function `pgagroal_management_json_read_status_details` is in charge of getting the answer of the management protocol (i.e., read the socket) and invoke the printing function in the case the output is of type text. The above `pgagroal_management_json_read_status_details` returns always a JSON object, that can be converted back to the text output via `pgagroal_management_json_print_status_details`. In this way, the output between the JSON and the text formats are always coherent for these commands.

The `ping` (i.e., `is-alive`) command does not print nothing by default. In the JSON version it provides the numerical status of the server and a string that represents a human-readable status.

The `conf get` command has been refactored to be symmetric with other commands: the logic to print out the result is now within the management function (pgagroal_management_read_config_get) as per other commands. The JSON provides the `config-key` and the `config-value` as strings. See #390

The `conf set` command has been refactored similarly to `conf get` in order to have all the logic to print out the information into the management read method (see #390).
The exit status provided by the command is now
the result of the matching within the JSON object of the expected configuration value and the requested configuration value.

The `conf ls` command has been refactored to produce a JSON object when reading data out of the management socket. Such JSON object is then printed as normal text if required.

A new utility function, named 'pgagroal_server_status_as_string' has been added to the utils.c stuff. The idea is to have a consistent way to translate the numerical status representation into an human readable string.

The text output format of commands has slightly changed due to the refactoring of some internal methods.

Documentation updated.

Close #385
Close #390