### PR TITLE
Password rotation functionality without '-F'

### DIFF
--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -481,6 +481,12 @@ pgagroal_validate_configuration(void* shm, bool has_unix_socket, bool has_main_s
       pgagroal_log_warn("pgagroal: Frontend users should not be used with allow_unknown_users");
    }
 
+   if (config->number_of_frontend_users == 0 && config->number_of_users == 0 && config->rotate_frontend_password_timeout > 0)
+   {
+      pgagroal_log_fatal("pgagroal: Users must be defined for rotation frontend password to be enabled");
+      return 1;
+   }
+
    if (config->failover)
    {
       if (strlen(config->failover_script) == 0)

--- a/src/vault.c
+++ b/src/vault.c
@@ -204,7 +204,7 @@ static int
 connect_pgagroal(struct vault_configuration* config, char* username, char* password, SSL** s_ssl, int* client_socket)
 {
    SSL* s = NULL;
-   
+
    if (pgagroal_connect(config->vault_server.server.host, config->vault_server.server.port, client_socket, false, false, &default_buffer_size, false))
    {
       pgagroal_disconnect(*client_socket);


### PR DESCRIPTION
## WORK IN PROGRESS

@jesperpedersen PTAL

### About the commit

The following commit provides a functionality to invoke a `startup` script (after reading all the configuration files)
This `startup` script generates passwords with rotation (with timeout `rotate_frontend_password_timeout`) for the frontend end user even if the frontend users file doesn't exists i.e `-F` is not provided.

It operates by creating new frontend users in the system by taking usernames from file provided in `-u` option i.e. `pgagroal_database.conf` and generating random passwords for the newly created `frontend_users`.

**Condition for startup function to work**:-
- `number_of_frontend_users` should be 0
- `rotate_frontend_password_timeout` should be non-zero

