### PR TITLE
admin: support password through environment

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Eugenio Gigante <giganteeugenio2@gmail.com>
 Haoran Zhang <andrewzhr9911@gmail.com>
 Mohanad Khaled <mohanadkhaled87@gmail.com>
 Christian Englert <code@c.roboticbrain.de>
+Georg Pfuetzenreuter <georg.pfuetzenreuter@suse.com>

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -32,6 +32,8 @@ Options can be specified either in short or long form, in any position of the co
 The `-f` option is mandatory for every operation that involves user management. If no
 user file is specified, `pgagroal-admin` will silently use the default one (`pgagroal_users.conf`).
 
+The password can be passed using the environment variable `PGAGROAL_PASSWORD` instead of `-P`, however the command line argument will have precedence.
+
 ## Commands
 
 ### user

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -245,13 +245,17 @@ In order to set the master key for all users you can use
 pgagroal-admin -g master-key
 ```
 
-The master key must be at least 8 characters.
+The master key must be at least 8 characters if provided interactively.
+
+For scripted use, the master key can be provided using the `PGAGROAL_PASSWORD` environment variable.
 
 Then use the other commands to add, update, remove or list the current user names, f.ex.
 
 ```
 pgagroal-admin -f pgagroal_users.conf user add
 ```
+
+For scripted use, the user password can be provided using the `PGAGROAL_PASSWORD` environment variable.
 
 ## Next Steps
 

--- a/doc/man/pgagroal-admin.1.rst
+++ b/doc/man/pgagroal-admin.1.rst
@@ -60,6 +60,14 @@ user del
 user ls
   List all users
 
+ENVIRONMENT VARIABLES
+=====================
+
+PGAGROAL_PASSWORD
+  Provide either a key for use with the `master-key` command, or a user password for use with the `user add` or `user edit` commands.
+  If provided, `pgagroal-admin` will not ask for the key/password interactively.
+  Note that a password provided using the `--password` command line argument will have precedence over this variable.
+
 REPORTING BUGS
 ==============
 

--- a/doc/manual/97-acknowledgement.md
+++ b/doc/manual/97-acknowledgement.md
@@ -22,6 +22,7 @@ Eugenio Gigante <giganteeugenio2@gmail.com>
 Mohanad Khaled <mohanadkhaled87@gmail.com>
 Haoran Zhang <andrewzhr9911@gmail.com>
 Christian Englert <code@c.roboticbrain.de>
+Georg Pfuetzenreuter <georg.pfuetzenreuter@suse.com>
 ```
 
 ## Committers

--- a/doc/manual/advanced/03-installation.md
+++ b/doc/manual/advanced/03-installation.md
@@ -139,6 +139,10 @@ First, we will need to create a master security key for the [**pgagroal**][pgagr
 pgagroal-admin -g master-key
 ```
 
+By default, this will ask for a key interactively. Alternatively, a key can be provided using either the
+`--password` command line argument, or the `PGAGROAL_PASSWORD` environment variable. Note that passing the
+key using the command line might not be secure.
+
 Then we will create the configuration for [**pgagroal**][pgagroal],
 
 ```

--- a/doc/manual/advanced/97-acknowledgement.md
+++ b/doc/manual/advanced/97-acknowledgement.md
@@ -22,6 +22,7 @@ Eugenio Gigante <giganteeugenio2@gmail.com>
 Mohanad Khaled <mohanadkhaled87@gmail.com>
 Haoran Zhang <andrewzhr9911@gmail.com>
 Christian Englert <code@c.roboticbrain.de>
+Georg Pfuetzenreuter <georg.pfuetzenreuter@suse.com>
 ```
 
 ## Committers

--- a/doc/tutorial/01_install.md
+++ b/doc/tutorial/01_install.md
@@ -128,7 +128,7 @@ As the [**pgagroal**](https://github.com/agroal/pgagroal) operating system user,
 
 ```
 pgagroal-admin master-key
-pgagroal-admin -f /etc/pgagroal/pgagroal_users.conf -U myuser -P mypassword user add
+PGAGROAL_PASSWORD=password pgagroal-admin -f /etc/pgagroal/pgagroal_users.conf -U myuser user add
 ```
 
 **You have to choose a password for the master key - remember it !**

--- a/doc/tutorial/05_split_security.md
+++ b/doc/tutorial/05_split_security.md
@@ -27,7 +27,7 @@ As an example, consider the user `myuser` created in the [Installing pgagroal tu
 To achieve this, as [**pgagroal**](https://github.com/agroal/pgagroal) operating system run the following command:
 
 ```
-pgagroal-admin -f /etc/pgagroal/pgagroal_frontend_users.conf -U myuser -P application_password user add
+PGAGROAL_PASSWORD=application_password pgagroal-admin -f /etc/pgagroal/pgagroal_frontend_users.conf -U myuser user add
 ```
 
 ([**pgagroal**](https://github.com/agroal/pgagroal) user)

--- a/doc/tutorial/07_vault.md
+++ b/doc/tutorial/07_vault.md
@@ -19,7 +19,7 @@ Assuming that the master key is already generated and an admin is already presen
 As the [**pgagroal**](https://github.com/agroal/pgagroal) operating system user, add the `myuser` to the pooler:
 
 ```
-pgagroal-admin -f /etc/pgagroal/pgagroal_users.conf -U myuser -P mypassword user add
+PGAGROAL_PASSWORD=mypassword pgagroal-admin -f /etc/pgagroal/pgagroal_users.conf -U myuser user add
 ```
 
 The `myuser` and `mypassword` should be the original PostgresSQL's user and its corresponding password.
@@ -29,7 +29,7 @@ The `myuser` and `mypassword` should be the original PostgresSQL's user and its 
 As the [**pgagroal**](https://github.com/agroal/pgagroal) operating system user, add the `myuser` to the pooler:
 
 ```
-pgagroal-admin -f /etc/pgagroal/pgagroal_frontend_users.conf -U myuser -P password user add
+PGAGROAL_PASSWORD=password pgagroal-admin -f /etc/pgagroal/pgagroal_frontend_users.conf -U myuser user add
 ```
 
 **Remember the frontend password should be between [8-1024] characters long.**
@@ -76,7 +76,7 @@ and press `Ctrl-d` (if running `cat`) to save the file.
 As the [**pgagroal**](https://github.com/agroal/pgagroal) operating system user, run the following command:
 
 ```
-pgagroal-admin -f /etc/pgagroal/pgagroal_vault_users.conf -U admin -P admin1234 add-user
+PGAGROAL_PASSWORD=admin1234 pgagroal-admin -f /etc/pgagroal/pgagroal_vault_users.conf -U admin user add
 ```
 
 The above will create the `admin` username with the `admin1234` password.Alternately, `/etc/pgagroal/pgagroal_admins.conf` can be provided for vault users information.

--- a/src/admin.c
+++ b/src/admin.c
@@ -387,28 +387,37 @@ master_key(char* password, bool generate_pwd, int pwd_length, int32_t output_for
 
    if (password == NULL)
    {
-      if (!generate_pwd)
-      {
-         while (password == NULL)
-         {
-            printf("Master key (will not echo): ");
-            password = pgagroal_get_password();
-            printf("\n");
-
-            if (password != NULL && strlen(password) < MIN_PASSWORD_LENGTH)
-            {
-               printf("Invalid key length, must be at least %d chars.\n", MIN_PASSWORD_LENGTH);
-               free(password);
-               password = NULL;
-            }
-         }
-      }
-      else
+      if (generate_pwd)
       {
          if (pgagroal_generate_password(pwd_length, &password))
          {
             do_free = false;
             goto error;
+         }
+      }
+      else
+      {
+         password = secure_getenv("PGAGROAL_PASSWORD");
+
+         if (password == NULL)
+         {
+            while (password == NULL)
+            {
+               printf("Master key (will not echo): ");
+               password = pgagroal_get_password();
+               printf("\n");
+
+               if (password != NULL && strlen(password) < MIN_PASSWORD_LENGTH)
+               {
+                  printf("Invalid key length, must be at least %d chars.\n", MIN_PASSWORD_LENGTH);
+                  free(password);
+                  password = NULL;
+               }
+            }
+         }
+         else
+         {
+            do_free = false;
          }
       }
    }
@@ -586,15 +595,25 @@ password:
       }
       else
       {
-         printf("Password : ");
+         password = secure_getenv("PGAGROAL_PASSWORD");
 
-         if (password != NULL)
+         if (password == NULL)
          {
-            free(password);
-            password = NULL;
-         }
+            printf("Password : ");
 
-         password = pgagroal_get_password();
+            if (password != NULL)
+            {
+               free(password);
+               password = NULL;
+            }
+
+            password = pgagroal_get_password();
+         }
+	       else
+         {
+            do_free = false;
+            do_verify = false;
+         }
       }
       printf("\n");
    }
@@ -815,15 +834,25 @@ password:
             }
             else
             {
-               printf("Password : ");
+               password = secure_getenv("PGAGROAL_PASSWORD");
 
-               if (password != NULL)
+               if (password == NULL)
                {
-                  free(password);
-                  password = NULL;
-               }
+                  printf("Password : ");
 
-               password = pgagroal_get_password();
+                  if (password != NULL)
+                  {
+                     free(password);
+                     password = NULL;
+                  }
+
+                  password = pgagroal_get_password();
+               }
+	             else
+               {
+                  do_free = false;
+                  do_verify = false;
+               }
             }
             printf("\n");
          }


### PR DESCRIPTION
Passing the password through the "--password" command line argument is potentially insecure, as the value would be exposed in a process listing or shell history. Read an environment variable as an alternative.