### PR TITLE
Adding filename to master key generation Issue #419

### DIFF
--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -179,14 +179,14 @@ extern "C" {
 #define unlikely(x)  __builtin_expect (!!(x), 0)
 
 #define MAX(a, b)            \
-({ __typeof__ (a) _a = (a);  \
-   __typeof__ (b) _b = (b);  \
-   _a > _b ? _a : _b; })
+        ({ __typeof__ (a) _a = (a);  \
+           __typeof__ (b) _b = (b);  \
+           _a > _b ? _a : _b; })
 
 #define MIN(a, b)            \
-({ __typeof__ (a) _a = (a);  \
-   __typeof__ (b) _b = (b);  \
-   _a < _b ? _a : _b; })
+        ({ __typeof__ (a) _a = (a);  \
+           __typeof__ (b) _b = (b);  \
+           _a < _b ? _a : _b; })
 
 /*
  * Common piece of code to perform a sleeping.
@@ -199,13 +199,13 @@ extern "C" {
  *
  */
 #define SLEEP(zzz)               \
-do                               \
-{                                \
-   struct timespec ts_private;   \
-   ts_private.tv_sec = 0;        \
-   ts_private.tv_nsec = zzz;     \
-   nanosleep(&ts_private, NULL); \
-} while (0);
+        do                               \
+        {                                \
+           struct timespec ts_private;   \
+           ts_private.tv_sec = 0;        \
+           ts_private.tv_nsec = zzz;     \
+           nanosleep(&ts_private, NULL); \
+        } while (0);
 
 /*
  * Commonly used block of code to sleep
@@ -222,14 +222,14 @@ do                               \
        SLEEP_AND_GOTO(100000L, retry)
  */
 #define SLEEP_AND_GOTO(zzz, goto_to) \
-do                                   \
-{                                    \
-   struct timespec ts_private;       \
-   ts_private.tv_sec = 0;            \
-   ts_private.tv_nsec = zzz;         \
-   nanosleep(&ts_private, NULL);     \
-   goto goto_to;                     \
-} while (0);
+        do                                   \
+        {                                    \
+           struct timespec ts_private;       \
+           ts_private.tv_sec = 0;            \
+           ts_private.tv_nsec = zzz;         \
+           nanosleep(&ts_private, NULL);     \
+           goto goto_to;                     \
+        } while (0);
 
 /**
  * The shared memory segment
@@ -514,6 +514,7 @@ struct main_configuration
    bool track_prepared_statements; /**< Track prepared statements (transaction pooling) */
 
    char unix_socket_dir[MISC_LENGTH]; /**< The directory for the Unix Domain Socket */
+   char master_key_file_location[MISC_LENGTH]; /**< The directory for the MasterKey */
 
    atomic_schar su_connection; /**< The superuser connection */
 

--- a/src/include/security.h
+++ b/src/include/security.h
@@ -39,6 +39,11 @@ extern "C" {
 
 #include <openssl/ssl.h>
 
+#define HOME_DIRECTORY_ERROR        1
+#define PGAGROAL_DIRECTORY_ERROR    2
+#define FILE_NOT_FOUND_ERROR        3
+#define INVALID_MASTERKEY_ERROR     4
+
 /**
  * Authenticate a user
  * @param client_fd The descriptor
@@ -90,7 +95,7 @@ pgagroal_remote_management_scram_sha256(char* username, char* password, int serv
  * @return 0 upon success, otherwise 1
  */
 int
-pgagroal_get_master_key(char** masterkey);
+pgagroal_get_master_key(char** masterkey, char* filename);
 
 /**
  * Encrypt a string

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -1274,15 +1274,15 @@ pgagroal_read_users_configuration(void* shm, char* filename)
       status = PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND;
       goto error;
    }
+   config = (struct main_configuration*)shm;
 
-   if (pgagroal_get_master_key(&master_key))
+   if (pgagroal_get_master_key(&master_key, config->master_key_file_location))
    {
       status = PGAGROAL_CONFIGURATION_STATUS_KO;
       goto error;
    }
 
    index = 0;
-   config = (struct main_configuration*)shm;
 
    while (fgets(line, sizeof(line), file))
    {
@@ -1396,15 +1396,15 @@ pgagroal_read_frontend_users_configuration(void* shm, char* filename)
       status = PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND;
       goto error;
    }
+   config = (struct main_configuration*)shm;
 
-   if (pgagroal_get_master_key(&master_key))
+   if (pgagroal_get_master_key(&master_key, config->master_key_file_location))
    {
       status = PGAGROAL_CONFIGURATION_STATUS_KO;
       goto error;
    }
 
    index = 0;
-   config = (struct main_configuration*)shm;
 
    while (fgets(line, sizeof(line), file))
    {
@@ -1543,15 +1543,15 @@ pgagroal_read_admins_configuration(void* shm, char* filename)
       status = PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND;
       goto error;
    }
+   config = (struct main_configuration*)shm;
 
-   if (pgagroal_get_master_key(&master_key))
+   if (pgagroal_get_master_key(&master_key, config->master_key_file_location))
    {
       status = PGAGROAL_CONFIGURATION_STATUS_KO;
       goto error;
    }
 
    index = 0;
-   config = (struct main_configuration*)shm;
 
    while (fgets(line, sizeof(line), file))
    {
@@ -1647,6 +1647,7 @@ pgagroal_vault_read_users_configuration(void* shm, char* filename)
    int decoded_length = 0;
    char* ptr = NULL;
    struct vault_configuration* config;
+   struct main_configuration* main_config;
    int status = PGAGROAL_CONFIGURATION_STATUS_OK;
 
    file = fopen(filename, "r");
@@ -1656,8 +1657,9 @@ pgagroal_vault_read_users_configuration(void* shm, char* filename)
       status = PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND;
       goto error;
    }
+   main_config = (struct main_configuration*)shm;
 
-   if (pgagroal_get_master_key(&master_key))
+   if (pgagroal_get_master_key(&master_key, main_config->master_key_file_location))
    {
       status = PGAGROAL_CONFIGURATION_STATUS_KO;
       goto error;
@@ -1784,15 +1786,15 @@ pgagroal_read_superuser_configuration(void* shm, char* filename)
       status = PGAGROAL_CONFIGURATION_STATUS_FILE_NOT_FOUND;
       goto error;
    }
+   config = (struct main_configuration*)shm;
 
-   if (pgagroal_get_master_key(&master_key))
+   if (pgagroal_get_master_key(&master_key, config->master_key_file_location))
    {
       status = PGAGROAL_CONFIGURATION_STATUS_KO;
       goto error;
    }
 
    index = 0;
-   config = (struct main_configuration*)shm;
 
    while (fgets(line, sizeof(line), file))
    {
@@ -4617,6 +4619,15 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
          max = MISC_LENGTH - 1;
       }
       memcpy(config->unix_socket_dir, value, max);
+   }
+   else if (key_in_section("master_key_file_location", section, key, true, &unknown))
+   {
+      max = strlen(value);
+      if (max > MISC_LENGTH - 1)
+      {
+         max = MISC_LENGTH - 1;
+      }
+      memcpy(config->master_key_file_location, value, max);
    }
    else if (key_in_section("libev", section, key, true, &unknown))
    {


### PR DESCRIPTION
Updated with respect to the new configuration.c changes.

- Can add -c `conf-file` to the master-key generation
`pgagroal-admin -c conf-file -g master-key`
- The pgagroal_get_master_key() is also updated to access the master_key_file_location from the conf file.

@jesperpedersen @fluca1978 