### PR TITLE
network.c: cleanup in case connect() fails in pgagroal_connect_unix_s…

### DIFF
--- a/src/libpgagroal/network.c
+++ b/src/libpgagroal/network.c
@@ -388,7 +388,9 @@ pgagroal_connect_unix_socket(const char* directory, const char* file, int* fd)
    if (connect(*fd, (struct sockaddr*)&addr, sizeof(addr)) == -1)
    {
       pgagroal_log_trace("pgagroal_connect_unix_socket: connect: %s/%s %s", directory, file, strerror(errno));
+      pgagroal_disconnect(*fd);
       errno = 0;
+      *fd = -1;
       return 1;
    }
 


### PR DESCRIPTION
…ocket()

The fd never gets closed when connect() fails inside pgagroal_connect_unix_socket(). Fix this by calling pgagroal_disconnect(fd).