### PR TITLE
Fix unchecked calloc bug in network.c

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Yihe Lu <t1t4m1un@gmail.com>
 Eugenio Gigante <giganteeugenio2@gmail.com>
 Haoran Zhang <andrewzhr9911@gmail.com>
 Mohanad Khaled <mohanadkhaled87@gmail.com>
+Christian Englert <code@c.roboticbrain.de>

--- a/doc/manual/97-acknowledgement.md
+++ b/doc/manual/97-acknowledgement.md
@@ -21,6 +21,7 @@ Yihe Lu <t1t4m1un@gmail.com>
 Eugenio Gigante <giganteeugenio2@gmail.com>
 Mohanad Khaled <mohanadkhaled87@gmail.com>
 Haoran Zhang <andrewzhr9911@gmail.com>
+Christian Englert <code@c.roboticbrain.de>
 ```
 
 ## Committers

--- a/doc/manual/advanced/97-acknowledgement.md
+++ b/doc/manual/advanced/97-acknowledgement.md
@@ -21,6 +21,7 @@ Yihe Lu <t1t4m1un@gmail.com>
 Eugenio Gigante <giganteeugenio2@gmail.com>
 Mohanad Khaled <mohanadkhaled87@gmail.com>
 Haoran Zhang <andrewzhr9911@gmail.com>
+Christian Englert <code@c.roboticbrain.de>
 ```
 
 ## Committers

--- a/src/libpgagroal/network.c
+++ b/src/libpgagroal/network.c
@@ -633,7 +633,7 @@ bind_host(const char* hostname, int port, int** fds, int* length, bool non_block
    }
 
    result = calloc(1, size * sizeof(int));
-   if (sport == NULL)
+   if (result == NULL)
    {
       pgagroal_log_fatal("Couldn't allocate memory while binding host");
       return 1;


### PR DESCRIPTION
Hi, i just read [this Blog-post](https://fluca1978.github.io/2025/01/16/pgagroalPortLengthBug.html) by @fluca1978 and stumbled across another bug in the same function. See below.

Also I'm curious as to why `sport` is heap-allocated in the first place? Wouldn't it be more efficient (and remove some error checking) if it was stack-allocated? In that case i would like to update the patch to convert `sport` into a stack-allocated, fixed size string.

### Problem summary
At line 636 `sport` will always be non-NULL because it has already been checked in line 608 using early return on error. Meanwhile `result` has never been checked against NULL and is subsequently used in line 696. Probable cause of the bug is inadequate copy-and-pasting of code. I assume this changes it to the intended behavior.

### Disclaimer
I did not try to compile or even checkout the code locally. This bug was found through static-analysis/code-review only.
Please verify that it compiles and passes any automatic tests before merging!

Old-PR: #492 