### PR TITLE
Issue #419 Allow pgagroal-admin to specify where to store the master key password file

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -61,7 +61,7 @@ static char CHARS[] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L
                        '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '-', '_', '=', '+', '[', '{', ']', '}', '\\', '|', ';', ':',
                        '\'', '\"', ',', '<', '.', '>', '/', '?'};
 
-static int master_key(char* password, bool generate_pwd, int pwd_length);
+static int master_key(char* password, bool generate_pwd, int pwd_length, char* filename);
 static int add_user(char* users_path, char* username, char* password, bool generate_pwd, int pwd_length);
 static int update_user(char* users_path, char* username, char* password, bool generate_pwd, int pwd_length);
 static int remove_user(char* users_path, char* username);
@@ -73,7 +73,7 @@ const struct pgagroal_command command_table[] =
    {
       .command = "master-key",
       .subcommand = "",
-      .accepted_argument_count = {0},
+      .accepted_argument_count = {0, 1},
       .deprecated = false,
       .action = ACTION_MASTER_KEY,
       .log_message = "<master-key>",
@@ -184,7 +184,7 @@ usage(void)
    printf("  -?, --help              Display help\n");
    printf("\n");
    printf("Commands:\n");
-   printf("  master-key              Create or update the master key\n");
+   printf("  master-key <filename>   Create or update the master key\n");
    printf("  user <subcommand>       Manage a specific user, where <subcommand> can be\n");
    printf("                          - add  to add a new user\n");
    printf("                          - del  to remove an existing user\n");
@@ -283,7 +283,7 @@ main(int argc, char** argv)
 
    if (parsed.cmd->action == ACTION_MASTER_KEY)
    {
-      if (master_key(password, generate_pwd, pwd_length))
+      if (master_key(password, generate_pwd, pwd_length, parsed.args[0]))
       {
          errx(1, "Cannot generate master key");
       }
@@ -328,77 +328,113 @@ error:
 }
 
 static int
-master_key(char* password, bool generate_pwd, int pwd_length)
+master_key(char* password, bool generate_pwd, int pwd_length, char* filename)
 {
    FILE* file = NULL;
    char buf[MISC_LENGTH];
    char* encoded = NULL;
    struct stat st = {0};
    bool do_free = true;
-
-   if (pgagroal_get_home_directory() == NULL)
+   if(filename == NULL)
    {
-      char* username = pgagroal_get_user_name();
-
-      if (username != NULL)
+      if (pgagroal_get_home_directory() == NULL)
       {
-         warnx("No home directory for user \'%s\'", username);
+         char* username = pgagroal_get_user_name();
+
+         if (username != NULL)
+         {
+            warnx("No home directory for user \'%s\'", username);
+         }
+         else
+         {
+            warnx("No home directory for user running pgagroal");
+         }
+
+         goto error;
+      }
+
+      memset(&buf, 0, sizeof(buf));
+      snprintf(&buf[0], sizeof(buf), "%s/.pgagroal", pgagroal_get_home_directory());
+
+      if (stat(&buf[0], &st) == -1)
+      {
+         mkdir(&buf[0], S_IRWXU);
       }
       else
       {
-         warnx("No home directory for user running pgagroal");
+         if (S_ISDIR(st.st_mode) && st.st_mode & S_IRWXU && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
+         {
+            /* Ok */
+         }
+         else
+         {
+            warnx("Wrong permissions for directory <%s> (must be 0700)", &buf[0]);
+            goto error;
+         }
       }
 
-      goto error;
-   }
+      memset(&buf, 0, sizeof(buf));
+      snprintf(&buf[0], sizeof(buf), "%s/.pgagroal/master.key", pgagroal_get_home_directory());
 
-   memset(&buf, 0, sizeof(buf));
-   snprintf(&buf[0], sizeof(buf), "%s/.pgagroal", pgagroal_get_home_directory());
+      if (pgagroal_exists(&buf[0]))
+      {
+         warnx("The file ~/.pgexporter/master.key already exists");
+         goto error;
+      }
 
-   if (stat(&buf[0], &st) == -1)
-   {
-      mkdir(&buf[0], S_IRWXU);
-   }
-   else
-   {
-      if (S_ISDIR(st.st_mode) && st.st_mode & S_IRWXU && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
+      if (stat(&buf[0], &st) == -1)
       {
          /* Ok */
       }
       else
       {
-         warnx("Wrong permissions for directory <%s> (must be 0700)", &buf[0]);
-         goto error;
+         if (S_ISREG(st.st_mode) && st.st_mode & (S_IRUSR | S_IWUSR) && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
+         {
+            /* Ok */
+         }
+         else
+         {
+            warnx("Wrong permissions for file <%s> (must be 0600)", &buf[0]);
+            goto error;
+         }
       }
    }
 
-   memset(&buf, 0, sizeof(buf));
-   snprintf(&buf[0], sizeof(buf), "%s/.pgagroal/master.key", pgagroal_get_home_directory());
-
+   if(filename != NULL)
+   {
+   snprintf(&buf[0], sizeof(buf), "%s", filename);
    if (pgagroal_exists(&buf[0]))
-   {
-      warnx("The file ~/.pgexporter/master.key already exists");
-      goto error;
-   }
+      {
+         warnx("The file ~/.pgexporter/master.key already exists");
+         goto error;
+      }
 
-   if (stat(&buf[0], &st) == -1)
-   {
-      /* Ok */
-   }
-   else
-   {
-      if (S_ISREG(st.st_mode) && st.st_mode & (S_IRUSR | S_IWUSR) && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
+      if (stat(&buf[0], &st) == -1)
       {
          /* Ok */
       }
       else
       {
-         warnx("Wrong permissions for file <%s> (must be 0600)", &buf[0]);
-         goto error;
+         if (S_ISREG(st.st_mode) && st.st_mode & (S_IRUSR | S_IWUSR) && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
+         {
+            /* Ok */
+         }
+         else
+         {
+            warnx("Wrong permissions for file <%s> (must be 0600)", &buf[0]);
+            goto error;
+         }
       }
+
+      file = fopen(filename, "w+");
    }
 
-   file = fopen(&buf[0], "w+");
+   else{
+      file = fopen(&buf[0], "w+");
+
+   }
+
+
    if (file == NULL)
    {
       warnx("Could not write to master key file <%s>", &buf[0]);

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -3172,6 +3172,38 @@ get_salt(void* data, char** salt)
 int
 pgagroal_get_master_key(char** masterkey)
 {
+   /*
+   Read the master key location from the master_key.txt
+   */
+   char *buffer;
+   int fileLength;
+
+   FILE *filePointer;
+   filePointer = fopen("master_key.txt", "r");
+   if (filePointer == NULL) 
+   {
+      printf("Error opening file for reading!\n");
+      return 1;
+   }
+
+   fseek(filePointer, 0, SEEK_END);
+   fileLength = ftell(filePointer);
+   fseek(filePointer, 0, SEEK_SET);
+
+   buffer = (char *)malloc(fileLength + 1);
+   if (buffer == NULL) 
+   {
+      printf("Memory allocation failed!\n");
+      fclose(filePointer);
+      return 1;
+   }
+
+   fread(buffer, 1, fileLength, filePointer);
+
+   buffer[fileLength] = '\0';
+
+   fclose(filePointer);
+   
    FILE* master_key_file = NULL;
    char buf[MISC_LENGTH];
    char line[MISC_LENGTH];
@@ -3179,50 +3211,62 @@ pgagroal_get_master_key(char** masterkey)
    int mk_length = 0;
    struct stat st = {0};
 
-   if (pgagroal_get_home_directory() == NULL)
-   {
-      goto error;
-   }
-
-   memset(&buf, 0, sizeof(buf));
-   snprintf(&buf[0], sizeof(buf), "%s/.pgagroal", pgagroal_get_home_directory());
-
-   if (stat(&buf[0], &st) == -1)
-   {
-      goto error;
-   }
-   else
-   {
-      if (S_ISDIR(st.st_mode) && st.st_mode & S_IRWXU && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
-      {
-         /* Ok */
-      }
-      else
+   if(fileLength == 0){
+      if (pgagroal_get_home_directory() == NULL)
       {
          goto error;
       }
-   }
 
-   memset(&buf, 0, sizeof(buf));
-   snprintf(&buf[0], sizeof(buf), "%s/.pgagroal/master.key", pgagroal_get_home_directory());
+      memset(&buf, 0, sizeof(buf));
+      snprintf(&buf[0], sizeof(buf), "%s/.pgagroal", pgagroal_get_home_directory());
 
-   if (stat(&buf[0], &st) == -1)
-   {
-      goto error;
-   }
-   else
-   {
-      if (S_ISREG(st.st_mode) && st.st_mode & (S_IRUSR | S_IWUSR) && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
-      {
-         /* Ok */
-      }
-      else
+      if (stat(&buf[0], &st) == -1)
       {
          goto error;
       }
+      else
+      {
+         if (S_ISDIR(st.st_mode) && st.st_mode & S_IRWXU && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
+         {
+            /* Ok */
+         }
+         else
+         {
+            goto error;
+         }
+      }
+
+      memset(&buf, 0, sizeof(buf));
+      snprintf(&buf[0], sizeof(buf), "%s/.pgagroal/master.key", pgagroal_get_home_directory());
+
+      if (stat(&buf[0], &st) == -1)
+      {
+         goto error;
+      }
+      else
+      {
+         if (S_ISREG(st.st_mode) && st.st_mode & (S_IRUSR | S_IWUSR) && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
+         {
+            /* Ok */
+         }
+         else
+         {
+            goto error;
+         }
+      }
+      master_key_file = fopen(&buf[0], "r");
+
+
    }
 
-   master_key_file = fopen(&buf[0], "r");
+   else
+   {
+      master_key_file = fopen(&buffer[0], "r");
+      free(buffer);
+
+   }
+
+   
    if (master_key_file == NULL)
    {
       goto error;
@@ -3233,6 +3277,7 @@ pgagroal_get_master_key(char** masterkey)
    {
       goto error;
    }
+
 
    pgagroal_base64_decode(&line[0], strlen(&line[0]), &mk, &mk_length);
 


### PR DESCRIPTION
Added the filename attribute to master-key generation.
To tackle the multiple uses of file in various location, stored the location of the file in a text file.