### PR TITLE
[#570] Documentation Update

### DIFF
--- a/doc/manual/user-10-cli.md
+++ b/doc/manual/user-10-cli.md
@@ -246,28 +246,38 @@ pgagroal-cli conf set max_connections 25
 The details about how to get and set values at run-time are explained in the following.
 
 #### conf get
-Given a configuration setting name, provides the current value for such setting.
 
-The configuration setting name must be the same as the one used in the configuration files.
-It is possible to specify the setting name with words separated by dots, so that it can assume
-the form `section.context.key` where:
-- `section` can be either
-   - [**pgagroal**](https://github.com/agroal/pgagroal) (optional) the search will be performed into the main configuration settings, that is
-      those under the `[pgagroal]` settings in the `pgagroal.conf` file;
-   - `limit` the search will match against the dataabse/limit configuration, i.e., the file `pgagroal_databases.conf`;
-   - `hba` the search will match against the Host Based Access configuration, i.e., the `pgagroal_hbs.conf`;
-   - `server` the search will match against a single server defined in the main `pgagroal.conf` file.
-- `context` is the match criteria to find the information into a specific context, depending on the value of the `section`:
-   - if the `section` is set to `limit`, than the `context` is the database name to match into the `pgagroal_databases.conf`.
-     Please note that the same user could be listed more than once, in such case *only the first match* is reported back;
-   - if the `section` is set to `hba`, than the `context` is the username to match into the `pgagroal_hba.conf`.
-     Please note that the same user could be listed more than once, in such case *only the first match* is reported back;
-   - if the `section` is set to `server`, than the `context` is the name of the server in the `pgagroal.conf` main file;
-   - if the `section` is set to [**pgagroal**](https://github.com/agroal/pgagroal), the `context` must be empty;
-- `key` is the configuration key to search for.
+The `conf get` command retrieves the current value of a configuration parameter from the running instance.
 
+**Syntax:**
+```
+pgagroal-cli conf get <parameter_name> [--verbose] [--format json]
+```
 
-Examples
+**Parameter Name Format:**
+The parameter name can be specified in several forms using dot notation:
+- `key`: Refers to a global configuration parameter (e.g., `log_level`)
+- `section.key`: Refers to a parameter within a named section (e.g., `server.venkman.port`)
+- `section.context.key`: Refers to a parameter within a context, such as a limit or HBA entry (e.g., `limit.pgbench.max_size`, `hba.myuser.method`)
+
+**Supported Namespaces:**
+- `pgagroal` (optional): Main configuration namespace, e.g., `pgagroal.log_level` or simply `log_level`
+- `server`: Refers to a specific server, e.g., `server.venkman.port`
+- `limit`: Refers to a specific limit entry, e.g., `limit.pgbench.max_size`
+- `hba`: Refers to a specific HBA entry, e.g., `hba.myuser.method`
+
+**Context Rules:**
+- For `limit`, the context is the database name as found in `pgagroal_databases.conf`.
+- For `hba`, the context is the username as found in `pgagroal_hba.conf`.
+- For `server`, the context is the server name as found in `pgagroal.conf`.
+- For `pgagroal`, the context must be empty.
+
+> **Important:**  
+> If there are multiple entries with the same database name in the `limit` section or the same username in the `hba` section, **the last matching entry in the configuration file is used** for `conf get`.
+
+---
+
+**Examples:**
 ```
 pgagroal-cli conf get pipeline
 performance
@@ -278,22 +288,64 @@ pgagroal-cli conf get limit.pgbench.max_size
 pgagroal-cli conf get server.venkman.primary
 off
 
+pgagroal-cli conf get hba.myuser.method
+scram-sha-256
 ```
 
-In the above examples, `pipeline` is equivalent to `pgagroal.pipeline` and looks for a global configuration setting named `pipeline`.
-The `limit.pgbench.max_size` looks for the `max_size` set into the *limit* file (`pgagroal_databases.conf`) for the database `pgbench`.
-The `server.venkman.primary` searches for the configuration parameter `primary` into the *server* section named `venkman` in the main configuration file `pgagraol.conf`.
+In the above examples:
+- `pipeline` is equivalent to `pgagroal.pipeline` and retrieves a global configuration setting.
+- `limit.pgbench.max_size` retrieves the `max_size` for the `pgbench` database from the *last* matching entry in `pgagroal_databases.conf`.
+- `server.venkman.primary` retrieves the `primary` parameter from the server section named `venkman` in `pgagroal.conf`.
+- `hba.myuser.method` retrieves the authentication method for `myuser` from the *last* matching entry in `pgagroal_hba.conf`.
 
-If the `--verbose` option is specified, a descriptive string of the configuration parameter is printed as *name = value*:
+---
 
+**Verbose Output:**
+If the `--verbose` option is specified, the output is more descriptive:
 ```
 pgagroal-cli conf get max_connections --verbose
 max_connections = 4
 Success (0)
 ```
 
-If the parameter name specified is not found or invalid, the program `pgagroal-cli` exit normally without printing any value.
+**Behavior:**
+- If the parameter is found, its value is printed.
+- If the parameter is not found or invalid, no output is printed and the exit code is non-zero.
 
+---
+
+**Full Configuration Output:**
+
+If you run the `conf get` command without specifying any parameter name, the command will return the complete configuration, including all main settings, servers, limits, and HBA entries.
+
+```
+pgagroal-cli conf get
+```
+
+You can also retrieve a specific section by specifying only the section name:
+
+- To get all limit entries:
+  ```
+  pgagroal-cli conf get limit
+  ```
+- To get all HBA entries:
+  ```
+  pgagroal-cli conf get hba
+  ```
+- To get all Server entries:
+  ```
+  pgagroal-cli conf get server
+  ```
+
+> **Important:**  
+> When viewing the full configuration or a section (such as `limit` or `hba`), **only a single entry will be present for each database name in `limit` and for each username in `hba`**.  
+> If your configuration file contains multiple entries with the same database name (in `limit`) or the same username (in `hba`), **only the last entry in the configuration file will be shown**.   
+> Always ensure your configuration files are ordered as intended, since only the last occurrence for each key is included in response of `conf get`.
+
+This behavior is important to consider when managing or troubleshooting your configuration.
+
+**Note:**  
+The configuration key must match the format and naming used in the configuration files. For more details on available parameters and their structure, see the [Configuration documentation](./CONFIGURATION.md).
 
 
 #### conf set


### PR DESCRIPTION
The previous PR https://github.com/agroal/pgagroal/pull/578 was focused on documentation, but I realized I missed a section.
This PR adds the remaining updates, particularly for the `conf get` command and its dotted notation support.
@jesperpedersen If I’ve missed any other spots, please let me know — I’d prefer to include everything here rather than open another PR just for documentation.