### PR TITLE
[#481] Add better error message about `Invalid master key file`

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -525,7 +525,7 @@ read_users_path:
 
          snprintf(message, MISC_LENGTH, "Invalid master key file");
 #ifdef HAVE_LINUX
-         sd_notifyf(0, "STATUS=%s: %s", message, users_path);
+         sd_notifyf(0, "STATUS=%s: <%s>", message, users_path);
 #endif
          errx(1, "%s (file <%s>)", message, users_path);
       }
@@ -567,9 +567,9 @@ read_frontend_users_path:
                || ret == PGAGROAL_CONFIGURATION_STATUS_KO)
       {
 #ifdef HAVE_LINUX
-         sd_notify(0, "STATUS=Invalid master key file");
+         sd_notifyf(0, "STATUS=Invalid master key file: <%s>", frontend_users_path);
 #endif
-         errx(1, "Invalid master key file");
+         errx(1, "%s (file <%s>)", message, frontend_users_path);
       }
       else if (ret == PGAGROAL_CONFIGURATION_STATUS_FILE_TOO_BIG)
       {
@@ -614,9 +614,9 @@ read_admins_path:
                || ret == PGAGROAL_CONFIGURATION_STATUS_KO)
       {
 #ifdef HAVE_LINUX
-         sd_notify(0, "STATUS=Invalid master key file");
+         sd_notifyf(0, "STATUS=Invalid master key file: <%s>", admins_path);
 #endif
-         errx(1, "Invalid master key file");
+         errx(1, "Invalid master key file (file <%s>)", admins_path);
       }
       else if (ret == PGAGROAL_CONFIGURATION_STATUS_FILE_TOO_BIG)
       {
@@ -657,9 +657,9 @@ read_superuser_path:
       else if (ret == PGAGROAL_CONFIGURATION_STATUS_CANNOT_DECRYPT || ret == PGAGROAL_CONFIGURATION_STATUS_KO)
       {
 #ifdef HAVE_LINUX
-         sd_notify(0, "STATUS=Invalid master key file");
+         sd_notifyf(0, "STATUS=Invalid master key file: <%s>", superuser_path);
 #endif
-         errx(1, "Invalid master key file");
+         errx(1, "Invalid master key file (file <%s>)", superuser_path);
       }
       else if (ret == PGAGROAL_CONFIGURATION_STATUS_FILE_TOO_BIG)
       {


### PR DESCRIPTION
When a users file, (frontend, admins or users files) cannot be decrypted, a generic `Invalid master key file` was raised. This commit adds the target file that cannot be decrypted, so that the user can understand which file has to be adjusted (e.g., `pgagroal-admin` usage on such file).

Makes the error messages consistent with those about a missing file.

Close #481