### PR TITLE
[#473] Fix connection status output

### DIFF
--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -157,14 +157,6 @@ int
 pgagroal_extract_error_message(struct message* msg, char** error);
 
 /**
- * Get a string for the state
- * @param state
- * @return The string
- */
-char*
-pgagroal_get_state_string(signed char state);
-
-/**
  * Read a byte
  * @param data Pointer to the data
  * @return The byte
@@ -523,6 +515,17 @@ parse_command(int argc,
  */
 char*
 pgagroal_server_state_as_string(signed char state);
+
+/**
+ * Utility function to convert the status of a connection
+ * into a descriptive string. Useful to spurt the status
+ * in command line output.
+ *
+ * @param state the actual state of the connection
+ * @returns the (allocated) buffer with the string
+ */
+char*
+pgagroal_connection_state_as_string(signed char state);
 
 #ifdef __cplusplus
 }

--- a/src/libpgagroal/management.c
+++ b/src/libpgagroal/management.c
@@ -948,7 +948,7 @@ pgagroal_management_json_read_status_details(SSL* ssl, int socket, bool include_
       cJSON* current_connection_json = cJSON_CreateObject();
 
       cJSON_AddNumberToObject(current_connection_json, "number", i + 1);
-      cJSON_AddStringToObject(current_connection_json, "state", pgagroal_server_state_as_string(state));
+      cJSON_AddStringToObject(current_connection_json, "state", pgagroal_connection_state_as_string(state));
       cJSON_AddStringToObject(current_connection_json, "time", time > 0 ? ts : "");
       cJSON_AddStringToObject(current_connection_json, "pid", pid > 0 ? p : "");
       cJSON_AddStringToObject(current_connection_json, "fd", fd > 0 ? f : "");

--- a/src/libpgagroal/utils.c
+++ b/src/libpgagroal/utils.c
@@ -249,8 +249,11 @@ error:
 }
 
 char*
-pgagroal_get_state_string(signed char state)
+pgagroal_connection_state_as_string(signed char state)
 {
+   char* buf;
+   int buf_size = strlen("Unknown") + 1 + 4 + 1;  // 'unknown' + <space> + <number> + \0
+
    switch (state)
    {
       case STATE_NOTINIT:
@@ -273,9 +276,12 @@ pgagroal_get_state_string(signed char state)
          return "Validating";
       case STATE_REMOVE:
          return "Removing";
+      default:
+         buf = malloc(buf_size);
+         memset(buf, 0, buf_size);
+         snprintf(buf, buf_size, "Unknown %02d", state);
+         return buf;
    }
-
-   return "Unknown";
 }
 
 signed char
@@ -1098,16 +1104,6 @@ parse_command(int argc,
 #undef EMPTY_STR
 }
 
-/**
- * Given a server state, it returns a string that
- * described the state in a human-readable form.
- *
- * If the state cannot be determined, the numeric
- * form of the state is returned as a string.
- *
- * @param state the value of the sate for the server
- * @returns the string representing the state
- */
 char*
 pgagroal_server_state_as_string(signed char state)
 {


### PR DESCRIPTION
`pgagroal-cli` was reporting the wrong status for connections because it was decoding the connection status via
`pgagroal_server_state_as_string` that is used to decode the status of a server.
This commit renames the already existent function
`pgagroal_get_state_string` as `pgagroal_connection_state_as_string` for consistency with the server
one (`pgagroal_server_state_as_string``) and makes the management decoding using such function to get the effective status of the connection.
Since the function `pgagroal_connection_state_as_string` keeps the already existent statuses, the text output is not changed. However, in the case `Unknwon` is reported, the function places also the numeric constant in the output so that it will be easy to debug edge cases.

Close #473