### PR TITLE
ci.yml: Fix Linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,16 @@ jobs:
       run: sudo apt install -y postgresql
     - name: Start postgres
       run: |
-        version=$(pg_config --version | grep -Eo "[0-9]{1,2}" | head -1)
-        sudo -u postgres /usr/lib/postgresql/${version}/bin/pg_ctl start -D /etc/postgresql/${version}/main/
+        sudo apt install curl ca-certificates
+        sudo install -d /usr/share/postgresql-common/pgdg
+        sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+        sudo sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+        sudo apt update
+        sudo apt install -y postgresql-17 postgresql-common postgresql-contrib
+    - name: Set Env Path Variable
+      run: |
+        echo "PATH=$PATH:/usr/lib/postgresql/17/bin" >> $GITHUB_ENV
+        echo $PATH
     - name: GCC/mkdir
       run: mkdir build
       working-directory: /home/runner/work/pgagroal/pgagroal/
@@ -63,19 +71,14 @@ jobs:
         sleep 5
         ./pgagroal-cli ping
       working-directory: /home/runner/work/pgagroal/pgagroal/build/src/
-    - name: GCC/Stop pgagroal & postgres
+    - name: GCC/Stop pgagroal
       run: |
         ./pgagroal-cli shutdown
         version=$(pg_config --version | grep -Eo "[0-9]{1,2}" | head -1)
-        sudo -u postgres /usr/lib/postgresql/${version}/bin/pg_ctl stop -D /etc/postgresql/${version}/main/
       working-directory: /home/runner/work/pgagroal/pgagroal/build/src/
     - name: rm -Rf
       run: rm -Rf build/
       working-directory: /home/runner/work/pgagroal/pgagroal/
-    - name: Start postgres
-      run: |
-        version=$(pg_config --version | grep -Eo "[0-9]{1,2}" | head -1)
-        sudo -u postgres /usr/lib/postgresql/${version}/bin/pg_ctl start -D /etc/postgresql/${version}/main/
     - name: CLANG/mkdir
       run: mkdir build
       working-directory: /home/runner/work/pgagroal/pgagroal/
@@ -94,11 +97,10 @@ jobs:
         sleep 5
         ./pgagroal-cli ping
       working-directory: /home/runner/work/pgagroal/pgagroal/build/src/
-    - name: CLANG/Stop pgagroal & postgres
+    - name: CLANG/Stop pgagroal
       run: |
         ./pgagroal-cli shutdown
         version=$(pg_config --version | grep -Eo "[0-9]{1,2}" | head -1)
-        sudo -u postgres /usr/lib/postgresql/${version}/bin/pg_ctl stop -D /etc/postgresql/${version}/main/
       working-directory: /home/runner/work/pgagroal/pgagroal/build/src/
 
 


### PR DESCRIPTION
Linux CI started to break due to new postgres version being installed with apt. Fix this by correcting the postgres data directory. Also download ca-certificates and install pgdg repository keys.

*This does not fix macOS CI* because CI is failing on secure_getenv() function. This function is present on FreeBSD 14+ but apparently not on macOS: https://man.freebsd.org/cgi/man.cgi?getenv(3).

Our options are to either disable CI, use HAVE_LINUX macros and getenv() function for macOS (which I think is bad unless we are supporting macOS) or we use this https://github.com/marketplace/actions/freebsd-vm