### PR TITLE
Enable PostgreSQL and run pgagroal-cli status in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,15 @@ jobs:
   build-linux:
 
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v3
+    - name: Add PostgreSQL apt repository
+      run: |
+        sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+        sudo wget --quiet --output-document /etc/apt/trusted.gpg.d/apt.postgresql.org.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc
     - name: Update system
-      run: sudo apt update -y
+      run: sudo apt update
     - name: Install libev
       run: sudo apt install -y libev4 libev-dev
     - name: Install cJSON
@@ -27,18 +31,43 @@ jobs:
       run: sudo apt install -y python3-docutils
     - name: Install clang
       run: sudo apt install -y clang
+    - name: Install PostgreSQL
+      run: sudo apt install -y postgresql
+    - name: Start postgres
+      run: |
+        version=$(pg_config --version | grep -Eo "[0-9]{1,2}" | head -1)
+        sudo -u postgres /usr/lib/postgresql/${version}/bin/pg_ctl start -D /etc/postgresql/${version}/main/
     - name: GCC/mkdir
       run: mkdir build
       working-directory: /home/runner/work/pgagroal/pgagroal/
     - name: GCC/cmake
-      run: export CC=/usr/bin/gcc && cmake -DCMAKE_BUILD_TYPE=Debug ..
+      run: sudo apt install cmake && export CC=/usr/bin/gcc && cmake -DCMAKE_BUILD_TYPE=Debug ..
       working-directory: /home/runner/work/pgagroal/pgagroal/build/
     - name: GCC/make
       run: make
       working-directory: /home/runner/work/pgagroal/pgagroal/build/
+    - name: GCC/Run pgagroal & confirm pgagroal is running
+      run: |
+        sudo mkdir -p /etc/pgagroal
+        sudo cp ../../doc/etc/*.conf /etc/pgagroal
+        ./pgagroal >> /dev/null 2>&1 &
+        pid=$!
+        sleep 5
+        ./pgagroal-cli ping
+      working-directory: /home/runner/work/pgagroal/pgagroal/build/src/
+    - name: GCC/Stop pgagroal & postgres
+      run: |
+        ./pgagroal-cli shutdown
+        version=$(pg_config --version | grep -Eo "[0-9]{1,2}" | head -1)
+        sudo -u postgres /usr/lib/postgresql/${version}/bin/pg_ctl stop -D /etc/postgresql/${version}/main/
+      working-directory: /home/runner/work/pgagroal/pgagroal/build/src/
     - name: rm -Rf
       run: rm -Rf build/
       working-directory: /home/runner/work/pgagroal/pgagroal/
+    - name: Start postgres
+      run: |
+        version=$(pg_config --version | grep -Eo "[0-9]{1,2}" | head -1)
+        sudo -u postgres /usr/lib/postgresql/${version}/bin/pg_ctl start -D /etc/postgresql/${version}/main/
     - name: CLANG/mkdir
       run: mkdir build
       working-directory: /home/runner/work/pgagroal/pgagroal/
@@ -48,13 +77,28 @@ jobs:
     - name: CLANG/make
       run: make
       working-directory: /home/runner/work/pgagroal/pgagroal/build/
+    - name: CLANG/Run pgagroal & confirm pgagroal is running
+      run: |
+        sudo mkdir -p /etc/pgagroal
+        sudo cp ../../doc/etc/*.conf /etc/pgagroal
+        ./pgagroal >> /dev/null 2>&1 &
+        pid=$!
+        sleep 5
+        ./pgagroal-cli ping
+      working-directory: /home/runner/work/pgagroal/pgagroal/build/src/
+    - name: CLANG/Stop pgagroal & postgres
+      run: |
+        ./pgagroal-cli shutdown
+        version=$(pg_config --version | grep -Eo "[0-9]{1,2}" | head -1)
+        sudo -u postgres /usr/lib/postgresql/${version}/bin/pg_ctl stop -D /etc/postgresql/${version}/main/
+      working-directory: /home/runner/work/pgagroal/pgagroal/build/src/
 
 
 
   build-macos:
 
     runs-on: macos-latest
-    
+
     steps:
     - uses: actions/checkout@v3
     - name: Install Homebrew
@@ -71,6 +115,14 @@ jobs:
       run: brew install docutils
     - name: Install clang
       run: brew install llvm
+    - name: Install PostgreSQL
+      run: |
+        latest_pg=$(brew search postgresql | grep postgresql@ | tail -n 1)
+        brew install ${latest_pg} || true  # `|| true` prevents install errors from breaking the run
+    - name: Start postgres
+      run: |
+        installed_pg=$(brew search postgresql | grep postgresql@ | tail -n 1)
+        brew services start ${installed_pg}
     - name: GCC/mkdir
       run: mkdir build
       working-directory: /Users/runner/work/pgagroal/pgagroal/
@@ -80,9 +132,28 @@ jobs:
     - name: GCC/make
       run: make
       working-directory: /Users/runner/work/pgagroal/pgagroal/build/
+    - name: GCC/Run pgagroal & confirm pgagroal is running
+      run: |
+         sudo mkdir -p /etc/pgagroal
+         sudo cp ../../doc/etc/*.conf /etc/pgagroal
+         ./pgagroal >> /dev/null 2>&1 &
+         pid=$!
+         sleep 5
+         ./pgagroal-cli ping
+      working-directory: /Users/runner/work/pgagroal/pgagroal/build/src/
+    - name: GCC/Stop pgagroal & postgres
+      run: |
+        ./pgagroal-cli shutdown
+        installed_pg=$(brew search postgresql | grep postgresql@ | tail -n 1)
+        brew services stop ${installed_pg}
+      working-directory: /Users/runner/work/pgagroal/pgagroal/build/src/
     - name: rm -Rf
       run: rm -Rf build/
       working-directory: /Users/runner/work/pgagroal/pgagroal/
+    - name: Start postgres
+      run: |
+        installed_pg=$(brew search postgresql | grep postgresql@ | tail -n 1)
+        brew services start ${installed_pg}
     - name: CLANG/mkdir
       run: mkdir build
       working-directory: /Users/runner/work/pgagroal/pgagroal/
@@ -92,3 +163,18 @@ jobs:
     - name: CLANG/make
       run: make
       working-directory: /Users/runner/work/pgagroal/pgagroal/build/
+    - name: CLANG/Run pgagroal & confirm pgagroal is running
+      run: |
+        sudo mkdir -p /etc/pgagroal
+        sudo cp ../../doc/etc/*.conf /etc/pgagroal
+        ./pgagroal >> /dev/null 2>&1 &
+        pid=$!
+        sleep 5
+        ./pgagroal-cli ping
+      working-directory: /Users/runner/work/pgagroal/pgagroal/build/src/
+    - name: CLANG/Stop pgagroal & postgres
+      run: |
+        ./pgagroal-cli shutdown
+        installed_pg=$(brew search postgresql | grep postgresql@ | tail -n 1)
+        brew services stop ${installed_pg}
+      working-directory: /Users/runner/work/pgagroal/pgagroal/build/src/


### PR DESCRIPTION
This commit modifies the build-linux workflow by incorporating PostgreSQL and by testing pgagroal for both GCC and CLANG build. The changes ensure that the workflow:

(a) Installs and runs the latest version of PostgreSQL; 
(b) Runs pgagroal; and
(c) Runs pgagroal-cli status command and to confirm that pgagroal's status is "Running".

I added a sleep to guarantee that pgagroal can start before pgagroal-cli is run.