### PR TITLE
[#399] Fix segmentation fault in `conf get` JSON format

### DIFF
--- a/src/include/json.h
+++ b/src/include/json.h
@@ -155,9 +155,14 @@ pgagroal_json_is_command_name_equals_to(cJSON* json, char* command_name);
  * when there is the need to print out the information
  * contained in a json object.
  *
+ * Since the JSON object will be invalidated, the method
+ * returns the status of the JSON command within it
+ * to be used.
+ *
  * @param json the json object to print
+ * @return the command status within the JSON object
  */
-void
+int
 pgagroal_json_print_and_free_json_object(cJSON* json);
 
 /**

--- a/src/libpgagroal/json.c
+++ b/src/libpgagroal/json.c
@@ -260,9 +260,11 @@ error:
 
 }
 
-void
+int
 pgagroal_json_print_and_free_json_object(cJSON* json)
 {
+   int status = pgagroal_json_command_object_exit_status(json);
    printf("%s\n", cJSON_Print(json));
    cJSON_Delete(json);
+   return status;
 }

--- a/src/libpgagroal/management.c
+++ b/src/libpgagroal/management.c
@@ -1812,8 +1812,7 @@ pgagroal_management_read_config_get(int socket, char* config_key, char* expected
 
    if (output_format == COMMAND_OUTPUT_FORMAT_JSON)
    {
-      pgagroal_json_print_and_free_json_object(json);
-      goto end;
+      return pgagroal_json_print_and_free_json_object(json);
    }
 
    // if here, print out in text format
@@ -1829,7 +1828,6 @@ pgagroal_management_read_config_get(int socket, char* config_key, char* expected
       printf("%s\n", value->valuestring);
    }
 
-end:
    return pgagroal_json_command_object_exit_status(json);
 
 error:


### PR DESCRIPTION
The `conf get` implementation in JSON format was trying to extract the command status after having freed the JSON object. This commit changes the `pgagroal_json_print_and_free_json_object()` function making it returning the status code for the command contained (possibly) in the JSON object.
In this way, it is possible to call the fuction in a way like:

     int status = pgagroal_json_print_and_free_json_object( json );

and get back the status leaving the function to free the object.

Close #399