### PR TITLE
[#422] Improve the `restart_server` function

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Lawrence Wu <lawrence910426@gmail.com>
 Yongting You <2010youy01@gmail.com>
 Ashutosh Sharma <ash2003sharma@gmail.com>
 Henrique de Carvalho <decarv.henrique@gmail.com>
+Yihe Lu <t1t4m1un@gmail.com>

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -243,6 +243,7 @@ However, some configuration settings requires a full restart of `pgagroal` in or
 * `unix_socket_dir`
 * `pidfile`
 * Limit rules defined by `pgagroal_databases.conf`
+* TLS rules defined by server section
 
 The configuration can also be reloaded using `pgagroal-cli -c pgagroal.conf reload`. The command is only supported
 over the local interface, and hence doesn't work remotely.

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -105,10 +105,10 @@ There can be up to `64` host sections, each with an unique name and different co
 | host | | String | Yes | The address of the PostgreSQL instance |
 | port | | Int | Yes | The port of the PostgreSQL instance |
 | primary | | Bool | No | Identify the instance as primary (hint) |
-| tls | `off` | Bool | No | Enable Transport Layer Security (TLS) support (Experimental - no pooling) |
-| tls_cert_file | | String | No | Certificate file for TLS. This file must be owned by either the user running pgagroal or root. |
-| tls_key_file | | String | No | Private key file for TLS. This file must be owned by either the user running pgagroal or root. Additionally permissions must be at least `0640` when owned by root or `0600` otherwise. |
-| tls_ca_file | | String | No | Certificate Authority (CA) file for TLS. This file must be owned by either the user running pgagroal or root.  |
+| tls | `off` | Bool | No | Enable Transport Layer Security (TLS) support (Experimental - no pooling). Changes require restart. |
+| tls_cert_file | | String | No | Certificate file for TLS. This file must be owned by either the user running pgagroal or root. Changes require restart. |
+| tls_key_file | | String | No | Private key file for TLS. This file must be owned by either the user running pgagroal or root. Additionally permissions must be at least `0640` when owned by root or `0600` otherwise.Changes require restart. |
+| tls_ca_file | | String | No | Certificate Authority (CA) file for TLS. This file must be owned by either the user running pgagroal or root. Changes require restart. |
 
 Note, that if `host` starts with a `/` it represents a path and `pgagroal` will connect using a Unix Domain Socket.
 

--- a/doc/man/pgagroal.conf.5.rst
+++ b/doc/man/pgagroal.conf.5.rst
@@ -129,16 +129,16 @@ failover_script
   The failover script
 
 tls
-  Enable Transport Layer Security (TLS). Default is false
+  Enable Transport Layer Security (TLS). Default is false. Changes require restart in the server section.
 
 tls_cert_file
-  Certificate file for TLS
+  Certificate file for TLS. Changes require restart in the server section.
 
 tls_key_file
-  Private key file for TLS
+  Private key file for TLS. Changes require restart in the server section.
 
 tls_ca_file
-  Certificate Authority (CA) file for TLS
+  Certificate Authority (CA) file for TLS. Changes require restart in the server section.
 
 libev
   The libev backend to use. Valid options: auto, select, poll, epoll, iouring, devpoll and port. Default is auto


### PR DESCRIPTION
### Functionality:

Implement `restart_server` function for daemon with conditional restarts and warnings for configuration changes, including TLS updates.

### Document:

```c
/**
 * Compares the TLS configurations of two servers to determine if they are identical.
 *
 * This function assesses whether the source and destination servers have matching TLS configurations, 
 * which is crucial for ensuring secure communication protocols are uniformly applied across server interactions.
 *
 * @param s1 Pointer to the first server structure to compare.
 * @param s2 Pointer to the second server structure to compare.
 * @return Returns true if both servers have identical TLS configurations, false if they differ.
 */
static bool is_same_tls(struct server* s1, struct server* s2);

/**
 * Checks if two boolean values are same. If not, prints a line in the log
 *
 * @param name The name of the configuration option.
 * @param e The existing boolean value.
 * @param n The new boolean value.
 * @return 1 if a restart is required, 0 otherwise.
 */
static int restart_bool(char* name, bool e, bool n);
```


### Test Case Verification:

1. Follow the documentation to configure the pgagroal daemon and pgagroal-cli using the provided demo 
2. Initiate the pgagroal 
3. Update the pgagroal.conf file under the [primary] section to enable TLS by setting tls = on
4. Execute pgagroal-ctl conf reload to apply the new 
5. Confirm the restart requirement in /tmp/pgagroal.log, which should log an entry similar to:

```
2024-03-25 16:55:04 INFO  configuration.c:2479 Restart required for Server <primary>, parameter <tls> - Existing false New true
```