### PR TITLE
[#563] Provide a warning message if user passwords do not match

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -628,6 +628,7 @@ password:
    {
       if ((unsigned char)(*(password + i)) & 0x80)
       {
+         warnx("Illegal character(s) in password");
          goto password;
       }
    }
@@ -647,6 +648,7 @@ password:
 
       if (strlen(password) != strlen(verify) || memcmp(password, verify, strlen(password)) != 0)
       {
+         warnx("Passwords do not match");
          goto password;
       }
    }
@@ -867,6 +869,7 @@ password:
          {
             if ((unsigned char)(*(password + i)) & 0x80)
             {
+               warnx("Illegal character(s) in password");
                goto password;
             }
          }
@@ -886,6 +889,7 @@ password:
 
             if (strlen(password) != strlen(verify) || memcmp(password, verify, strlen(password)) != 0)
             {
+               warnx("Passwords do not match");
                goto password;
             }
          }


### PR DESCRIPTION
While editing password interactively, `pgagroal-admin` provides a warning message in the case the entered password do not match.

Close #563