### PR TITLE
Issue#419 Allow pgagroal-admin to specify where to store the master key password file

### DIFF
--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -477,6 +477,7 @@ struct configuration
    bool track_prepared_statements; /**< Track prepared statements (transaction pooling) */
 
    char unix_socket_dir[MISC_LENGTH]; /**< The directory for the Unix Domain Socket */
+   char master_key_file_location[MISC_LENGTH]; /**< The directory for the MasterKey */
 
    atomic_schar su_connection; /**< The superuser connection */
 

--- a/src/include/security.h
+++ b/src/include/security.h
@@ -90,7 +90,7 @@ pgagroal_remote_management_scram_sha256(char* username, char* password, int serv
  * @return 0 upon success, otherwise 1
  */
 int
-pgagroal_get_master_key(char** masterkey);
+pgagroal_get_master_key(char** masterkey, char* foldername);
 
 /**
  * Encrypt a string

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -1031,14 +1031,16 @@ pgagroal_read_users_configuration(void* shm, char* filename)
       goto error;
    }
 
-   if (pgagroal_get_master_key(&master_key))
+   config = (struct configuration*)shm;
+
+
+   if (pgagroal_get_master_key(&master_key, config->master_key_file_location))
    {
       status = PGAGROAL_CONFIGURATION_STATUS_KO;
       goto error;
    }
 
    index = 0;
-   config = (struct configuration*)shm;
 
    while (fgets(line, sizeof(line), file))
    {
@@ -1152,15 +1154,15 @@ pgagroal_read_frontend_users_configuration(void* shm, char* filename)
       status = PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND;
       goto error;
    }
+   config = (struct configuration*)shm;
 
-   if (pgagroal_get_master_key(&master_key))
+   if (pgagroal_get_master_key(&master_key, config->master_key_file_location))
    {
       status = PGAGROAL_CONFIGURATION_STATUS_KO;
       goto error;
    }
 
    index = 0;
-   config = (struct configuration*)shm;
 
    while (fgets(line, sizeof(line), file))
    {
@@ -1299,15 +1301,15 @@ pgagroal_read_admins_configuration(void* shm, char* filename)
       status = PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND;
       goto error;
    }
+   config = (struct configuration*)shm;
 
-   if (pgagroal_get_master_key(&master_key))
+   if (pgagroal_get_master_key(&master_key, config->master_key_file_location))
    {
       status = PGAGROAL_CONFIGURATION_STATUS_KO;
       goto error;
    }
 
    index = 0;
-   config = (struct configuration*)shm;
 
    while (fgets(line, sizeof(line), file))
    {
@@ -1427,15 +1429,15 @@ pgagroal_read_superuser_configuration(void* shm, char* filename)
       status = PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND;
       goto error;
    }
+   config = (struct configuration*)shm;
 
-   if (pgagroal_get_master_key(&master_key))
+   if (pgagroal_get_master_key(&master_key, config->master_key_file_location))
    {
       status = PGAGROAL_CONFIGURATION_STATUS_KO;
       goto error;
    }
 
    index = 0;
-   config = (struct configuration*)shm;
 
    while (fgets(line, sizeof(line), file))
    {
@@ -4189,6 +4191,15 @@ pgagroal_apply_main_configuration(struct configuration* config,
          max = MISC_LENGTH - 1;
       }
       memcpy(config->unix_socket_dir, value, max);
+   }
+   else if (key_in_section("master_key_file_location", section, key, true, &unknown))
+   {
+      max = strlen(value);
+      if (max > MISC_LENGTH - 1)
+      {
+         max = MISC_LENGTH - 1;
+      }
+      memcpy(config->master_key_file_location, value, max);
    }
    else if (key_in_section("libev", section, key, true, &unknown))
    {

--- a/src/libpgagroal/utils.c
+++ b/src/libpgagroal/utils.c
@@ -564,7 +564,7 @@ pgagroal_libev_engine(unsigned int val)
 
 char*
 pgagroal_get_home_directory(void)
-{
+{   
    struct passwd* pw = getpwuid(getuid());
 
    if (pw == NULL)


### PR DESCRIPTION
Added the master_key_file location in configuration file.
The ./pgagoral-admin -c conf file location -g master-key is to be used to generate the master key.
The pgagroal.conf file location should be modified in order to change the master key location.
master_key_file_location = desired location

@fluca1978 @jesperpedersen 