### PR TITLE
Issue#419 Allow pgagroal-admin to specify where to store the master key password file

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -57,6 +57,7 @@
 #define ACTION_REMOVE_USER 4
 #define ACTION_LIST_USERS  5
 
+
 static char CHARS[] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
                        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
                        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
@@ -69,6 +70,7 @@ static int update_user(char* users_path, char* username, char* password, bool ge
 static int remove_user(char* users_path, char* username);
 static int list_users(char* users_path);
 static char* generate_password(int pwd_length);
+
 
 const struct pgagroal_command command_table[] =
 {
@@ -158,6 +160,7 @@ const struct pgagroal_command command_table[] =
    },
 };
 
+
 static void
 version(void)
 {
@@ -188,11 +191,7 @@ usage(void)
    printf("  -?, --help              Display help\n");
    printf("\n");
    printf("Commands:\n");
-<<<<<<< HEAD
-   printf("  master-key <filename>   Create or update the master key\n");
-=======
    printf("  master-key              Create or update the master key\n");
->>>>>>> a9dc5ea (Added master key file location in pgagroal.conf)
    printf("  user <subcommand>       Manage a specific user, where <subcommand> can be\n");
    printf("                          - add  to add a new user\n");
    printf("                          - del  to remove an existing user\n");
@@ -205,9 +204,6 @@ usage(void)
 
 int
 main(int argc, char** argv)
-<<<<<<< HEAD
-{
-=======
 { 
    struct configuration* config = NULL;
    char* configuration_path = NULL;
@@ -215,7 +211,6 @@ main(int argc, char** argv)
    bool remote_connection = false;
    size_t size;
    int ret;   
->>>>>>> a9dc5ea (Added master key file location in pgagroal.conf)
    int c;
    char* username = NULL;
    char* password = NULL;
@@ -338,6 +333,7 @@ else
       }
    }
 
+
    if (!parse_command(argc, argv, optind, &parsed, command_table, command_count))
    {
       usage();
@@ -403,60 +399,48 @@ error:
 }
 
 static int
-<<<<<<< HEAD
-master_key(char* password, bool generate_pwd, int pwd_length, char* filename)
-{
-=======
 master_key(char* password, bool generate_pwd, int pwd_length, char* foldername)
 {  
->>>>>>> a9dc5ea (Added master key file location in pgagroal.conf)
    FILE* file = NULL;
    char buf[MISC_LENGTH];
    char* encoded = NULL;
    struct stat st = {0};
    bool do_free = true;
-   if(filename == NULL)
+
+   if (pgagroal_get_home_directory() == NULL)
    {
-      if (pgagroal_get_home_directory() == NULL)
+      char* username = pgagroal_get_user_name();
+
+      if (username != NULL)
       {
-         char* username = pgagroal_get_user_name();
-
-         if (username != NULL)
-         {
-            warnx("No home directory for user \'%s\'", username);
-         }
-         else
-         {
-            warnx("No home directory for user running pgagroal");
-         }
-
-         goto error;
-      }
-<<<<<<< HEAD
-
-      memset(&buf, 0, sizeof(buf));
-      snprintf(&buf[0], sizeof(buf), "%s/.pgagroal", pgagroal_get_home_directory());
-
-      if (stat(&buf[0], &st) == -1)
-      {
-         mkdir(&buf[0], S_IRWXU);
+         warnx("No home directory for user \'%s\'", username);
       }
       else
       {
-         if (S_ISDIR(st.st_mode) && st.st_mode & S_IRWXU && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
-         {
-            /* Ok */
-         }
-         else
-         {
-            warnx("Wrong permissions for directory <%s> (must be 0700)", &buf[0]);
-            goto error;
-         }
+         warnx("No home directory for user running pgagroal");
       }
 
-      memset(&buf, 0, sizeof(buf));
-      snprintf(&buf[0], sizeof(buf), "%s/.pgagroal/master.key", pgagroal_get_home_directory());
-=======
+      goto error;
+   }
+
+   memset(&buf, 0, sizeof(buf));
+   snprintf(&buf[0], sizeof(buf), "%s/.pgagroal", pgagroal_get_home_directory());
+
+   if (stat(&buf[0], &st) == -1)
+   {
+      mkdir(&buf[0], S_IRWXU);
+   }
+   else
+   {
+      if (S_ISDIR(st.st_mode) && st.st_mode & S_IRWXU && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
+      {
+         /* Ok */
+      }
+      else
+      {
+         warnx("Wrong permissions for directory <%s> (must be 0700)", &buf[0]);
+         goto error;
+      }
    }
    if(foldername==NULL){
       memset(&buf, 0, sizeof(buf));
@@ -472,67 +456,25 @@ master_key(char* password, bool generate_pwd, int pwd_length, char* foldername)
       warnx("The file ~/.pgexporter/master.key already exists");
       goto error;
    }
->>>>>>> a9dc5ea (Added master key file location in pgagroal.conf)
 
-      if (pgagroal_exists(&buf[0]))
-      {
-         warnx("The file ~/.pgexporter/master.key already exists");
-         goto error;
-      }
-
-      if (stat(&buf[0], &st) == -1)
-      {
-         /* Ok */
-      }
-      else
-      {
-         if (S_ISREG(st.st_mode) && st.st_mode & (S_IRUSR | S_IWUSR) && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
-         {
-            /* Ok */
-         }
-         else
-         {
-            warnx("Wrong permissions for file <%s> (must be 0600)", &buf[0]);
-            goto error;
-         }
-      }
-   }
-
-   if(filename != NULL)
+   if (stat(&buf[0], &st) == -1)
    {
-   snprintf(&buf[0], sizeof(buf), "%s", filename);
-   if (pgagroal_exists(&buf[0]))
-      {
-         warnx("The file ~/.pgexporter/master.key already exists");
-         goto error;
-      }
-
-      if (stat(&buf[0], &st) == -1)
+      /* Ok */
+   }
+   else
+   {
+      if (S_ISREG(st.st_mode) && st.st_mode & (S_IRUSR | S_IWUSR) && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
       {
          /* Ok */
       }
       else
       {
-         if (S_ISREG(st.st_mode) && st.st_mode & (S_IRUSR | S_IWUSR) && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
-         {
-            /* Ok */
-         }
-         else
-         {
-            warnx("Wrong permissions for file <%s> (must be 0600)", &buf[0]);
-            goto error;
-         }
+         warnx("Wrong permissions for file <%s> (must be 0600)", &buf[0]);
+         goto error;
       }
-
-      file = fopen(filename, "w+");
    }
 
-   else{
-      file = fopen(&buf[0], "w+");
-
-   }
-
-
+   file = fopen(&buf[0], "w+");
    if (file == NULL)
    {
       warnx("Could not write to master key file <%s>", &buf[0]);

--- a/src/admin.c
+++ b/src/admin.c
@@ -61,7 +61,7 @@ static char CHARS[] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L
                        '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '-', '_', '=', '+', '[', '{', ']', '}', '\\', '|', ';', ':',
                        '\'', '\"', ',', '<', '.', '>', '/', '?'};
 
-static int master_key(char* password, bool generate_pwd, int pwd_length);
+static int master_key(char* password, bool generate_pwd, int pwd_length, char* filename);
 static int add_user(char* users_path, char* username, char* password, bool generate_pwd, int pwd_length);
 static int update_user(char* users_path, char* username, char* password, bool generate_pwd, int pwd_length);
 static int remove_user(char* users_path, char* username);
@@ -73,7 +73,7 @@ const struct pgagroal_command command_table[] =
    {
       .command = "master-key",
       .subcommand = "",
-      .accepted_argument_count = {0},
+      .accepted_argument_count = {0, 1},
       .deprecated = false,
       .action = ACTION_MASTER_KEY,
       .log_message = "<master-key>",
@@ -184,7 +184,7 @@ usage(void)
    printf("  -?, --help              Display help\n");
    printf("\n");
    printf("Commands:\n");
-   printf("  master-key              Create or update the master key\n");
+   printf("  master-key <filename>   Create or update the master key\n");
    printf("  user <subcommand>       Manage a specific user, where <subcommand> can be\n");
    printf("                          - add  to add a new user\n");
    printf("                          - del  to remove an existing user\n");
@@ -283,7 +283,7 @@ main(int argc, char** argv)
 
    if (parsed.cmd->action == ACTION_MASTER_KEY)
    {
-      if (master_key(password, generate_pwd, pwd_length))
+      if (master_key(password, generate_pwd, pwd_length, parsed.args[0]))
       {
          errx(1, "Cannot generate master key");
       }
@@ -328,77 +328,113 @@ error:
 }
 
 static int
-master_key(char* password, bool generate_pwd, int pwd_length)
+master_key(char* password, bool generate_pwd, int pwd_length, char* filename)
 {
    FILE* file = NULL;
    char buf[MISC_LENGTH];
    char* encoded = NULL;
    struct stat st = {0};
    bool do_free = true;
-
-   if (pgagroal_get_home_directory() == NULL)
+   if(filename == NULL)
    {
-      char* username = pgagroal_get_user_name();
-
-      if (username != NULL)
+      if (pgagroal_get_home_directory() == NULL)
       {
-         warnx("No home directory for user \'%s\'", username);
+         char* username = pgagroal_get_user_name();
+
+         if (username != NULL)
+         {
+            warnx("No home directory for user \'%s\'", username);
+         }
+         else
+         {
+            warnx("No home directory for user running pgagroal");
+         }
+
+         goto error;
+      }
+
+      memset(&buf, 0, sizeof(buf));
+      snprintf(&buf[0], sizeof(buf), "%s/.pgagroal", pgagroal_get_home_directory());
+
+      if (stat(&buf[0], &st) == -1)
+      {
+         mkdir(&buf[0], S_IRWXU);
       }
       else
       {
-         warnx("No home directory for user running pgagroal");
+         if (S_ISDIR(st.st_mode) && st.st_mode & S_IRWXU && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
+         {
+            /* Ok */
+         }
+         else
+         {
+            warnx("Wrong permissions for directory <%s> (must be 0700)", &buf[0]);
+            goto error;
+         }
       }
 
-      goto error;
-   }
+      memset(&buf, 0, sizeof(buf));
+      snprintf(&buf[0], sizeof(buf), "%s/.pgagroal/master.key", pgagroal_get_home_directory());
 
-   memset(&buf, 0, sizeof(buf));
-   snprintf(&buf[0], sizeof(buf), "%s/.pgagroal", pgagroal_get_home_directory());
+      if (pgagroal_exists(&buf[0]))
+      {
+         warnx("The file ~/.pgexporter/master.key already exists");
+         goto error;
+      }
 
-   if (stat(&buf[0], &st) == -1)
-   {
-      mkdir(&buf[0], S_IRWXU);
-   }
-   else
-   {
-      if (S_ISDIR(st.st_mode) && st.st_mode & S_IRWXU && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
+      if (stat(&buf[0], &st) == -1)
       {
          /* Ok */
       }
       else
       {
-         warnx("Wrong permissions for directory <%s> (must be 0700)", &buf[0]);
-         goto error;
+         if (S_ISREG(st.st_mode) && st.st_mode & (S_IRUSR | S_IWUSR) && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
+         {
+            /* Ok */
+         }
+         else
+         {
+            warnx("Wrong permissions for file <%s> (must be 0600)", &buf[0]);
+            goto error;
+         }
       }
    }
 
-   memset(&buf, 0, sizeof(buf));
-   snprintf(&buf[0], sizeof(buf), "%s/.pgagroal/master.key", pgagroal_get_home_directory());
-
+   if(filename != NULL)
+   {
+   snprintf(&buf[0], sizeof(buf), "%s", filename);
    if (pgagroal_exists(&buf[0]))
-   {
-      warnx("The file ~/.pgexporter/master.key already exists");
-      goto error;
-   }
+      {
+         warnx("The file ~/.pgexporter/master.key already exists");
+         goto error;
+      }
 
-   if (stat(&buf[0], &st) == -1)
-   {
-      /* Ok */
-   }
-   else
-   {
-      if (S_ISREG(st.st_mode) && st.st_mode & (S_IRUSR | S_IWUSR) && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
+      if (stat(&buf[0], &st) == -1)
       {
          /* Ok */
       }
       else
       {
-         warnx("Wrong permissions for file <%s> (must be 0600)", &buf[0]);
-         goto error;
+         if (S_ISREG(st.st_mode) && st.st_mode & (S_IRUSR | S_IWUSR) && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
+         {
+            /* Ok */
+         }
+         else
+         {
+            warnx("Wrong permissions for file <%s> (must be 0600)", &buf[0]);
+            goto error;
+         }
       }
+
+      file = fopen(filename, "w+");
    }
 
-   file = fopen(&buf[0], "w+");
+   else{
+      file = fopen(&buf[0], "w+");
+
+   }
+
+
    if (file == NULL)
    {
       warnx("Could not write to master key file <%s>", &buf[0]);

--- a/src/admin.c
+++ b/src/admin.c
@@ -44,6 +44,8 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <err.h>
+#include <shmem.h>
+#include <configuration.h>
 
 #define DEFAULT_PASSWORD_LENGTH 64
 #define MIN_PASSWORD_LENGTH 8
@@ -61,9 +63,9 @@ static char CHARS[] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L
                        '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '-', '_', '=', '+', '[', '{', ']', '}', '\\', '|', ';', ':',
                        '\'', '\"', ',', '<', '.', '>', '/', '?'};
 
-static int master_key(char* password, bool generate_pwd, int pwd_length, char* filename);
-static int add_user(char* users_path, char* username, char* password, bool generate_pwd, int pwd_length);
-static int update_user(char* users_path, char* username, char* password, bool generate_pwd, int pwd_length);
+static int master_key(char* password, bool generate_pwd, int pwd_length, char* foldername);
+static int add_user(char* users_path, char* username, char* password, bool generate_pwd, int pwd_length, char* foldername);
+static int update_user(char* users_path, char* username, char* password, bool generate_pwd, int pwd_length, char* foldername);
 static int remove_user(char* users_path, char* username);
 static int list_users(char* users_path);
 static char* generate_password(int pwd_length);
@@ -73,7 +75,7 @@ const struct pgagroal_command command_table[] =
    {
       .command = "master-key",
       .subcommand = "",
-      .accepted_argument_count = {0, 1},
+      .accepted_argument_count = {0},
       .deprecated = false,
       .action = ACTION_MASTER_KEY,
       .log_message = "<master-key>",
@@ -174,6 +176,8 @@ usage(void)
    printf("  pgagroal-admin [ -f FILE ] [ COMMAND ] \n");
    printf("\n");
    printf("Options:\n");
+   printf("  -c, --config CONFIG_FILE Set the path to the pgagroal.conf file\n");
+   printf("                           Default: %s\n", PGAGROAL_DEFAULT_CONF_FILE);
    printf("  -f, --file FILE         Set the path to a user file\n");
    printf("                          Defaults to %s\n", PGAGROAL_DEFAULT_USERS_FILE);
    printf("  -U, --user USER         Set the user name\n");
@@ -184,7 +188,11 @@ usage(void)
    printf("  -?, --help              Display help\n");
    printf("\n");
    printf("Commands:\n");
+<<<<<<< HEAD
    printf("  master-key <filename>   Create or update the master key\n");
+=======
+   printf("  master-key              Create or update the master key\n");
+>>>>>>> a9dc5ea (Added master key file location in pgagroal.conf)
    printf("  user <subcommand>       Manage a specific user, where <subcommand> can be\n");
    printf("                          - add  to add a new user\n");
    printf("                          - del  to remove an existing user\n");
@@ -197,7 +205,17 @@ usage(void)
 
 int
 main(int argc, char** argv)
+<<<<<<< HEAD
 {
+=======
+{ 
+   struct configuration* config = NULL;
+   char* configuration_path = NULL;
+   char* logfile = NULL;
+   bool remote_connection = false;
+   size_t size;
+   int ret;   
+>>>>>>> a9dc5ea (Added master key file location in pgagroal.conf)
    int c;
    char* username = NULL;
    char* password = NULL;
@@ -212,6 +230,7 @@ main(int argc, char** argv)
    {
       static struct option long_options[] =
       {
+         {"config", required_argument, 0, 'c'},
          {"user", required_argument, 0, 'U'},
          {"password", required_argument, 0, 'P'},
          {"file", required_argument, 0, 'f'},
@@ -221,7 +240,7 @@ main(int argc, char** argv)
          {"help", no_argument, 0, '?'}
       };
 
-      c = getopt_long(argc, argv, "gV?f:U:P:l:",
+      c = getopt_long(argc, argv, "gV?c:f:U:P:l:",
                       long_options, &option_index);
 
       if (c == -1)
@@ -231,6 +250,9 @@ main(int argc, char** argv)
 
       switch (c)
       {
+         case 'c':
+            configuration_path = optarg;
+            break;
          case 'U':
             username = optarg;
             break;
@@ -262,6 +284,59 @@ main(int argc, char** argv)
    {
       errx(1, "Using the root account is not allowed");
    }
+      
+   size = sizeof(struct configuration);
+   if (pgagroal_create_shared_memory(size, HUGEPAGE_OFF, &shmem))
+   {
+      errx(1, "Error creating shared memory");
+   }
+   pgagroal_init_configuration(shmem);
+
+   if (configuration_path != NULL)
+   {
+      ret = pgagroal_read_configuration(shmem, configuration_path, false);
+      if (ret == PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND)
+      {
+         errx(1, "Configuration not found: <%s>", configuration_path);
+      }
+      else if (ret == PGAGROAL_CONFIGURATION_STATUS_FILE_TOO_BIG)
+      {
+         errx(1, "Too many sections in the configuration file <%s>", configuration_path);
+      }
+
+      config = (struct configuration*)shmem;
+   }
+else
+   {
+      ret = pgagroal_read_configuration(shmem, PGAGROAL_DEFAULT_CONF_FILE, false);
+      if (ret != PGAGROAL_CONFIGURATION_STATUS_OK)
+      {
+         if (!remote_connection)
+         {
+            errx(1, "Host (-h) and port (-p) must be specified to connect to the remote host");
+         }
+      }
+      else
+      {
+         configuration_path = PGAGROAL_DEFAULT_CONF_FILE;
+
+         if (logfile)
+         {
+            config = (struct configuration*)shmem;
+
+            config->log_type = PGAGROAL_LOGGING_TYPE_FILE;
+            memset(&config->log_path[0], 0, MISC_LENGTH);
+            memcpy(&config->log_path[0], logfile, MIN(MISC_LENGTH - 1, strlen(logfile)));
+         }
+
+         if (pgagroal_start_logging())
+         {
+            errx(1, "Cannot start the logging subsystem");
+         }
+
+         config = (struct configuration*)shmem;
+      }
+   }
 
    if (!parse_command(argc, argv, optind, &parsed, command_table, command_count))
    {
@@ -283,21 +358,21 @@ main(int argc, char** argv)
 
    if (parsed.cmd->action == ACTION_MASTER_KEY)
    {
-      if (master_key(password, generate_pwd, pwd_length, parsed.args[0]))
+      if (master_key(password, generate_pwd, pwd_length, config->master_key_file_location))
       {
          errx(1, "Cannot generate master key");
       }
    }
    else if (parsed.cmd->action == ACTION_ADD_USER)
    {
-      if (add_user(file_path, username, password, generate_pwd, pwd_length))
+      if (add_user(file_path, username, password, generate_pwd, pwd_length, config->master_key_file_location))
       {
          errx(1, "Error for <user add>");
       }
    }
    else if (parsed.cmd->action == ACTION_UPDATE_USER)
    {
-      if (update_user(file_path, username, password, generate_pwd, pwd_length))
+      if (update_user(file_path, username, password, generate_pwd, pwd_length, config->master_key_file_location))
       {
          errx(1, "Error for <user edit>");
       }
@@ -328,8 +403,13 @@ error:
 }
 
 static int
+<<<<<<< HEAD
 master_key(char* password, bool generate_pwd, int pwd_length, char* filename)
 {
+=======
+master_key(char* password, bool generate_pwd, int pwd_length, char* foldername)
+{  
+>>>>>>> a9dc5ea (Added master key file location in pgagroal.conf)
    FILE* file = NULL;
    char buf[MISC_LENGTH];
    char* encoded = NULL;
@@ -352,6 +432,7 @@ master_key(char* password, bool generate_pwd, int pwd_length, char* filename)
 
          goto error;
       }
+<<<<<<< HEAD
 
       memset(&buf, 0, sizeof(buf));
       snprintf(&buf[0], sizeof(buf), "%s/.pgagroal", pgagroal_get_home_directory());
@@ -375,6 +456,23 @@ master_key(char* password, bool generate_pwd, int pwd_length, char* filename)
 
       memset(&buf, 0, sizeof(buf));
       snprintf(&buf[0], sizeof(buf), "%s/.pgagroal/master.key", pgagroal_get_home_directory());
+=======
+   }
+   if(foldername==NULL){
+      memset(&buf, 0, sizeof(buf));
+      snprintf(&buf[0], sizeof(buf), "%s/.pgagroal/master.key", pgagroal_get_home_directory());
+   }
+   else{
+      memset(&buf, 0, sizeof(buf));
+      snprintf(&buf[0], sizeof(buf), "%s", foldername);
+   }
+   
+   if (pgagroal_exists(&buf[0]))
+   {
+      warnx("The file ~/.pgexporter/master.key already exists");
+      goto error;
+   }
+>>>>>>> a9dc5ea (Added master key file location in pgagroal.conf)
 
       if (pgagroal_exists(&buf[0]))
       {
@@ -503,7 +601,7 @@ error:
 }
 
 static int
-add_user(char* users_path, char* username, char* password, bool generate_pwd, int pwd_length)
+add_user(char* users_path, char* username, char* password, bool generate_pwd, int pwd_length, char* foldername)
 {
    FILE* users_file = NULL;
    char line[MISC_LENGTH];
@@ -519,7 +617,7 @@ add_user(char* users_path, char* username, char* password, bool generate_pwd, in
    char* verify = NULL;
    bool do_free = true;
 
-   if (pgagroal_get_master_key(&master_key))
+   if (pgagroal_get_master_key(&master_key, foldername))
    {
       warnx("Invalid master key");
       goto error;
@@ -674,7 +772,7 @@ error:
 }
 
 static int
-update_user(char* users_path, char* username, char* password, bool generate_pwd, int pwd_length)
+update_user(char* users_path, char* username, char* password, bool generate_pwd, int pwd_length, char* foldername)
 {
    FILE* users_file = NULL;
    FILE* users_file_tmp = NULL;
@@ -695,7 +793,7 @@ update_user(char* users_path, char* username, char* password, bool generate_pwd,
 
    memset(&tmpfilename, 0, sizeof(tmpfilename));
 
-   if (pgagroal_get_master_key(&master_key))
+   if (pgagroal_get_master_key(&master_key, foldername))
    {
       warnx("Invalid master key");
       goto error;

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -477,6 +477,7 @@ struct configuration
    bool track_prepared_statements; /**< Track prepared statements (transaction pooling) */
 
    char unix_socket_dir[MISC_LENGTH]; /**< The directory for the Unix Domain Socket */
+   char master_key_file_location[MISC_LENGTH]; /**< The directory for the MasterKey */
 
    atomic_schar su_connection; /**< The superuser connection */
 

--- a/src/include/security.h
+++ b/src/include/security.h
@@ -90,7 +90,7 @@ pgagroal_remote_management_scram_sha256(char* username, char* password, int serv
  * @return 0 upon success, otherwise 1
  */
 int
-pgagroal_get_master_key(char** masterkey);
+pgagroal_get_master_key(char** masterkey, char* foldername);
 
 /**
  * Encrypt a string

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -1031,14 +1031,16 @@ pgagroal_read_users_configuration(void* shm, char* filename)
       goto error;
    }
 
-   if (pgagroal_get_master_key(&master_key))
+   config = (struct configuration*)shm;
+
+
+   if (pgagroal_get_master_key(&master_key, config->master_key_file_location))
    {
       status = PGAGROAL_CONFIGURATION_STATUS_KO;
       goto error;
    }
 
    index = 0;
-   config = (struct configuration*)shm;
 
    while (fgets(line, sizeof(line), file))
    {
@@ -1152,15 +1154,15 @@ pgagroal_read_frontend_users_configuration(void* shm, char* filename)
       status = PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND;
       goto error;
    }
+   config = (struct configuration*)shm;
 
-   if (pgagroal_get_master_key(&master_key))
+   if (pgagroal_get_master_key(&master_key, config->master_key_file_location))
    {
       status = PGAGROAL_CONFIGURATION_STATUS_KO;
       goto error;
    }
 
    index = 0;
-   config = (struct configuration*)shm;
 
    while (fgets(line, sizeof(line), file))
    {
@@ -1299,15 +1301,15 @@ pgagroal_read_admins_configuration(void* shm, char* filename)
       status = PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND;
       goto error;
    }
+   config = (struct configuration*)shm;
 
-   if (pgagroal_get_master_key(&master_key))
+   if (pgagroal_get_master_key(&master_key, config->master_key_file_location))
    {
       status = PGAGROAL_CONFIGURATION_STATUS_KO;
       goto error;
    }
 
    index = 0;
-   config = (struct configuration*)shm;
 
    while (fgets(line, sizeof(line), file))
    {
@@ -1427,15 +1429,15 @@ pgagroal_read_superuser_configuration(void* shm, char* filename)
       status = PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND;
       goto error;
    }
+   config = (struct configuration*)shm;
 
-   if (pgagroal_get_master_key(&master_key))
+   if (pgagroal_get_master_key(&master_key, config->master_key_file_location))
    {
       status = PGAGROAL_CONFIGURATION_STATUS_KO;
       goto error;
    }
 
    index = 0;
-   config = (struct configuration*)shm;
 
    while (fgets(line, sizeof(line), file))
    {
@@ -4189,6 +4191,15 @@ pgagroal_apply_main_configuration(struct configuration* config,
          max = MISC_LENGTH - 1;
       }
       memcpy(config->unix_socket_dir, value, max);
+   }
+   else if (key_in_section("master_key_file_location", section, key, true, &unknown))
+   {
+      max = strlen(value);
+      if (max > MISC_LENGTH - 1)
+      {
+         max = MISC_LENGTH - 1;
+      }
+      memcpy(config->master_key_file_location, value, max);
    }
    else if (key_in_section("libev", section, key, true, &unknown))
    {

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -3170,13 +3170,8 @@ get_salt(void* data, char** salt)
 }
 
 int
-<<<<<<< HEAD
-pgagroal_get_master_key(char** masterkey)
-{
-=======
 pgagroal_get_master_key(char** masterkey, char* foldername)
 {   
->>>>>>> a9dc5ea (Added master key file location in pgagroal.conf)
    FILE* master_key_file = NULL;
    char buf[MISC_LENGTH];
    char line[MISC_LENGTH];
@@ -3184,11 +3179,6 @@ pgagroal_get_master_key(char** masterkey, char* foldername)
    int mk_length = 0;
    struct stat st = {0};
 
-<<<<<<< HEAD
-   if (pgagroal_get_home_directory() == NULL)
-   {
-      goto error;
-=======
    if(foldername == NULL){
       if (pgagroal_get_home_directory() == NULL)
       {
@@ -3235,52 +3225,14 @@ pgagroal_get_master_key(char** masterkey, char* foldername)
       master_key_file = fopen(&buf[0], "r");
 
 
->>>>>>> a9dc5ea (Added master key file location in pgagroal.conf)
    }
 
-   memset(&buf, 0, sizeof(buf));
-   snprintf(&buf[0], sizeof(buf), "%s/.pgagroal", pgagroal_get_home_directory());
-
-   if (stat(&buf[0], &st) == -1)
-   {
-      goto error;
-   }
    else
    {
-<<<<<<< HEAD
-      if (S_ISDIR(st.st_mode) && st.st_mode & S_IRWXU && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
-      {
-         /* Ok */
-      }
-      else
-      {
-         goto error;
-      }
-=======
       master_key_file = fopen(foldername, "r");
->>>>>>> a9dc5ea (Added master key file location in pgagroal.conf)
    }
 
-   memset(&buf, 0, sizeof(buf));
-   snprintf(&buf[0], sizeof(buf), "%s/.pgagroal/master.key", pgagroal_get_home_directory());
-
-   if (stat(&buf[0], &st) == -1)
-   {
-      goto error;
-   }
-   else
-   {
-      if (S_ISREG(st.st_mode) && st.st_mode & (S_IRUSR | S_IWUSR) && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
-      {
-         /* Ok */
-      }
-      else
-      {
-         goto error;
-      }
-   }
-
-   master_key_file = fopen(&buf[0], "r");
+   
    if (master_key_file == NULL)
    {
       goto error;
@@ -3291,6 +3243,7 @@ pgagroal_get_master_key(char** masterkey, char* foldername)
    {
       goto error;
    }
+
 
    pgagroal_base64_decode(&line[0], strlen(&line[0]), &mk, &mk_length);
 

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -3170,8 +3170,13 @@ get_salt(void* data, char** salt)
 }
 
 int
+<<<<<<< HEAD
 pgagroal_get_master_key(char** masterkey)
 {
+=======
+pgagroal_get_master_key(char** masterkey, char* foldername)
+{   
+>>>>>>> a9dc5ea (Added master key file location in pgagroal.conf)
    FILE* master_key_file = NULL;
    char buf[MISC_LENGTH];
    char line[MISC_LENGTH];
@@ -3179,9 +3184,58 @@ pgagroal_get_master_key(char** masterkey)
    int mk_length = 0;
    struct stat st = {0};
 
+<<<<<<< HEAD
    if (pgagroal_get_home_directory() == NULL)
    {
       goto error;
+=======
+   if(foldername == NULL){
+      if (pgagroal_get_home_directory() == NULL)
+      {
+         goto error;
+      }
+
+      memset(&buf, 0, sizeof(buf));
+      snprintf(&buf[0], sizeof(buf), "%s/.pgagroal", pgagroal_get_home_directory());
+
+      if (stat(&buf[0], &st) == -1)
+      {
+         goto error;
+      }
+      else
+      {
+         if (S_ISDIR(st.st_mode) && st.st_mode & S_IRWXU && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
+         {
+            /* Ok */
+         }
+         else
+         {
+            goto error;
+         }
+      }
+
+      memset(&buf, 0, sizeof(buf));
+      snprintf(&buf[0], sizeof(buf), "%s/.pgagroal/master.key", pgagroal_get_home_directory());
+
+      if (stat(&buf[0], &st) == -1)
+      {
+         goto error;
+      }
+      else
+      {
+         if (S_ISREG(st.st_mode) && st.st_mode & (S_IRUSR | S_IWUSR) && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
+         {
+            /* Ok */
+         }
+         else
+         {
+            goto error;
+         }
+      }
+      master_key_file = fopen(&buf[0], "r");
+
+
+>>>>>>> a9dc5ea (Added master key file location in pgagroal.conf)
    }
 
    memset(&buf, 0, sizeof(buf));
@@ -3193,6 +3247,7 @@ pgagroal_get_master_key(char** masterkey)
    }
    else
    {
+<<<<<<< HEAD
       if (S_ISDIR(st.st_mode) && st.st_mode & S_IRWXU && !(st.st_mode & S_IRWXG) && !(st.st_mode & S_IRWXO))
       {
          /* Ok */
@@ -3201,6 +3256,9 @@ pgagroal_get_master_key(char** masterkey)
       {
          goto error;
       }
+=======
+      master_key_file = fopen(foldername, "r");
+>>>>>>> a9dc5ea (Added master key file location in pgagroal.conf)
    }
 
    memset(&buf, 0, sizeof(buf));

--- a/src/libpgagroal/utils.c
+++ b/src/libpgagroal/utils.c
@@ -564,7 +564,7 @@ pgagroal_libev_engine(unsigned int val)
 
 char*
 pgagroal_get_home_directory(void)
-{
+{   
    struct passwd* pw = getpwuid(getuid());
 
    if (pw == NULL)


### PR DESCRIPTION
Added the master_key_file location in configuration file. 
The ./pgagoral-admin -c conf file location -g master-key is to be used to generate the master key.
The pgagroal.conf file location should be modified in order to change the master key location.
master_key_file_location = desired location

@fluca1978 @jesperpedersen
