### PR TITLE
admin: remove stray tab characters

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -609,7 +609,7 @@ password:
 
             password = pgagroal_get_password();
          }
-	       else
+         else
          {
             do_free = false;
             do_verify = false;
@@ -848,7 +848,7 @@ password:
 
                   password = pgagroal_get_password();
                }
-	             else
+               else
                {
                   do_free = false;
                   do_verify = false;


### PR DESCRIPTION
Accidentally introduced, remove to align with rest of the file.

Fixes: 3b43af89b9c5 ("admin: support password through environment")