### PR TITLE
[#517] Add OS and Kernel Version as a Prometheus Metric.

### DIFF
--- a/doc/manual/user-11-prometheus.md
+++ b/doc/manual/user-11-prometheus.md
@@ -259,3 +259,105 @@ Number of sockets the client used
 ## pgagroal_vault_self_sockets
 
 Number of sockets used by pgagroal-vault itself
+
+# Prometheus Metrics for OS Info 
+
+pgagroal exposes operating system information through three distinct Prometheus metrics, depending on the underlying operating system:
+
+---
+
+| Operating System           |    Metric Name       |       Included Labels                | 
+|----------------------------|----------------------|--------------------------------------|
+| **Linux**                  | `pgagroal_os_linux`  | `os`, `major`, `minor`, `patch`      |
+| **macOS**                  | `pgagroal_os_macos`  | `os`, `major`, `minor`, `patch`      |
+|**BSD (FreeBSD, OpenBSD)**  | `pgagroal_os_bsd`    | `os`, `major`, `minor`               |
+
+---
+
+
+## pgagroal_os_linux
+
+The `pgagroal_os_linux` metric reports the kernel version for **Linux-based** systems. It includes the following labels:
+
+- `os`: The name of the operating system.
+- `major`: The major version of the kernel.
+- `minor`: The minor version of the kernel.
+- `patch`: The patch version of the kernel.
+
+###  Conditions for Exposure:
+- The metric is exposed **only if the kernel version retrieval succeeds**.
+- If kernel version retrieval fails, **no metric will be emitted**.
+
+### Example Output:
+```text
+# HELP pgagroal_os_linux Kernel version as major.minor.patch
+# TYPE pgagroal_os_linux gauge
+pgagroal_os_linux{os="Linux", major="6", minor="13", patch="4"} 1
+```
+
+---
+
+## pgagroal_os_macos
+
+The `pgagroal_os_macos` metric reports the kernel version for **macOS-based** systems. It includes the same labels as Linux:
+
+- `os`: The name of the operating system.
+- `major`: The major version of the kernel.
+- `minor`: The minor version of the kernel.
+- `patch`: The patch version of the kernel.
+
+###  Conditions for Exposure:
+- The metric is exposed **only if the kernel version retrieval succeeds**.
+- If kernel version retrieval fails, **no metric will be emitted**.
+
+### Example Output:
+```text
+# HELP pgagroal_os_macos Kernel version as major.minor.patch
+# TYPE pgagroal_os_macos gauge
+pgagroal_os_macos{os="macOS", major="23", minor="3", patch="0"} 1
+```
+
+---
+
+## pgagroal_os_bsd
+
+The `pgagroal_os_bsd` metric reports the operating system version for **BSD-based** systems (such as FreeBSD and OpenBSD).  
+Since BSD systems do not provide a patch version in the same way as Linux/macOS, the metric includes only:
+
+- `os`: The name of the operating system.
+- `major`: The major version of the operating system.
+- `minor`: The minor version of the operating system.
+
+Unlike Linux/macOS, which report the kernel version, BSD reports the operating system version.
+
+### Conditions for Exposure:
+- The metric is exposed **only if the operating system version retrieval succeeds**.
+- The **patch version is not available** on BSD systems, so it is omitted from the metric.
+- If operating system version retrieval fails, **no metric will be emitted**.
+
+### Example Output:
+```text
+# HELP pgagroal_os_bsd operating system version as major.minor
+# TYPE pgagroal_os_bsd gauge
+pgagroal_os_bsd{os="FreeBSD", major="13", minor="2"} 1
+```
+---
+
+## Behavior Summary
+
+| Operating System           | Metric Name                       | Availability Conditions                                       |
+|----------------------------|-----------------------------------|---------------------------------------------------------------|
+| **Linux**                  | `pgagroal_os_linux`               |    Available if kernel version retrieval succeeds               |
+| **macOS**                  | `pgagroal_os_macos`               |    Available if kernel version retrieval succeeds               |
+| **BSD (FreeBSD, OpenBSD)** | `pgagroal_os_bsd`                 |    Available if operating system version retrieval succeeds (patch not available) |
+
+---
+
+
+##  When Metrics Are Not Exposed
+
+- If version retrieval **fails** (e.g., unsupported system call, permission issues), **no metric will be emitted**.
+- If the system is **unsupported** (e.g., Windows or an unknown OS), **pgagroal will not attempt to expose a metric**.
+
+---
+

--- a/src/admin.c
+++ b/src/admin.c
@@ -384,7 +384,7 @@ master_key(char* password, bool generate_pwd, int pwd_length, int32_t output_for
       warnx("Could not write to master key file <%s>", &buf[0]);
       goto error;
    }
-   
+
    #if defined(HAVE_OSX)
       #define PGAGROAL_GETENV(name) getenv(name)
    #else

--- a/src/main.c
+++ b/src/main.c
@@ -921,8 +921,6 @@ read_superuser_path:
 
    pgagroal_set_proc_title(argc, argv, "main", NULL);
 
-   pgagroal_os_kernel_version(&os, &kernel_major, &kernel_minor, &kernel_patch);
-
    free(os);
 
    /* Bind Unix Domain Socket: Main */
@@ -1175,6 +1173,9 @@ read_superuser_path:
    pgagroal_log_debug("Known frontend users: %d", config->number_of_frontend_users);
    pgagroal_log_debug("Known admins: %d", config->number_of_admins);
    pgagroal_log_debug("Known superuser: %s", strlen(config->superuser.username) > 0 ? "Yes" : "No");
+
+   /* Retrieve and log the OS kernel version; this has no effect on Pgagroal's operation */
+   pgagroal_os_kernel_version(&os, &kernel_major, &kernel_minor, &kernel_patch);
 
    if (!config->allow_unknown_users && config->number_of_users == 0)
    {


### PR DESCRIPTION
Added Prometheus metrics to expose OS and kernel version:

    pgagroal_os_linux (Linux)

    pgagroal_os_macos (macOS)

    pgagroal_os_bsd (BSD)

Metrics include labels: os, major, minor (patch for Linux/macOS).

Emitted only if retrieval succeeds; failure logs an error.
