### PR TITLE
libpgagroal: utils.c: fix UB in pgagroal_read_int32()

### DIFF
--- a/src/libpgagroal/utils.c
+++ b/src/libpgagroal/utils.c
@@ -316,10 +316,10 @@ pgagroal_read_int32(void* data)
                             *((unsigned char*)(data + 2)),
                             *((unsigned char*)(data + 3))};
 
-   int32_t res = (int32_t)((bytes[0] << 24)) |
-                 ((bytes[1] << 16)) |
-                 ((bytes[2] << 8)) |
-                 ((bytes[3]));
+   int32_t res = (int32_t)(((uint32_t)bytes[0] << 24)) |
+                 (((uint32_t)bytes[1] << 16)) |
+                 (((uint32_t)bytes[2] << 8)) |
+                 (((uint32_t)bytes[3]));
 
    return res;
 }


### PR DESCRIPTION
In `pgagroal_read_int32`, the byte[i] value is promoted to int32. According to the C spec, if you cannot represent the result in the result type, then that behavior is undefined (6.5.7).

The compiler was able to catch this after recent additions to cmake file, producing the runtime error:

libpgagroal/utils.c:319:38: runtime error: left shift of 166 by 24 places cannot be represented in type 'int'

This issue is fixed by explicitly casting the bytes[i] values to uint32_t.