### PR TITLE
[#392] Add application name and version in management protocol

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Yongting You <2010youy01@gmail.com>
 Ashutosh Sharma <ash2003sharma@gmail.com>
 Henrique de Carvalho <decarv.henrique@gmail.com>
 Yihe Lu <t1t4m1un@gmail.com>
+Eugenio Gigante <giganteeugenio2@gmail.com>

--- a/src/include/json.h
+++ b/src/include/json.h
@@ -76,7 +76,7 @@
  * response object
  */
 cJSON*
-pgagroal_json_create_new_command_object(char* command_name, bool success, char* executable_name);
+pgagroal_json_create_new_command_object(char* command_name, bool success, char* executable_name, char* executable_version);
 
 /**
  * Utility method to "jump" to the output JSON object wrapped into

--- a/src/include/management.h
+++ b/src/include/management.h
@@ -77,6 +77,25 @@ extern "C" {
 #define COMMAND_OUTPUT_FORMAT_JSON 'J'
 
 /**
+ * Available applications
+ */
+#define PGAGROAL_EXECUTABLE 1
+#define PGAGROAL_EXECUTABLE_CLI 2
+#define PGAGROAL_EXECUTABLE_VAULT 3
+
+/*
+ * stores the application name and its version
+ * which are sent through the socket
+ */
+struct pgagroal_version_info
+{
+   char s[2];
+   int command;
+   char v[3];
+   int version;
+};
+
+/**
  * Get the frontend password of a user
  * @param ssl The SSL connection
  * @param socket The socket descriptor

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -3066,7 +3066,7 @@ key_in_section(char* wanted, char* section, char* key, bool global, bool* unknow
 
    // if here there is a match on the key, ensure the section is
    // appropriate
-   if (global && (!strncmp(section, PGAGROAL_MAIN_INI_SECTION, MISC_LENGTH) | !strncmp(section, PGAGROAL_VAULT_INI_SECTION, MISC_LENGTH)))
+   if (global && (!strncmp(section, PGAGROAL_MAIN_INI_SECTION, MISC_LENGTH) || !strncmp(section, PGAGROAL_VAULT_INI_SECTION, MISC_LENGTH)))
    {
       return true;
    }


### PR DESCRIPTION
In order to improve debugging, [#392] suggested to write the sender application name and its version into the header over which pgagroal-cli and pgagroal communicate.

Introduces the `write_header_info` function in `management.c`

Every time a pgagroal-cli is used, `cli.c` writes into the communication socket through the `write_header` function.
Then pgagroal replies with one of the `pgagroal_write_` functions, depending on the option specified.
Therefore, the strategy is to call `write_header_info` into both.

Arguments of `write_header_info`:
- `char* header`: the header to write sender application name and its version into
- `bool start`: In case the function is called in `write_header`, the block is written after `type` and `slot.`
- `char* command`: server application name.

As for now, this commit adds `write_header_info` only in the  `pgagroal_write_isalive`  function called if the user specified option `ping` while calling the `pgagroal-cli` command.

The plan is to insert `write_header_info` into every `pgagroal_write_` function called by `main.c`, if the strategy is successful and after code reviews. 