### PR TITLE
Fix exit status when parsing error occurs in pgagroal-cli

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -686,6 +686,7 @@ main(int argc, char** argv)
    if (!parse_command(argc, argv, optind, &parsed, command_table, command_count))
    {
       usage();
+      exit_code = 1;
       goto done;
    }
    pgagroal_log_trace((char*)parsed.cmd->log_message, parsed.args[0], parsed.args[1]);


### PR DESCRIPTION
While experimenting in https://github.com/agroal/pgagroal/pull/427, I found out that `pgagroal-cli` returns an exit status of 0, indicating success to the caller, if a command parsing error occurs.

This commit resolves the issue by setting `exit_error = 1;` after a parsing error, ensuring it properly returns the correct error status to the caller.

Notice that the same does not occur with `pgagroal-admin` (it has a different way of handling errors -- `goto error`, while `pgagroal-cli` goes to the same label  --`done`).
