### PR TITLE
[#496] admin.c: fix UAF in list_users()

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -1129,6 +1129,7 @@ list_users(char* users_path, int32_t output_format)
    }
 
    fclose(users_file);
+   users_file = NULL;
 
    end_t = time(NULL);
 


### PR DESCRIPTION
The fclose(users_file) in the error path can still be called after the first fclose(users_file).

Fix this by setting users_file to NULL.

This makes the build with type Release fail.