### PR TITLE
[#396] List `libatomic` on the requirements list

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,29 @@ See [Architecture](./doc/ARCHITECTURE.md) for the architecture of `pgagroal`.
 * [OpenSSL](http://www.openssl.org/)
 * [systemd](https://www.freedesktop.org/wiki/Software/systemd/)
 * [rst2man](https://docutils.sourceforge.io/)
+* [libatomic](https://gcc.gnu.org/wiki/Atomic)
+
+On Rocky Linux (and similar) operating systems, the dependencies
+can be installed via `dnf(8)` as follows:
 
 ```sh
-dnf install git gcc cmake make libev libev-devel openssl openssl-devel systemd systemd-devel python3-docutils
+dnf install git gcc cmake make    \
+            libev libev-devel     \
+            openssl openssl-devel \
+	    systemd systemd-devel \
+	    python3-docutils      \
+	    libatomic
 ```
 
-Alternative [clang 8+](https://clang.llvm.org/) can be used.
+Please note that, on Rocky Linux, in order to install the `python3-docutils`
+package (that provides `rst2man` executable), you need to enable the `crb` repository:
+
+```sh
+dnf config-manager --set-enabled crb
+```
+
+
+Alternatively to GCC, [clang 8+](https://clang.llvm.org/) can be used.
 
 ### Release build
 


### PR DESCRIPTION
Improve the documentation listing `libatomic`,
a possible way to install all the dependencies
on Rocky Linux and provides some instructions
for enabling `crb` so to install `rst2man`.

Close #396