### PR TITLE
[#512] Added pgagroal_linux_version function to extract Linux kernel Version.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Haoran Zhang <andrewzhr9911@gmail.com>
 Mohanad Khaled <mohanadkhaled87@gmail.com>
 Christian Englert <code@c.roboticbrain.de>
 Georg Pfuetzenreuter <georg.pfuetzenreuter@suse.com>
+Tejas Tyagi <tejastyagi.tt@gmail.com>

--- a/doc/manual/97-acknowledgement.md
+++ b/doc/manual/97-acknowledgement.md
@@ -23,6 +23,7 @@ Mohanad Khaled <mohanadkhaled87@gmail.com>
 Haoran Zhang <andrewzhr9911@gmail.com>
 Christian Englert <code@c.roboticbrain.de>
 Georg Pfuetzenreuter <georg.pfuetzenreuter@suse.com>
+Tejas Tyagi <tejastyagi.tt@gmail.com>
 ```
 
 ## Committers

--- a/doc/manual/advanced/97-acknowledgement.md
+++ b/doc/manual/advanced/97-acknowledgement.md
@@ -23,6 +23,7 @@ Mohanad Khaled <mohanadkhaled87@gmail.com>
 Haoran Zhang <andrewzhr9911@gmail.com>
 Christian Englert <code@c.roboticbrain.de>
 Georg Pfuetzenreuter <georg.pfuetzenreuter@suse.com>
+Tejas Tyagi <tejastyagi.tt@gmail.com>
 ```
 
 ## Committers

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -586,6 +586,19 @@ pgagroal_server_state_as_string(signed char state);
 char*
 pgagroal_connection_state_as_string(signed char state);
 
+/**
+ * Get the OS name and kernel version.
+ *
+ * @param os            Pointer to store the OS name (e.g., "Linux", "FreeBSD", "OpenBSD").
+ *                      Memory will be allocated internally and should be freed by the caller.
+ * @param kernel_major  Pointer to store the kernel major version.
+ * @param kernel_minor  Pointer to store the kernel minor version.
+ * @param kernel_patch  Pointer to store the kernel patch version.
+ * @return              0 on success, 1 on error.
+ */
+int
+pgagroal_os_kernel_version(char** os, int* kernel_major, int* kernel_minor, int* kernel_patch);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libpgagroal/utils.c
+++ b/src/libpgagroal/utils.c
@@ -46,6 +46,7 @@
 #include <openssl/pem.h>
 #include <sys/types.h>
 #include <err.h>
+#include <sys/utsname.h>
 
 #ifndef EVBACKEND_LINUXAIO
 #define EVBACKEND_LINUXAIO 0x00000040U
@@ -1301,4 +1302,88 @@ pgagroal_escape_string(char* str)
    translated_ec_string[idx] = '\0'; // terminator
 
    return translated_ec_string;
+}
+
+int
+pgagroal_os_kernel_version(char** os, int* kernel_major, int* kernel_minor, int* kernel_patch)
+{
+
+   *os = NULL;
+   *kernel_major = 0;
+   *kernel_minor = 0;
+   *kernel_patch = 0;
+
+#if defined(HAVE_LINUX) || defined(HAVE_FREEBSD) || defined(HAVE_OPENBSD) || defined(HAVE_OSX)
+   struct utsname buffer;
+
+   if (uname(&buffer) != 0)
+   {
+      pgagroal_log_debug("Failed to retrieve system information.\n");
+      goto error;
+   }
+
+   // Copy system name using pgagroal_append (dynamically allocated)
+   *os = pgagroal_append(NULL, buffer.sysname);
+   if (*os == NULL)
+   {
+      pgagroal_log_debug("Failed to allocate memory for OS name.\n");
+      goto error;
+   }
+
+   // Parse kernel version based on OS
+#if defined(HAVE_LINUX)
+   if (sscanf(buffer.release, "%d.%d.%d", kernel_major, kernel_minor, kernel_patch) < 2)
+   {
+      pgagroal_log_debug("Failed to parse Linux kernel version.\n");
+      goto error;
+   }
+#elif defined(HAVE_FREEBSD) || defined(HAVE_OPENBSD)
+   if (sscanf(buffer.release, "%d.%d", kernel_major, kernel_minor) < 2)
+   {
+      pgagroal_log_debug("Failed to parse BSD OS kernel version.\n");
+      goto error;
+   }
+   *kernel_patch = 0; // BSD doesn't use patch version
+#elif defined(HAVE_OSX)
+   if (sscanf(buffer.release, "%d.%d.%d", kernel_major, kernel_minor, kernel_patch) < 2)
+   {
+      pgagroal_log_debug("Failed to parse macOS kernel version.\n");
+      goto error;
+   }
+#endif
+
+   pgagroal_log_debug("OS: %s | Kernel Version: %d.%d.%d\n", *os, *kernel_major, *kernel_minor, *kernel_patch);
+   return 0;
+
+error:
+   //Free memory if already allocated
+   if (*os != NULL)
+   {
+      free(*os);
+      *os = NULL;
+   }
+
+   *os = pgagroal_append(NULL, "Unknown");
+   if (*os == NULL)
+   {
+      pgagroal_log_debug("Failed to allocate memory for unknown OS name.\n");
+   }
+
+   pgagroal_log_debug("Unable to retrieve OS and kernel version.\n");
+
+   *kernel_major = 0;
+   *kernel_minor = 0;
+   *kernel_patch = 0;
+   return 1;
+
+#else
+   *os = pgagroal_append(NULL, "Unknown");
+   if (*os == NULL)
+   {
+      pgagroal_log_debug("Failed to allocate memory for unknown OS name.\n");
+   }
+
+   pgagroal_log_debug("Kernel version not available.\n");
+   return 1;
+#endif
 }

--- a/src/main.c
+++ b/src/main.c
@@ -344,6 +344,9 @@ main(int argc, char** argv)
    struct main_configuration* config = NULL;
    int ret;
    int c;
+   char* os = NULL;
+
+   int kernel_major, kernel_minor, kernel_patch;
    bool conf_file_mandatory;
    char message[MISC_LENGTH]; // a generic message used for errors
    argv_ptr = argv;
@@ -917,6 +920,10 @@ read_superuser_path:
    pgagroal_initialize_random();
 
    pgagroal_set_proc_title(argc, argv, "main", NULL);
+
+   pgagroal_os_kernel_version(&os, &kernel_major, &kernel_minor, &kernel_patch);
+
+   free(os);
 
    /* Bind Unix Domain Socket: Main */
    if (pgagroal_bind_unix_socket(config->unix_socket_dir, MAIN_UDS, &unix_management_socket))


### PR DESCRIPTION
This PR introduces the function pgagroal_os_kernel_version() to retrieve the operating system name and kernel version as integers (major, minor, patch).

Key Features:

Utilizes uname() to extract system information.

Supports Linux, FreeBSD, OpenBSD, and macOS (Darwin).

Returns "Unknown" for unsupported platforms.

Logs the OS name and kernel version if available.

Handles errors gracefully and logs debug messages if retrieval fails.

Let me know if any refinements are required! 
