### PR TITLE
[#416] Improve `pgagroal-admin` warning messages

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -285,7 +285,7 @@ main(int argc, char** argv)
    {
       if (master_key(password, generate_pwd, pwd_length))
       {
-         errx(1, "Error for master key");
+         errx(1, "Cannot generate master key");
       }
    }
    else if (parsed.cmd->action == ACTION_ADD_USER)
@@ -367,7 +367,7 @@ master_key(char* password, bool generate_pwd, int pwd_length)
       }
       else
       {
-         warnx("Wrong permissions for ~/.pgagroal (must be 0700)");
+         warnx("Wrong permissions for directory <%s> (must be 0700)", &buf[0]);
          goto error;
       }
    }
@@ -387,7 +387,7 @@ master_key(char* password, bool generate_pwd, int pwd_length)
       }
       else
       {
-         warnx("Wrong permissions for ~/.pgagroal/master.key (must be 0600)");
+         warnx("Wrong permissions for file <%s> (must be 0600)", &buf[0]);
          goto error;
       }
    }

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -174,14 +174,14 @@ extern "C" {
 #define unlikely(x)  __builtin_expect (!!(x), 0)
 
 #define MAX(a, b)               \
-   ({ __typeof__ (a) _a = (a);  \
-      __typeof__ (b) _b = (b);  \
-      _a > _b ? _a : _b; })
+        ({ __typeof__ (a) _a = (a);  \
+           __typeof__ (b) _b = (b);  \
+           _a > _b ? _a : _b; })
 
 #define MIN(a, b)               \
-   ({ __typeof__ (a) _a = (a);  \
-      __typeof__ (b) _b = (b);  \
-      _a < _b ? _a : _b; })
+        ({ __typeof__ (a) _a = (a);  \
+           __typeof__ (b) _b = (b);  \
+           _a < _b ? _a : _b; })
 
 /*
  * Common piece of code to perform a sleeping.
@@ -194,13 +194,13 @@ extern "C" {
  *
  */
 #define SLEEP(zzz)                  \
-   do                               \
-   {                                \
-      struct timespec ts_private;   \
-      ts_private.tv_sec = 0;        \
-      ts_private.tv_nsec = zzz;     \
-      nanosleep(&ts_private, NULL); \
-   } while (0);
+        do                               \
+        {                                \
+           struct timespec ts_private;   \
+           ts_private.tv_sec = 0;        \
+           ts_private.tv_nsec = zzz;     \
+           nanosleep(&ts_private, NULL); \
+        } while (0);
 
 /*
  * Commonly used block of code to sleep
@@ -217,14 +217,14 @@ extern "C" {
        SLEEP_AND_GOTO(100000L, retry)
  */
 #define SLEEP_AND_GOTO(zzz, goto_to)    \
-   do                                   \
-   {                                    \
-      struct timespec ts_private;       \
-      ts_private.tv_sec = 0;            \
-      ts_private.tv_nsec = zzz;         \
-      nanosleep(&ts_private, NULL);     \
-      goto goto_to;                     \
-   } while (0);
+        do                                   \
+        {                                    \
+           struct timespec ts_private;       \
+           ts_private.tv_sec = 0;            \
+           ts_private.tv_nsec = zzz;         \
+           nanosleep(&ts_private, NULL);     \
+           goto goto_to;                     \
+        } while (0);
 
 /**
  * The shared memory segment


### PR DESCRIPTION
Improves some messages about the `master-key` command when dealing with wrong file permissions: it clearly indicates the directory or the file that has wrong permissions.

Close #416