### PR TITLE
[#428] Fix error message in `pgagroal-admin`

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -377,7 +377,7 @@ master_key(char* password, bool generate_pwd, int pwd_length)
 
    if (pgagroal_exists(&buf[0]))
    {
-      warnx("The file ~/.pgexporter/master.key already exists");
+      warnx("The file %s already exists, cannot continue", &buf[0]);
       goto error;
    }
 


### PR DESCRIPTION
Removes references to `pgexporter`.

Close #428