### PR TITLE
[#521] Add directory configuration option

### DIFF
--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -18,6 +18,7 @@ Options:
   -F, --frontend FRONTEND_USERS_FILE Set the path to the pgagroal_frontend_users.conf file
   -A, --admins ADMINS_FILE           Set the path to the pgagroal_admins.conf file
   -S, --superuser SUPERUSER_FILE     Set the path to the pgagroal_superuser.conf file
+  -D, --directory DIRECTORY_PATH     Set the path to load configuration files
   -d, --daemon                       Run as a daemon
   -V, --version                      Display version information
   -?, --help                         Display help

--- a/doc/man/pgagroal.1.rst
+++ b/doc/man/pgagroal.1.rst
@@ -39,6 +39,9 @@ OPTIONS
 -S, --superuser SUPERUSER_FILE
   Set the path to the pgagroal_superuser.conf file
 
+-D, --directory DIRECTORY_PATH
+  Set the path to load configuration files
+
 -d, --daemon
   Run as a daemon
 

--- a/doc/manual/user-01-quickstart.md
+++ b/doc/manual/user-01-quickstart.md
@@ -19,6 +19,7 @@ Options:
   -F, --frontend FRONTEND_USERS_FILE Set the path to the pgagroal_frontend_users.conf file
   -A, --admins ADMINS_FILE           Set the path to the pgagroal_admins.conf file
   -S, --superuser SUPERUSER_FILE     Set the path to the pgagroal_superuser.conf file
+  -D, --directory DIRECTORY_PATH     Set the path to load configuration files
   -d, --daemon                       Run as a daemon
   -V, --version                      Display version information
   -?, --help                         Display help

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -132,6 +132,16 @@ int
 pgagroal_init_configuration(void* shmem);
 
 /**
+ * Check and set directory path
+ * @param directory_path Directory to search for path
+ * @param default_path Default path to file
+ * @param path Pointer to the path to be set
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgagroal_normalize_path(char* directory_path, char* default_path, char** path);
+
+/**
  * Initialize the vault configuration structure
  * @param shmem The shared memory segment
  * @return 0 upon success, otherwise 1

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -177,6 +177,59 @@ pgagroal_init_configuration(void* shm)
    return 0;
 }
 
+int
+pgagroal_normalize_path(char* directory_path, char* default_path, char** path)
+{
+   char* dir_copy = NULL;
+   char* temp_path = NULL;
+   char* local_path = NULL;
+
+   if (*path != NULL || default_path == NULL)
+   {
+      return 0;
+   }
+
+   dir_copy = strdup(directory_path);
+   if (dir_copy == NULL)
+   {
+      goto error;
+   }
+
+   temp_path = pgagroal_append(dir_copy, default_path + strlen(PGAGROAL_DEFAULT_CONFIGURATION_PATH));
+   if (temp_path == NULL)
+   {
+      goto error;
+   }
+
+   if (access(temp_path, F_OK) == 0)
+   {
+      local_path = strdup(temp_path);
+
+      if (local_path == NULL)
+      {
+         goto error;
+      }
+
+      *path = local_path;
+   }
+   else
+   {
+      pgagroal_log_warn("pgagroal: %s not found", temp_path);
+   }
+
+   free(temp_path);
+   return 0;
+
+error:
+   if (temp_path == NULL)
+   {
+      free(dir_copy);
+   }
+   free(temp_path);
+   free(local_path);
+   return 1;
+}
+
 /**
  * This struct is going to store the metadata
  * about which sections have been parsed during


### PR DESCRIPTION
Changes: 

- Implements 
#521, 
#487 
- Support for setting configuration directory using -D flag, while configuration files passed with individual flags take precedence over directory configuration files.
- Adds fallback configuration path.
- Add `WARN` in case default directory is passed as argument. [#521(comment)](https://github.com/agroal/pgagroal/issues/521#issuecomment-2739689989)
- Update relevant docs and CLI help messages.

also a couple files that changed after running uncrustify have been added.
 
Let me know if any changes are required. 

an `INFO` to log the precedence of flags wasn't added. [#521(comment)](https://github.com/agroal/pgagroal/issues/521#issuecomment-2739803410)