### PR TITLE
Bug-fix in cli remote connection

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -679,7 +679,6 @@ main(int argc, char** argv)
             errx(1, "Cannot start the logging subsystem");
          }
 
-         config = (struct main_configuration*)shmem;
       }
    }
 
@@ -690,6 +689,8 @@ main(int argc, char** argv)
       goto done;
    }
    pgagroal_log_trace((char*)parsed.cmd->log_message, parsed.args[0], parsed.args[1]);
+
+   config = (struct main_configuration*)shmem;
 
    if (!remote_connection)
    {


### PR DESCRIPTION
## Work in Progress

@jesperpedersen PTAL

### Bug Fix

There is also a bug fix in this commit -

Now (uptill the latest commit), if we try to connect remotely to the management port from `cli` it will give error --> `Segmentation fault (core dumped)` because at line number `706` in `cli.c`  :-
```
if (pgagroal_connect(host, atoi(port), &socket, config->keep_alive, config->non_blocking, &config->buffer_size, config->nodelay))
```

we were passing extra arguments to `pgagroal_connect` which comes from `config` which was not defined for remote connection sequence of execution as per the latest code.

So currently, remote connection functionality won't work!!

