### PR TITLE
[#480] Adds DISTRIBUTIONS.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,48 +54,30 @@ See [Architecture](./doc/ARCHITECTURE.md) for the architecture of [**pgagroal**]
 * [FreeBSD](https://www.freebsd.org/)
 * [OpenBSD](http://www.openbsd.org/)
 
-## Compiling the source
 
-[**pgagroal**](https://github.com/agroal/pgagroal) requires
+## Compiling from sources
 
-* [gcc 8+](https://gcc.gnu.org) (C17)
+[**pgagroal**](https://github.com/agroal/pgagroal) can be compiled from sources,
+after having installed all the required dependencies:
+
+* [gcc 8+](https://gcc.gnu.org) (C17) or [clang 8+](https://clang.llvm.org/)
 * [cmake](https://cmake.org)
-* [make](https://www.gnu.org/software/make/)
+* [GNU make](https://www.gnu.org/software/make/) or BSD `make`
 * [libev](http://software.schmorp.de/pkg/libev.html)
 * [OpenSSL](http://www.openssl.org/)
-* [systemd](https://www.freedesktop.org/wiki/Software/systemd/)
 * [rst2man](https://docutils.sourceforge.io/)
 * [libatomic](https://gcc.gnu.org/wiki/Atomic)
+* [Doxygen](https://doxygen.nl/index.html)
+* [pdflatex](https://tug.org/texlive/)
+* [systemd](https://www.freedesktop.org/wiki/Software/systemd/) (on Linux systems)
 * [zlib](https://zlib.net)
 * [zstd](http://www.zstd.net)
 * [lz4](https://lz4.github.io/lz4/)
 * [bzip2](http://sourceware.org/bzip2/)
 
-On Rocky Linux (and similar) operating systems, the dependencies
-can be installed via `dnf(8)` as follows:
 
-```sh
-dnf install git gcc cmake make    \
-            libev libev-devel     \
-            openssl openssl-devel \
-            systemd systemd-devel \
-            python3-docutils      \
-            libatomic \
-            zlib zlib-devel \
-            libzstd libzstd-devel \
-            lz4 lz4-devel \
-            bzip2 bzip2-devel
-```
+See the [documentation about installing the required dependencies](doc/DISTRIBUTIONS.md).
 
-Please note that, on Rocky Linux, in order to install the `python3-docutils`
-package (that provides `rst2man` executable), you need to enable the `crb` repository:
-
-```sh
-dnf config-manager --set-enabled crb
-```
-
-
-Alternatively to GCC, [clang 8+](https://clang.llvm.org/) can be used.
 
 ### Release build
 

--- a/doc/DISTRIBUTIONS.md
+++ b/doc/DISTRIBUTIONS.md
@@ -1,0 +1,59 @@
+# Compiling `pgagroal` from sources
+
+[**pgagroal**](https://github.com/agroal/pgagroal) requires the following dependencies:
+
+* a C compiler like [gcc 8+](https://gcc.gnu.org) (C17) or [clang 8+](https://clang.llvm.org/)
+* [cmake](https://cmake.org)
+* [GNU make](https://www.gnu.org/software/make/) or BSD `make`
+* [libev](http://software.schmorp.de/pkg/libev.html)
+* [OpenSSL](http://www.openssl.org/)
+* [rst2man](https://docutils.sourceforge.io/)
+* [libatomic](https://gcc.gnu.org/wiki/Atomic)
+* [Doxygen](https://doxygen.nl/index.html)
+* [pdflatex](https://tug.org/texlive/)
+* [zlib](https://zlib.net)
+* [zstd](http://www.zstd.net)
+* [lz4](https://lz4.github.io/lz4/)
+* [bzip2](http://sourceware.org/bzip2/)
+* on Linux platforms, there is also the need for
+  * [systemd](https://www.freedesktop.org/wiki/Software/systemd/)
+
+
+
+## Compiling on Rocky Linux
+
+All the dependencies can be installed via `dnf(8)` as follows:
+
+```sh
+dnf install git gcc cmake make    \
+            libev libev-devel     \
+            openssl openssl-devel \
+            systemd systemd-devel \
+            python3-docutils      \
+            libatomic             \
+            zlib zlib-devel       \
+            libzstd libzstd-devel \
+            lz4 lz4-devel         \
+            bzip2 bzip2-devel
+```
+
+Please note that, on Rocky Linux, in order to install the `python3-docutils`
+package (that provides `rst2man` executable), you need to enable the `crb` repository:
+
+```sh
+dnf config-manager --set-enabled crb
+```
+
+## Compiling on FreeBSD
+
+All the dependencies can be installed via `pkg(8)` as follows:
+
+```sh
+pkg install cmake          	\
+            libev libevent 	\
+            py311-docutils 	\
+            lzlib           \
+            liblz4          \
+            lbizp2          \
+            texlive-formats
+```

--- a/pgagroal.spec
+++ b/pgagroal.spec
@@ -52,6 +52,7 @@ cmake -DCMAKE_BUILD_TYPE=Release ..
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/doc/PIPELINES.md %{buildroot}%{_docdir}/%{name}/PIPELINES.md
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/doc/RPM.md %{buildroot}%{_docdir}/%{name}/RPM.md
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/doc/SECURITY.md %{buildroot}%{_docdir}/%{name}/SECURITY.md
+%{__install} -m 644 %{_builddir}/%{name}-%{version}/doc/DISTRIBUTIONS.md %{buildroot}%{_docdir}/%{name}/DISTRIBUTIONS.md
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/doc/etc/pgagroal.service %{buildroot}%{_docdir}/%{name}/etc/pgagroal.service
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/doc/etc/pgagroal.socket %{buildroot}%{_docdir}/%{name}/etc/pgagroal.socket
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/doc/images/perf-extended.png %{buildroot}%{_docdir}/%{name}/images/perf-extended.png
@@ -108,6 +109,7 @@ cd %{buildroot}%{_libdir}/
 %{_docdir}/%{name}/README.md
 %{_docdir}/%{name}/RPM.md
 %{_docdir}/%{name}/SECURITY.md
+%{_docdir}/%{name}/DISTRIBUTIONS.md
 %{_docdir}/%{name}/grafana/dashboard.json
 %{_docdir}/%{name}/grafana/README.md
 %{_docdir}/%{name}/etc/pgagroal.service


### PR DESCRIPTION
Adds instrunctions to install the required dependencies in order to compile from sources.
So far, there are commands for Rocky Linux and FreeBSD.

Close #480