### PR TITLE
[#426] Fix a problem in `pgagroal_bind`

### DIFF
--- a/src/libpgagroal/network.c
+++ b/src/libpgagroal/network.c
@@ -120,10 +120,17 @@ pgagroal_bind(const char* hostname, int port, int** fds, int* length)
          }
       }
 
+      freeifaddrs(ifaddr);
+
+      if (star_length == 0)
+      {
+         // cannot bind to anything!
+         return 1;
+      }
+
       *fds = star_fds;
       *length = star_length;
 
-      freeifaddrs(ifaddr);
       return 0;
    }
 


### PR DESCRIPTION
If the configuration `host` is set to `*`, meaning all the interfaces, the `pgagroal_bind` function was always returning a true value even if no available bind addresses were left.
In order to fix this, the commit tests if the `star_length` variable has been set to something non-zero, otherwise no more sockets are available (bound) and the function returns a `1` to indicate an error.

Close #426