### PR TITLE
Use secure_getenv or getenv based on OS for compatibility

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -384,6 +384,12 @@ master_key(char* password, bool generate_pwd, int pwd_length, int32_t output_for
       warnx("Could not write to master key file <%s>", &buf[0]);
       goto error;
    }
+   
+   #if defined(HAVE_OSX)
+      #define PGAGROAL_GETENV(name) getenv(name)
+   #else
+      #define PGAGROAL_GETENV(name) secure_getenv(name)
+   #endif
 
    if (password == NULL)
    {
@@ -397,7 +403,7 @@ master_key(char* password, bool generate_pwd, int pwd_length, int32_t output_for
       }
       else
       {
-         password = secure_getenv("PGAGROAL_PASSWORD");
+         password = PGAGROAL_GETENV("PGAGROAL_PASSWORD");
 
          if (password == NULL)
          {
@@ -595,7 +601,7 @@ password:
       }
       else
       {
-         password = secure_getenv("PGAGROAL_PASSWORD");
+         password = PGAGROAL_GETENV("PGAGROAL_PASSWORD");
 
          if (password == NULL)
          {
@@ -834,7 +840,7 @@ password:
             }
             else
             {
-               password = secure_getenv("PGAGROAL_PASSWORD");
+               password = PGAGROAL_GETENV("PGAGROAL_PASSWORD");
 
                if (password == NULL)
                {


### PR DESCRIPTION
Implemented a macro that automatically chooses getenv on Apple platforms and secure_getenv on other systems to ensure macOS compatibility