### PR TITLE
[#403][#410] Improve error messages for pgagroal-cli

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -85,6 +85,338 @@ static int config_ls(SSL* ssl, int socket, char output_format);
 static int config_get(SSL* ssl, int socket, char* config_key, bool verbose, char output_format);
 static int config_set(SSL* ssl, int socket, char* config_key, char* config_value, bool verbose, char output_format);
 
+const struct pgagroal_command command_table[] = {
+   {
+      .command = "flush",
+      .subcommand = "",
+      .accepted_argument_count = {0, 1},
+      .action = ACTION_FLUSH,
+      .mode = FLUSH_GRACEFULLY,
+      .default_argument = "*",
+      .deprecated = false,
+      .log_message = "<flush gracefully> [%s]",
+   },
+   {
+      .command = "ping",
+      .subcommand = "",
+      .accepted_argument_count = {0},
+      .action = ACTION_ISALIVE,
+      .deprecated = false,
+      .log_message = "<is-alive>"
+   },
+   {
+      .command = "enable",
+      .subcommand = "",
+      .accepted_argument_count = {0, 1},
+      .action = ACTION_ENABLEDB,
+      .default_argument = "*",
+      .deprecated = false,
+      .log_message = "<enable> [%s]",
+   },
+   {
+      .command = "disable",
+      .subcommand = "",
+      .accepted_argument_count = {0, 1},
+      .action = ACTION_DISABLEDB,
+      .default_argument = "*",
+      .deprecated = false,
+      .log_message = "<disable> [%s]",
+   },
+   {
+      .command = "shutdown",
+      .subcommand = "",
+      .accepted_argument_count = {0},
+      .action = ACTION_GRACEFULLY,
+      .deprecated = false,
+      .log_message = "<shutdown gracefully>"
+   },
+   {
+      .command = "status",
+      .subcommand = "",
+      .accepted_argument_count = {0},
+      .action = ACTION_STATUS,
+      .deprecated = false,
+      .log_message = "<status>"
+   },
+   {
+      .command = "switch-to",
+      .subcommand = "",
+      .accepted_argument_count = {1},
+      .action = ACTION_SWITCH_TO,
+      .deprecated = false,
+      .log_message = "<switch-to> [%s]"
+   },
+   {
+      .command = "clear",
+      .subcommand = "",
+      .accepted_argument_count = {1},
+      .action = ACTION_RESET_SERVER,
+      .deprecated = false,
+      .log_message = "<clear server [%s]>",
+   },
+   {
+      .command = "shutdown",
+      .subcommand = "gracefully",
+      .accepted_argument_count = {0},
+      .action = ACTION_GRACEFULLY,
+      .deprecated = false,
+      .log_message = "<shutdown gracefully>"
+   },
+   {
+      .command = "shutdown",
+      .subcommand = "immediate",
+      .accepted_argument_count = {0},
+      .action = ACTION_STOP,
+      .deprecated = false,
+      .log_message = "<shutdown immediate>"
+   },
+   {
+      .command = "shutdown",
+      .subcommand = "cancel",
+      .accepted_argument_count = {0},
+      .action = ACTION_CANCELSHUTDOWN,
+      .deprecated = false,
+      .log_message = "<shutdown cancel>"
+   },
+   {
+      .command = "conf",
+      .subcommand = "reload",
+      .accepted_argument_count = {0},
+      .action = ACTION_RELOAD,
+      .deprecated = false,
+      .log_message = "<conf reload>"
+   },
+   {
+      .command = "conf",
+      .subcommand = "get",
+      .accepted_argument_count = {1},
+      .action = ACTION_CONFIG_GET,
+      .deprecated = false,
+      .log_message = "<conf get> [%s]"
+   },
+   {
+      .command = "conf",
+      .subcommand = "set",
+      .accepted_argument_count = {2},
+      .action = ACTION_CONFIG_SET,
+      .deprecated = false,
+      .log_message = "<conf set> [%s] = [%s]"
+   },
+   {
+      .command = "conf",
+      .subcommand = "ls",
+      .accepted_argument_count = {0},
+      .action = ACTION_CONFIG_LS,
+      .deprecated = false,
+      .log_message = "<conf ls>"
+   },
+   {
+      .command = "clear",
+      .subcommand = "server",
+      .accepted_argument_count = {0, 1},
+      .action = ACTION_RESET_SERVER,
+      .default_argument = "server",
+      .deprecated = false,
+      .log_message = "<clear server> [%s]",
+   },
+   {
+      .command = "flush",
+      .subcommand = "idle",
+      .accepted_argument_count = {0, 1},
+      .action = ACTION_FLUSH,
+      .mode = FLUSH_IDLE,
+      .default_argument = "*",
+      .deprecated = false,
+      .log_message = "<flush idle> [%s]",
+   },
+   {
+      .command = "flush",
+      .subcommand = "gracefully",
+      .accepted_argument_count = {0, 1},
+      .action = ACTION_FLUSH,
+      .mode = FLUSH_GRACEFULLY,
+      .default_argument = "*",
+      .deprecated = false,
+      .log_message = "<flush gracefully> [%s]",
+   },
+   {
+      .command = "flush",
+      .subcommand = "all",
+      .accepted_argument_count = {0, 1},
+      .action = ACTION_FLUSH,
+      .mode = FLUSH_ALL,
+      .default_argument = "*",
+      .deprecated = false,
+      .log_message = "<flush all> [%s]",
+   },
+   {
+      .command = "clear",
+      .subcommand = "prometheus",
+      .accepted_argument_count = {0},
+      .action = ACTION_RESET,
+      .deprecated = false,
+      .log_message = "<clear prometheus>"
+   },
+   {
+      .command = "status",
+      .subcommand = "details",
+      .accepted_argument_count = {0},
+      .action = ACTION_STATUS_DETAILS,
+      .deprecated = false,
+      .log_message = "<status details>"
+   },
+   {
+      .command = "flush-idle",
+      .subcommand = "",
+      .accepted_argument_count = {0, 1},
+      .action = ACTION_FLUSH,
+      .mode = FLUSH_IDLE,
+      .default_argument = "*",
+      .deprecated = true,
+      .deprecated_since_major = 1,
+      .deprecated_since_minor = 6,
+      .deprecated_by = "flush idle",
+      .log_message = "<flush idle> [%s]",
+   },
+   {
+      .command = "flush-all",
+      .subcommand = "",
+      .accepted_argument_count = {0, 1},
+      .action = ACTION_FLUSH,
+      .mode = FLUSH_ALL,
+      .default_argument = "*",
+      .deprecated = true,
+      .deprecated_since_major = 1,
+      .deprecated_since_minor = 6,
+      .deprecated_by = "flush all",
+      .log_message = "<flush all> [%s]",
+   },
+   {
+      .command = "flush-gracefully",
+      .subcommand = "",
+      .accepted_argument_count = {0, 1},
+      .action = ACTION_FLUSH,
+      .mode = FLUSH_GRACEFULLY,
+      .default_argument = "*",
+      .deprecated = true,
+      .deprecated_since_major = 1,
+      .deprecated_since_minor = 6,
+      .deprecated_by = "flush gracefully",
+      .log_message = "<flush gracefully> [%s]",
+   },
+   {
+      .command = "stop",
+      .subcommand = "",
+      .accepted_argument_count = {0},
+      .action = ACTION_STOP,
+      .deprecated = true,
+      .deprecated_since_major = 1,
+      .deprecated_since_minor = 6,
+      .deprecated_by = "shutdown immediate",
+      .log_message = "<shutdown immediate>",
+   },
+   {
+      .command = "cancel-shutdown",
+      .subcommand = "",
+      .accepted_argument_count = {0},
+      .action = ACTION_CANCELSHUTDOWN,
+      .deprecated = true,
+      .deprecated_since_major = 1,
+      .deprecated_since_minor = 6,
+      .deprecated_by = "shutdown cancel",
+      .log_message = "<shutdown cancel>",
+   },
+   {
+      .command = "gracefully",
+      .subcommand = "",
+      .accepted_argument_count = {0},
+      .action = ACTION_GRACEFULLY,
+      .deprecated = true,
+      .deprecated_since_major = 1,
+      .deprecated_since_minor = 6,
+      .deprecated_by = "shutdown gracefully",
+      .log_message = "<shutdown gracefully>",
+   },
+   {
+      .command = "details",
+      .subcommand = "",
+      .accepted_argument_count = {0},
+      .action = ACTION_STATUS_DETAILS,
+      .deprecated = true,
+      .deprecated_since_major = 1,
+      .deprecated_since_minor = 6,
+      .deprecated_by = "status details",
+      .log_message = "<status details>",
+   },
+   {
+      .command = "is-alive",
+      .subcommand = "",
+      .accepted_argument_count = {0},
+      .action = ACTION_ISALIVE,
+      .deprecated = true,
+      .deprecated_since_major = 1,
+      .deprecated_since_minor = 6,
+      .deprecated_by = "ping",
+      .log_message = "<ping>",
+   },
+   {
+      .command = "reset",
+      .subcommand = "",
+      .accepted_argument_count = {0},
+      .action = ACTION_RESET,
+      .deprecated = true,
+      .deprecated_since_major = 1,
+      .deprecated_since_minor = 6,
+      .deprecated_by = "clear prometheus",
+      .log_message = "<clear prometheus>",
+   },
+   {
+      .command = "reset-server",
+      .subcommand = "",
+      .accepted_argument_count = {0, 1},
+      .action = ACTION_RESET_SERVER,
+      .default_argument = "*",
+      .deprecated = true,
+      .deprecated_since_major = 1,
+      .deprecated_since_minor = 6,
+      .deprecated_by = "clear server",
+      .log_message = "<clear server [%s]>",
+   },
+   {
+      .command = "reload",
+      .subcommand = "",
+      .accepted_argument_count = {0},
+      .action = ACTION_RELOAD,
+      .deprecated = true,
+      .deprecated_since_major = 1,
+      .deprecated_since_minor = 6,
+      .deprecated_by = "conf reload",
+      .log_message = "<conf reload>",
+   },
+   {
+      .command = "config-get",
+      .subcommand = "",
+      .accepted_argument_count = {0, 1},
+      .action = ACTION_CONFIG_GET,
+      .deprecated = true,
+      .deprecated_since_major = 1,
+      .deprecated_since_minor = 6,
+      .deprecated_by = "conf get",
+      .log_message = "<conf get [%s]>",
+   },
+   {
+      .command = "config-set",
+      .subcommand = "",
+      .accepted_argument_count = {2},
+      .action = ACTION_CONFIG_SET,
+      .deprecated = true,
+      .deprecated_since_major = 1,
+      .deprecated_since_minor = 6,
+      .deprecated_by = "conf set",
+      .log_message = "<conf set> [%s] = [%s]",
+   },
+};
+
 static void
 version(void)
 {
@@ -166,17 +498,13 @@ main(int argc, char** argv)
    int c;
    int option_index = 0;
    size_t size;
-   int32_t action = ACTION_UNKNOWN;
-   int32_t mode = FLUSH_IDLE;
-   char* database = NULL;
    char un[MAX_USERNAME_LENGTH];
-   char* server = NULL;
    struct configuration* config = NULL;
    bool remote_connection = false;
    long l_port;
-   char* config_key = NULL; /* key for a configuration setting */
-   char* config_value = NULL; /* value for a configuration setting */
    char output_format = COMMAND_OUTPUT_FORMAT_TEXT;
+   size_t command_count = sizeof(command_table) / sizeof(struct pgagroal_command);
+   struct pgagroal_parsed_command parsed = {.cmd = NULL, .args = {0}};
 
    while (1)
    {
@@ -355,272 +683,169 @@ main(int argc, char** argv)
       }
    }
 
-   if (parse_command(argc, argv, optind, "flush", "idle", &database, "*", NULL, NULL)
-       || parse_deprecated_command(argc, argv, optind, "flush-idle", &database, "flush idle", 1, 6))
+   if (!parse_command(argc, argv, optind, &parsed, command_table, command_count))
    {
-      mode = FLUSH_IDLE;
-      action = ACTION_FLUSH;
-      pgagroal_log_trace("Command: <flush idle> [%s]", database);
+      usage();
+      goto done;
    }
-   else if (parse_command(argc, argv, optind, "flush", "all", &database, "*", NULL, NULL)
-            || parse_deprecated_command(argc, argv, optind, "flush-all", &database, "flush all", 1, 6))
-   {
-      mode = FLUSH_ALL;
-      action = ACTION_FLUSH;
-      pgagroal_log_trace("Command: <flush all> [%s]", database);
-   }
-   else if (parse_command(argc, argv, optind, "flush", "gracefully", &database, "*", NULL, NULL)
-            || parse_command(argc, argv, optind, "flush", NULL, &database, "*", NULL, NULL)
-            || parse_deprecated_command(argc, argv, optind, "flush-gracefully", &database, "flush", 1, 6))
-   {
-      mode = FLUSH_GRACEFULLY;
-      action = ACTION_FLUSH;
-      pgagroal_log_trace("Command: <flush gracefully> [%s]", database);
-   }
-   else if (parse_command(argc, argv, optind, "enable", NULL, &database, "*", NULL, NULL))
-   {
-      action = ACTION_ENABLEDB;
-      pgagroal_log_trace("Command: <enable> [%s]", database);
-   }
-   else if (parse_command(argc, argv, optind, "disable", NULL, &database, "*", NULL, NULL))
-   {
-      action = ACTION_DISABLEDB;
-      pgagroal_log_trace("Command: <disable> [%s]", database);
-   }
-   else if (parse_command_simple(argc, argv, optind, "shutdown", "immediate")
-            || parse_deprecated_command(argc, argv, optind, "stop", NULL, "shutdown immediate", 1, 6))
-   {
-      action = ACTION_STOP;
-      pgagroal_log_trace("Command: <shutdown immediate>");
-   }
-   else if (parse_command_simple(argc, argv, optind, "shutdown", "cancel")
-            || parse_deprecated_command(argc, argv, optind, "cancel-shutdown", NULL, "shutdown cancel", 1, 6))
-   {
-      action = ACTION_CANCELSHUTDOWN;
-      pgagroal_log_trace("Command: <shutdown cancel>");
-   }
-   else if (parse_command_simple(argc, argv, optind, "shutdown", "gracefully")
-            || parse_command_simple(argc, argv, optind, "shutdown", NULL)
-            || parse_deprecated_command(argc, argv, optind, "gracefully", NULL, "shutdown gracefully", 1, 6))
-   {
-      action = ACTION_GRACEFULLY;
-      pgagroal_log_trace("Command: <shutdown gracefully>");
-   }
-   else if (parse_command_simple(argc, argv, optind, "status", "details")
-            || parse_deprecated_command(argc, argv, optind, "details", NULL, "status details", 1, 6))
-   {
-      /* the 'status details' has to be parsed before the normal 'status' command !*/
-      action = ACTION_STATUS_DETAILS;
-      pgagroal_log_trace("Command: <status details>");
-   }
-   else if (parse_command_simple(argc, argv, optind, "status", NULL))
-   {
-      action = ACTION_STATUS;
-      pgagroal_log_trace("Command: <status>");
-   }
-   else if (parse_command_simple(argc, argv, optind, "ping", NULL)
-            || parse_deprecated_command(argc, argv, optind, "is-alive", NULL, "ping", 1, 6))
-   {
-      action = ACTION_ISALIVE;
-      pgagroal_log_trace("Command: <is-alive>");
-   }
-   else if (parse_command_simple(argc, argv, optind, "clear", "prometheus")
-            || parse_deprecated_command(argc, argv, optind, "reset", NULL, "clear prometheus", 1, 6))
-   {
-      action = ACTION_RESET;
-      pgagroal_log_trace("Command: <clear prometheus>");
-   }
-   else if (parse_command(argc, argv, optind, "clear", "server", &server, "\0", NULL, NULL)
-            || parse_command(argc, argv, optind, "clear", NULL, &server, "\0", NULL, NULL)
-            || parse_deprecated_command(argc, argv, optind, "reset-server", &server, "clear server", 1, 6))
-   {
-      action = strlen(server) > 0 ? ACTION_RESET_SERVER : ACTION_UNKNOWN;
-      pgagroal_log_trace("Command: <clear server> [%s]", server);
-   }
-   else if (parse_command(argc, argv, optind, "switch-to", NULL, &server, "\0", NULL, NULL))
-   {
-      action = strlen(server) > 0 ? ACTION_SWITCH_TO : ACTION_UNKNOWN;
-      pgagroal_log_trace("Command: <switch-to> [%s]", server);
-   }
-   else if (parse_command_simple(argc, argv, optind, "conf", "reload")
-            || parse_deprecated_command(argc, argv, optind, "reload", NULL, "conf reload", 1, 6))
-   {
-      /* Local connection only */
-      if (configuration_path != NULL)
-      {
-         action = ACTION_RELOAD;
-      }
-      pgagroal_log_trace("Command: <reload>");
-   }
-   else if (parse_command(argc, argv, optind, "conf", "get", &config_key, NULL, NULL, NULL)
-            || parse_deprecated_command(argc, argv, optind, "config-get", NULL, "conf get", 1, 6))
-   {
-      action = config_key != NULL && strlen(config_key) > 0 ? ACTION_CONFIG_GET : ACTION_UNKNOWN;
-      pgagroal_log_trace("Command: <conf get> [%s]", config_key);
-   }
-   else if (parse_command(argc, argv, optind, "conf", "set", &config_key, NULL, &config_value, NULL)
-            || parse_deprecated_command(argc, argv, optind, "config-set", NULL, "conf set", 1, 6))
-   {
-      // if there is no configuration key set the action to unknown, so the help screen will be printed
-      action = config_key != NULL && strlen(config_key) > 0 ? ACTION_CONFIG_SET : ACTION_UNKNOWN;
-      pgagroal_log_trace("Command: <conf set> [%s] = [%s]", config_key, config_value);
-   }
-   else if (parse_command_simple(argc, argv, optind, "conf", "ls"))
-   {
-      pgagroal_log_debug("Command: <conf ls>");
-      action = ACTION_CONFIG_LS;
-   }
+   pgagroal_log_trace((char*)parsed.cmd->log_message, parsed.args[0], parsed.args[1]);
 
-   if (action != ACTION_UNKNOWN)
+   if (!remote_connection)
    {
-      if (!remote_connection)
+      /* Local connection */
+      if (pgagroal_connect_unix_socket(config->unix_socket_dir, MAIN_UDS, &socket))
       {
-         /* Local connection */
-         if (pgagroal_connect_unix_socket(config->unix_socket_dir, MAIN_UDS, &socket))
+         exit_code = 1;
+         goto done;
+      }
+   }
+   else
+   {
+      /* Remote connection */
+      if (pgagroal_connect(host, atoi(port), &socket))
+      {
+         /* Remote connection */
+
+         l_port = strtol(port, NULL, 10);
+         if ((errno == ERANGE && (l_port == LONG_MAX || l_port == LONG_MIN)) || (errno != 0 && l_port == 0))
+         {
+            warnx("Specified port %s out of range", port);
+            goto done;
+         }
+
+         // cannot connect to port less than 1024 because pgagroal
+         // cannot be run as root!
+         if (l_port <= 1024)
+         {
+            warnx("Not allowed port %ld", l_port);
+            goto done;
+         }
+
+         if (pgagroal_connect(host, (int)l_port, &socket))
+         {
+            warnx("No route to host: %s:%ld\n", host, l_port);
+            goto done;
+         }
+
+      }
+
+      /* User name */
+      if (username == NULL)
+      {
+username:
+         printf("User name: ");
+
+         memset(&un, 0, sizeof(un));
+         if (fgets(&un[0], sizeof(un), stdin) == NULL)
          {
             exit_code = 1;
             goto done;
          }
+         un[strlen(un) - 1] = 0;
+         username = &un[0];
       }
-      else
+
+      if (username == NULL || strlen(username) == 0)
       {
-         /* Remote connection */
-         if (pgagroal_connect(host, atoi(port), &socket))
+         goto username;
+      }
+
+      /* Password */
+      if (password == NULL)
+      {
+         printf("Password : ");
+         password = pgagroal_get_password();
+         printf("\n");
+      }
+
+      for (int i = 0; i < strlen(password); i++)
+      {
+         if ((unsigned char)(*(password + i)) & 0x80)
          {
-            /* Remote connection */
 
-            l_port = strtol(port, NULL, 10);
-            if ((errno == ERANGE && (l_port == LONG_MAX || l_port == LONG_MIN)) || (errno != 0 && l_port == 0))
-            {
-               warnx("Specified port %s out of range", port);
-               goto done;
-            }
-
-            // cannot connect to port less than 1024 because pgagroal
-            // cannot be run as root!
-            if (l_port <= 1024)
-            {
-               warnx("Not allowed port %ld", l_port);
-               goto done;
-            }
-
-            if (pgagroal_connect(host, (int)l_port, &socket))
-            {
-               warnx("No route to host: %s:%ld\n", host, l_port);
-               goto done;
-            }
-
-         }
-
-         /* User name */
-         if (username == NULL)
-         {
-username:
-            printf("User name: ");
-
-            memset(&un, 0, sizeof(un));
-            if (fgets(&un[0], sizeof(un), stdin) == NULL)
-            {
-               exit_code = 1;
-               goto done;
-            }
-            un[strlen(un) - 1] = 0;
-            username = &un[0];
-         }
-
-         if (username == NULL || strlen(username) == 0)
-         {
-            goto username;
-         }
-
-         /* Password */
-         if (password == NULL)
-         {
-            printf("Password : ");
-            password = pgagroal_get_password();
-            printf("\n");
-         }
-
-         for (int i = 0; i < strlen(password); i++)
-         {
-            if ((unsigned char)(*(password + i)) & 0x80)
-            {
-
-               warnx("Bad credentials for %s\n", username);
-               goto done;
-            }
-         }
-
-         /* Authenticate */
-         if (pgagroal_remote_management_scram_sha256(username, password, socket, &s_ssl) != AUTH_SUCCESS)
-         {
-            printf("pgagroal-cli: Bad credentials for %s\n", username);
+            warnx("Bad credentials for %s\n", username);
             goto done;
          }
       }
+
+      /* Authenticate */
+      if (pgagroal_remote_management_scram_sha256(username, password, socket, &s_ssl) != AUTH_SUCCESS)
+      {
+         printf("pgagroal-cli: Bad credentials for %s\n", username);
+         goto done;
+      }
    }
 
-   if (action == ACTION_FLUSH)
+   if (parsed.cmd->action == ACTION_FLUSH)
    {
-      exit_code = flush(s_ssl, socket, mode, database);
+      exit_code = flush(s_ssl, socket, parsed.cmd->mode, parsed.args[0]);
    }
-   else if (action == ACTION_ENABLEDB)
+   else if (parsed.cmd->action == ACTION_ENABLEDB)
    {
-      exit_code = enabledb(s_ssl, socket, database);
+      exit_code = enabledb(s_ssl, socket, parsed.args[0]);
    }
-   else if (action == ACTION_DISABLEDB)
+   else if (parsed.cmd->action == ACTION_DISABLEDB)
    {
-      exit_code = disabledb(s_ssl, socket, database);
+      exit_code = disabledb(s_ssl, socket, parsed.args[0]);
    }
-   else if (action == ACTION_GRACEFULLY)
+   else if (parsed.cmd->action == ACTION_GRACEFULLY)
    {
       exit_code = gracefully(s_ssl, socket);
    }
-   else if (action == ACTION_STOP)
+   else if (parsed.cmd->action == ACTION_STOP)
    {
       exit_code = stop(s_ssl, socket);
    }
-   else if (action == ACTION_CANCELSHUTDOWN)
+   else if (parsed.cmd->action == ACTION_CANCELSHUTDOWN)
    {
       exit_code = cancel_shutdown(s_ssl, socket);
    }
-   else if (action == ACTION_STATUS)
+   else if (parsed.cmd->action == ACTION_STATUS)
    {
       exit_code = status(s_ssl, socket, output_format);
    }
-   else if (action == ACTION_STATUS_DETAILS)
+   else if (parsed.cmd->action == ACTION_STATUS_DETAILS)
    {
       exit_code = details(s_ssl, socket, output_format);
    }
-   else if (action == ACTION_ISALIVE)
+   else if (parsed.cmd->action == ACTION_ISALIVE)
    {
       exit_code = isalive(s_ssl, socket, output_format);
    }
-   else if (action == ACTION_RESET)
+   else if (parsed.cmd->action == ACTION_RESET)
    {
       exit_code = reset(s_ssl, socket);
    }
-   else if (action == ACTION_RESET_SERVER)
+   else if (parsed.cmd->action == ACTION_RESET_SERVER)
    {
-      exit_code = reset_server(s_ssl, socket, server);
+      exit_code = reset_server(s_ssl, socket, parsed.args[0]);
    }
-   else if (action == ACTION_SWITCH_TO)
+   else if (parsed.cmd->action == ACTION_SWITCH_TO)
    {
-      exit_code = switch_to(s_ssl, socket, server);
+      exit_code = switch_to(s_ssl, socket, parsed.args[0]);
    }
-   else if (action == ACTION_RELOAD)
+   else if (parsed.cmd->action == ACTION_RELOAD)
    {
-      exit_code = reload(s_ssl, socket);
+      if (configuration_path == NULL)
+      {
+         warnx("Configuration path has to specified to use <reload>");
+         parsed.cmd = NULL;
+         goto done;
+      }
+      else
+      {
+         exit_code = reload(s_ssl, socket);
+      }
    }
-   else if (action == ACTION_CONFIG_GET)
+   else if (parsed.cmd->action == ACTION_CONFIG_GET)
    {
-      exit_code = config_get(s_ssl, socket, config_key, verbose, output_format);
+      exit_code = config_get(s_ssl, socket, parsed.args[0], verbose, output_format);
    }
-   else if (action == ACTION_CONFIG_SET)
+   else if (parsed.cmd->action == ACTION_CONFIG_SET)
    {
-      exit_code = config_set(s_ssl, socket, config_key, config_value, verbose, output_format);
+      exit_code = config_set(s_ssl, socket, parsed.args[0], parsed.args[1], verbose, output_format);
    }
-   else if (action == ACTION_CONFIG_LS)
+   else if (parsed.cmd->action == ACTION_CONFIG_LS)
    {
       exit_code = config_ls(s_ssl, socket, output_format);
    }
@@ -642,16 +867,9 @@ done:
 
    pgagroal_disconnect(socket);
 
-   if (action == ACTION_UNKNOWN)
-   {
-      printf("pgagroal-cli: unknown command %s\n", argv[optind]);
-      usage();
-      exit_code = 1;
-   }
-
    if (configuration_path != NULL)
    {
-      if (action != ACTION_UNKNOWN)
+      if (parsed.cmd != NULL)
       {
          switch (exit_code)
          {
@@ -662,7 +880,6 @@ done:
             case EXIT_STATUS_OK:
                break;
          }
-
       }
    }
 


### PR DESCRIPTION
This commit improves the error messages for pgagroal-cli and pgagroal-admin commands by modifying the parse_command function. 

It also tries to simplify adding new commands. Now adding a command with the structure "<command> [subcommand] [arg] [arg] ..." requires the addition of the command enum and its struct in the `command_table`.

This means that the command parsing now involves the interpretation of a command_table defined in each cli.c and admin.c files.


