### PR TITLE
Fix sprintf of size_t

### DIFF
--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -2101,7 +2101,7 @@ send_chunk(int client_fd, char* data)
       return MESSAGE_STATUS_ERROR;
    }
 
-   sprintf(m, "%lX\r\n", strlen(data));
+   sprintf(m, "%zX\r\n", strlen(data));
 
    m = pgagroal_append(m, data);
    m = pgagroal_append(m, "\r\n");


### PR DESCRIPTION
This failed on 32-bit platforms.

```
/home/myon/projects/postgresql/pgagroal/pgagroal/src/libpgagroal/prometheus.c: In function ‘send_chunk’:
/home/myon/projects/postgresql/pgagroal/pgagroal/src/libpgagroal/prometheus.c:2104:18: error: format ‘%lX’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘size_t’ {aka ‘unsigned int’} [-Werror=format=]
 2104 |    sprintf(m, "%lX\r\n", strlen(data));
      |                ~~^       ~~~~~~~~~~~~
      |                  |       |
      |                  |       size_t {aka unsigned int}
      |                  long unsigned int
      |                %X
```