### PR TITLE
Enable Vault Prometheus

### DIFF
--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -250,7 +250,9 @@ over the local interface, and hence doesn't work remotely.
 
 ## Prometheus
 
-pgagroal has support for [Prometheus](https://prometheus.io/) when the `metrics` port is specified.
+pgagroal has support for [Prometheus](https://prometheus.io/) when the `metrics` port is specified. 
+
+**Note:** It is crucial to carefully initialize Prometheus memory in any program files for example functions like `pgagroal_init_prometheus()` and `pgagroal_init_prometheus_cache()` should only be invoked if `metrics` is greater than 0.
 
 The module serves two endpoints
 

--- a/doc/VAULT.md
+++ b/doc/VAULT.md
@@ -27,6 +27,10 @@ The available keys and their accepted values are reported in the table below.
 |----------|---------|------|----------|-------------|
 | host | | String | Yes | The bind address for pgagroal-vault |
 | port | | Int | Yes | The bind port for pgagroal-vault |
+| metrics | 0 | Int | No | The metrics port (disable = 0) |
+| metrics_cache_max_age | 0 | String | No | The number of seconds to keep in cache a Prometheus (metrics) response. If set to zero, the caching will be disabled. Can be a string with a suffix, like `2m` to indicate 2 minutes |
+| metrics_cache_max_size | 256k | String | No | The maximum amount of data to keep in cache when serving Prometheus responses. Changes require restart. This parameter determines the size of memory allocated for the cache even if `metrics_cache_max_age` or `metrics` are disabled. Its value, however, is taken into account only if `metrics_cache_max_age` is set to a non-zero value. Supports suffixes: 'B' (bytes), the default if omitted, 'K' or 'KB' (kilobytes), 'M' or 'MB' (megabytes), 'G' or 'GB' (gigabytes).|
+| authentication_timeout | 5 | Int | No | The number of seconds the process will wait for valid credentials |
 | log_type | console | String | No | The logging type (console, file, syslog) |
 | log_level | info | String | No | The logging level, any of the (case insensitive) strings `FATAL`, `ERROR`, `WARN`, `INFO` and `DEBUG` (that can be more specific as `DEBUG1` thru `DEBUG5`). Debug level greater than 5 will be set to `DEBUG5`. Not recognized values will make the log_level be `INFO` |
 | log_path | pgagroal.log | String | No | The log file location. Can be a strftime(3) compatible string. |
@@ -36,6 +40,7 @@ The available keys and their accepted values are reported in the table below.
 | log_mode | append | String | No | Append to or create the log file (append, create) |
 | log_connections | `off` | Bool | No | Log connects |
 | log_disconnections | `off` | Bool | No | Log disconnects |
+| hugepage | `try` | String | No | Huge page support (`off`, `try`, `on`) |
 
 ## [main]
 

--- a/doc/man/pgagroal_vault.conf.5.rst
+++ b/doc/man/pgagroal_vault.conf.5.rst
@@ -33,6 +33,22 @@ host
 port
   The bind port for pgagroal-vault. Mandatory
 
+metrics
+  The metrics port. Default is 0 (disabled)
+
+metrics_cache_max_age
+  The number of seconds to keep in cache a Prometheus (metrics) response.
+  If set to zero, the caching will be disabled. Can be a string with a suffix, like ``2m`` to indicate 2 minutes.
+  Default is 0 (disabled)
+
+metrics_cache_max_size
+  The maximum amount of data to keep in cache when serving Prometheus responses. Changes require restart.
+  This parameter determines the size of memory allocated for the cache even if ``metrics_cache_max_age`` or
+  ``metrics`` are disabled. Its value, however, is taken into account only if ``metrics_cache_max_age`` is set
+  to a non-zero value. Supports suffixes: ``B`` (bytes), the default if omitted, ``K`` or ``KB`` (kilobytes),
+  ``M`` or ``MB`` (megabytes), ``G`` or ``GB`` (gigabytes).
+  Default is 256k
+
 log_type
   The logging type (console, file, syslog). Default is console
 
@@ -66,6 +82,12 @@ log_connections
 
 log_disconnections
   Log disconnects. Default is off
+
+authentication_timeout
+  The number of seconds the process will wait for valid credentials. Default is 5
+
+hugepage
+  Huge page support. Default is try
 
 The options for the main section are
 

--- a/doc/manual/dev-02-architecture.md
+++ b/doc/manual/dev-02-architecture.md
@@ -254,6 +254,8 @@ over the local interface, and hence doesn't work remotely.
 
 pgagroal has support for [Prometheus](https://prometheus.io/) when the `metrics` port is specified.
 
+**Note:** It is crucial to carefully initialize Prometheus memory in any program files for example functions like `pgagroal_init_prometheus()` and `pgagroal_init_prometheus_cache()` should only be invoked if `metrics` is greater than 0.
+
 The module serves two endpoints
 
 * `/` - Overview of the functionality (`text/html`)

--- a/doc/manual/user-11-prometheus.md
+++ b/doc/manual/user-11-prometheus.md
@@ -233,3 +233,29 @@ Number of sockets the client used
 ## pgagroal_self_sockets
 
 Number of sockets used by pgagroal itself
+
+[**pgagroal-vault**][pgagroal-vault] has the following [Prometheus][prometheus] metrics.
+
+## pgagroal_vault_logging_info
+
+The number of INFO statements
+
+## pgagroal_vault_logging_warn
+
+The number of WARN statements
+
+## pgagroal_vault_logging_error
+
+The number of ERROR statements
+
+## pgagroal_vault_logging_fatal
+
+The number of FATAL statements
+
+## pgagroal_vault_client_sockets
+
+Number of sockets the client used
+
+## pgagroal_vault_self_sockets
+
+Number of sockets used by pgagroal-vault itself

--- a/doc/manual/user-12-vault.md
+++ b/doc/manual/user-12-vault.md
@@ -29,6 +29,9 @@ The available keys and their accepted values are reported in the table below.
 |----------|---------|------|----------|-------------|
 | host | | String | Yes | The bind address for pgagroal-vault |
 | port | | Int | Yes | The bind port for pgagroal-vault |
+| metrics | 0 | Int | No | The metrics port (disable = 0) |
+| metrics_cache_max_age | 0 | String | No | The number of seconds to keep in cache a Prometheus (metrics) response. If set to zero, the caching will be disabled. Can be a string with a suffix, like `2m` to indicate 2 minutes |
+| metrics_cache_max_size | 256k | String | No | The maximum amount of data to keep in cache when serving Prometheus responses. Changes require restart. This parameter determines the size of memory allocated for the cache even if `metrics_cache_max_age` or `metrics` are disabled. Its value, however, is taken into account only if `metrics_cache_max_age` is set to a non-zero value. Supports suffixes: 'B' (bytes), the default if omitted, 'K' or 'KB' (kilobytes), 'M' or 'MB' (megabytes), 'G' or 'GB' (gigabytes).|
 | log_type | console | String | No | The logging type (console, file, syslog) |
 | log_level | info | String | No | The logging level, any of the (case insensitive) strings `FATAL`, `ERROR`, `WARN`, `INFO` and `DEBUG` (that can be more specific as `DEBUG1` thru `DEBUG5`). Debug level greater than 5 will be set to `DEBUG5`. Not recognized values will make the log_level be `INFO` |
 | log_path | pgagroal.log | String | No | The log file location. Can be a strftime(3) compatible string. |
@@ -38,6 +41,8 @@ The available keys and their accepted values are reported in the table below.
 | log_mode | append | String | No | Append to or create the log file (append, create) |
 | log_connections | `off` | Bool | No | Log connects |
 | log_disconnections | `off` | Bool | No | Log disconnects |
+| authentication_timeout | 5 | Int | No | The number of seconds the process will wait for valid credentials |
+| hugepage | `try` | String | No | Huge page support (`off`, `try`, `on`) |
 
 ## [main]
 

--- a/doc/tutorial/04_prometheus.md
+++ b/doc/tutorial/04_prometheus.md
@@ -59,3 +59,44 @@ It is also possible to get an explaination of what is the meaning of each metric
 ```
 http://localhost:2346/
 ```
+
+## Prometheus metrics for pgagroal-vault
+This tutorial will show you how to do basic  [Prometheus](https://prometheus.io/){:target="_blank"} setup  for [**pgagroal-vault**](https://github.com/agroal/pgagroal).
+
+**pgagroal-vault** is able to provide a set of metrics about what it is happening within the vault, so that a Prometheus instance can collect them and help you monitor the vault activities.
+
+### Change the pgagroal-vault configuration
+
+In order to enable to export of the metrics, you need to add the `metrics` option in the main `pgagroal_vault.conf` configuration. The value of this setting is the TCP/IP port number that Prometheus will use to grab the exported metrics.
+
+Add a line like the following to `/etc/pgagroal/pgagroal_vault.conf` by editing such file with your editor of choice:
+
+```
+metrics = 2501
+```
+
+Place it within the `[pgagroal-vault]` section, like
+
+```
+[pgagroal-vault]
+...
+metrics = 2501
+```
+
+This will bind the TCP/IP port number `2501` to the metrics export.
+
+See [the pgagroal-vault configuration settings](https://github.com/agroal/pgagroal/blob/master/doc/VAULT.md#pgagroal-vault) with particular regard to `metrics`, `metrics_cache_max_age` and `metrics_cache_max_size` for more details.
+
+### Get Prometheus metrics
+
+Once **pgagroal-vault** is running you can access the metrics with a browser at the pgagroal-vault address, specifying the `metrics` port number and routing to the `/metrics` page. For example, point your web browser at:
+
+```
+http://localhost:2501/metrics
+```
+
+It is also possible to get an explaination of what is the meaning of each metric by pointing your web browser at:
+
+```
+http://localhost:2501/
+```

--- a/src/include/prometheus.h
+++ b/src/include/prometheus.h
@@ -65,10 +65,23 @@ void
 pgagroal_prometheus(int fd);
 
 /**
+ * Create a prometheus instance for vault
+ * @param fd The client descriptor
+ */
+void
+pgagroal_vault_prometheus(int fd);
+
+/**
  * Initialize prometheus shmem
  */
 int
 pgagroal_init_prometheus(size_t* p_size, void** p_shmem);
+
+/**
+ * Initialize prometheus shmem for vault
+ */
+int
+pgagroal_vault_init_prometheus(size_t* p_size, void** p_shmem);
 
 /**
  * Add session time information

--- a/src/libpgagroal/pipeline_session.c
+++ b/src/libpgagroal/pipeline_session.c
@@ -108,7 +108,7 @@ session_initialize(void* shmem, void** pipeline_shmem, size_t* pipeline_shmem_si
    if (config->disconnect_client > 0)
    {
       session_shmem_size = config->max_connections * sizeof(struct client_session);
-      if (pgagroal_create_shared_memory(session_shmem_size, config->hugepage, &session_shmem))
+      if (pgagroal_create_shared_memory(session_shmem_size, config->common.hugepage, &session_shmem))
       {
          return 1;
       }

--- a/src/libpgagroal/remote.c
+++ b/src/libpgagroal/remote.c
@@ -68,7 +68,7 @@ pgagroal_remote_management(int client_fd, char* address)
    auth_status = pgagroal_remote_management_auth(client_fd, address, &client_ssl);
    if (auth_status == AUTH_SUCCESS)
    {
-      status = pgagroal_read_timeout_message(client_ssl, client_fd, config->authentication_timeout, &msg);
+      status = pgagroal_read_timeout_message(client_ssl, client_fd, config->common.authentication_timeout, &msg);
       if (status != MESSAGE_STATUS_OK)
       {
          goto done;
@@ -113,7 +113,7 @@ pgagroal_remote_management(int client_fd, char* address)
          case MANAGEMENT_FLUSH:
          case MANAGEMENT_RESET_SERVER:
          case MANAGEMENT_SWITCH_TO:
-            status = pgagroal_read_timeout_message(client_ssl, client_fd, config->authentication_timeout, &msg);
+            status = pgagroal_read_timeout_message(client_ssl, client_fd, config->common.authentication_timeout, &msg);
             if (status != MESSAGE_STATUS_OK)
             {
                goto done;
@@ -126,7 +126,7 @@ pgagroal_remote_management(int client_fd, char* address)
             }
          case MANAGEMENT_ENABLEDB:
          case MANAGEMENT_DISABLEDB:
-            status = pgagroal_read_timeout_message(client_ssl, client_fd, config->authentication_timeout, &msg);
+            status = pgagroal_read_timeout_message(client_ssl, client_fd, config->common.authentication_timeout, &msg);
             if (status != MESSAGE_STATUS_OK)
             {
                goto done;
@@ -138,7 +138,7 @@ pgagroal_remote_management(int client_fd, char* address)
                goto done;
             }
 
-            status = pgagroal_read_timeout_message(client_ssl, client_fd, config->authentication_timeout, &msg);
+            status = pgagroal_read_timeout_message(client_ssl, client_fd, config->common.authentication_timeout, &msg);
             if (status != MESSAGE_STATUS_OK)
             {
                goto done;
@@ -154,7 +154,7 @@ pgagroal_remote_management(int client_fd, char* address)
 
          case MANAGEMENT_GET_PASSWORD:
             // Read username size from local
-            status = pgagroal_read_timeout_message(client_ssl, client_fd, config->authentication_timeout, &msg);
+            status = pgagroal_read_timeout_message(client_ssl, client_fd, config->common.authentication_timeout, &msg);
             if (status != MESSAGE_STATUS_OK)
             {
                goto done;
@@ -166,7 +166,7 @@ pgagroal_remote_management(int client_fd, char* address)
                goto done;
             }
 
-            status = pgagroal_read_timeout_message(NULL, server_fd, config->authentication_timeout, &msg);
+            status = pgagroal_read_timeout_message(NULL, server_fd, config->common.authentication_timeout, &msg);
             if (status != MESSAGE_STATUS_OK)
             {
                goto done;

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -159,7 +159,7 @@ pgagroal_authenticate(int client_fd, char* address, int* slot, SSL** client_ssl,
    *server_ssl = NULL;
 
    /* Receive client calls - at any point if client exits return AUTH_ERROR */
-   status = pgagroal_read_timeout_message(NULL, client_fd, config->authentication_timeout, &msg);
+   status = pgagroal_read_timeout_message(NULL, client_fd, config->common.authentication_timeout, &msg);
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;
@@ -225,7 +225,7 @@ pgagroal_authenticate(int client_fd, char* address, int* slot, SSL** client_ssl,
       }
       pgagroal_free_message(msg);
 
-      status = pgagroal_read_timeout_message(NULL, client_fd, config->authentication_timeout, &msg);
+      status = pgagroal_read_timeout_message(NULL, client_fd, config->common.authentication_timeout, &msg);
       if (status != MESSAGE_STATUS_OK)
       {
          goto error;
@@ -276,7 +276,7 @@ pgagroal_authenticate(int client_fd, char* address, int* slot, SSL** client_ssl,
             goto error;
          }
 
-         status = pgagroal_read_timeout_message(c_ssl, client_fd, config->authentication_timeout, &msg);
+         status = pgagroal_read_timeout_message(c_ssl, client_fd, config->common.authentication_timeout, &msg);
          if (status != MESSAGE_STATUS_OK)
          {
             goto error;
@@ -292,7 +292,7 @@ pgagroal_authenticate(int client_fd, char* address, int* slot, SSL** client_ssl,
          }
          pgagroal_free_message(msg);
 
-         status = pgagroal_read_timeout_message(NULL, client_fd, config->authentication_timeout, &msg);
+         status = pgagroal_read_timeout_message(NULL, client_fd, config->common.authentication_timeout, &msg);
          if (status != MESSAGE_STATUS_OK)
          {
             goto error;
@@ -590,7 +590,7 @@ pgagroal_remote_management_auth(int client_fd, char* address, SSL** client_ssl)
    *client_ssl = NULL;
 
    /* Receive client calls - at any point if client exits return AUTH_ERROR */
-   status = pgagroal_read_timeout_message(NULL, client_fd, config->authentication_timeout, &msg);
+   status = pgagroal_read_timeout_message(NULL, client_fd, config->common.authentication_timeout, &msg);
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;
@@ -638,7 +638,7 @@ pgagroal_remote_management_auth(int client_fd, char* address, SSL** client_ssl)
             goto error;
          }
 
-         status = pgagroal_read_timeout_message(c_ssl, client_fd, config->authentication_timeout, &msg);
+         status = pgagroal_read_timeout_message(c_ssl, client_fd, config->common.authentication_timeout, &msg);
          if (status != MESSAGE_STATUS_OK)
          {
             goto error;
@@ -654,7 +654,7 @@ pgagroal_remote_management_auth(int client_fd, char* address, SSL** client_ssl)
          }
          pgagroal_free_message(msg);
 
-         status = pgagroal_read_timeout_message(NULL, client_fd, config->authentication_timeout, &msg);
+         status = pgagroal_read_timeout_message(NULL, client_fd, config->common.authentication_timeout, &msg);
          if (status != MESSAGE_STATUS_OK)
          {
             goto error;
@@ -1311,7 +1311,7 @@ use_pooled_connection(SSL* c_ssl, int client_fd, int slot, char* username, char*
       /* Password or MD5 */
       if (config->connections[slot].has_security != SECURITY_TRUST)
       {
-         status = pgagroal_read_timeout_message(c_ssl, client_fd, config->authentication_timeout, &msg);
+         status = pgagroal_read_timeout_message(c_ssl, client_fd, config->common.authentication_timeout, &msg);
          if (status != MESSAGE_STATUS_OK)
          {
             goto error;
@@ -1652,7 +1652,7 @@ retry:
    status = pgagroal_read_timeout_message(c_ssl, client_fd, 1, &msg);
    if (status != MESSAGE_STATUS_OK)
    {
-      if (difftime(time(NULL), start_time) < config->authentication_timeout)
+      if (difftime(time(NULL), start_time) < config->common.authentication_timeout)
       {
          if (pgagroal_socket_isvalid(client_fd))
          /* Sleep for 100ms */
@@ -1736,7 +1736,7 @@ retry:
    status = pgagroal_read_timeout_message(c_ssl, client_fd, 1, &msg);
    if (status != MESSAGE_STATUS_OK)
    {
-      if (difftime(time(NULL), start_time) < config->authentication_timeout)
+      if (difftime(time(NULL), start_time) < config->common.authentication_timeout)
       {
          if (pgagroal_socket_isvalid(client_fd))
          /* Sleep for 100ms */
@@ -1863,7 +1863,7 @@ retry:
    status = pgagroal_read_timeout_message(c_ssl, client_fd, 1, &msg);
    if (status != MESSAGE_STATUS_OK)
    {
-      if (difftime(time(NULL), start_time) < config->authentication_timeout)
+      if (difftime(time(NULL), start_time) < config->common.authentication_timeout)
       {
          if (pgagroal_socket_isvalid(client_fd))
          /* Sleep for 100ms */
@@ -1914,7 +1914,7 @@ retry:
       goto error;
    }
 
-   status = pgagroal_read_timeout_message(c_ssl, client_fd, config->authentication_timeout, &msg);
+   status = pgagroal_read_timeout_message(c_ssl, client_fd, config->common.authentication_timeout, &msg);
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;
@@ -2148,7 +2148,7 @@ server_passthrough(struct message* msg, int auth_type, SSL* c_ssl, int client_fd
    if (auth_type != SECURITY_TRUST)
    {
       /* Receive client response, keep it, and send it to PostgreSQL */
-      status = pgagroal_read_timeout_message(c_ssl, client_fd, config->authentication_timeout, &msg);
+      status = pgagroal_read_timeout_message(c_ssl, client_fd, config->common.authentication_timeout, &msg);
       if (status != MESSAGE_STATUS_OK)
       {
          goto error;
@@ -2198,7 +2198,7 @@ server_passthrough(struct message* msg, int auth_type, SSL* c_ssl, int client_fd
          }
          pgagroal_free_message(msg);
 
-         status = pgagroal_read_timeout_message(c_ssl, client_fd, config->authentication_timeout, &msg);
+         status = pgagroal_read_timeout_message(c_ssl, client_fd, config->common.authentication_timeout, &msg);
          if (status != MESSAGE_STATUS_OK)
          {
             goto error;
@@ -5411,7 +5411,7 @@ retry:
    status = pgagroal_read_timeout_message(c_ssl, client_fd, 1, &msg);
    if (status != MESSAGE_STATUS_OK)
    {
-      if (difftime(time(NULL), start_time) < config->authentication_timeout)
+      if (difftime(time(NULL), start_time) < config->common.authentication_timeout)
       {
          if (pgagroal_socket_isvalid(client_fd))
          /* Sleep for 100ms */
@@ -5530,7 +5530,7 @@ retry:
    status = pgagroal_read_timeout_message(c_ssl, client_fd, 1, &msg);
    if (status != MESSAGE_STATUS_OK)
    {
-      if (difftime(time(NULL), start_time) < config->authentication_timeout)
+      if (difftime(time(NULL), start_time) < config->common.authentication_timeout)
       {
          if (pgagroal_socket_isvalid(client_fd))
          /* Sleep for 100ms */
@@ -5604,7 +5604,7 @@ retry:
       goto error;
    }
 
-   status = pgagroal_read_timeout_message(c_ssl, client_fd, config->authentication_timeout, &msg);
+   status = pgagroal_read_timeout_message(c_ssl, client_fd, config->common.authentication_timeout, &msg);
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;

--- a/src/libpgagroal/shmem.c
+++ b/src/libpgagroal/shmem.c
@@ -96,7 +96,7 @@ pgagroal_resize_shared_memory(size_t size, void* shmem, size_t* new_size, void**
    config = (struct main_configuration*)shmem;
 
    *new_size = size + (config->max_connections * sizeof(struct connection));
-   if (pgagroal_create_shared_memory(*new_size, config->hugepage, new_shmem))
+   if (pgagroal_create_shared_memory(*new_size, config->common.hugepage, new_shmem))
    {
       return 1;
    }


### PR DESCRIPTION
## Enable Prometheus in vault

### About this commit
- Bind an HTTP server in `pgagroal-vault`  at port `metrics` in configuration to track server activities
- Added some fields like - `metrics`, `hugepage`, `metric_cache_max_age` and `metric_cache_max_size` in the common configuration
- Added an additional check `is_prometheus_enabled` on all the `prometheus` functions and code blocks which basically checks whether the metrics port is active or not.
- Based on the `metric` port value we allocate memory to `prometheus` structure and `prometheus_cache`

### Future work
- Segregate the `prometheus` structure for `main` and `vault` similar to `configuration` for optimal memory management.
- `prometheus` should be initiated only when `metric` port is active --> **Document it properly somewhere**.

@jesperpedersen @fluca1978  PTAL.
