### PR TITLE
[#581] Add ev_backend support to vault

### DIFF
--- a/doc/VAULT.md
+++ b/doc/VAULT.md
@@ -40,6 +40,7 @@ The available keys and their accepted values are reported in the table below.
 | log_mode | append | String | No | Append to or create the log file (append, create) |
 | log_connections | `off` | Bool | No | Log connects |
 | log_disconnections | `off` | Bool | No | Log disconnects |
+| ev_backend | auto | String | No | The event backend to use for the vault's I/O operations (`auto`, `io_uring`, `epoll`, `kqueue`). Default is `auto`, which selects the best available backend for the platform. On Linux, the preference order is: io_uring, epoll. On other platforms, kqueue is used if available. |
 | hugepage | `try` | String | No | Huge page support (`off`, `try`, `on`) |
 | tls | `off` | Bool | No | Enable Transport Layer Security (TLS) |
 | tls_cert_file | | String | No | Certificate file for TLS. This file must be owned by either the user running pgagroal or root. |

--- a/doc/etc/pgagroal_vault.conf
+++ b/doc/etc/pgagroal_vault.conf
@@ -2,6 +2,8 @@
 host = localhost
 port = 2500
 
+ev_backend = auto
+
 log_type = console
 log_level = info
 log_path =

--- a/doc/manual/advanced/10-vault.md
+++ b/doc/manual/advanced/10-vault.md
@@ -30,6 +30,8 @@ port = 2500
 
 metrics = 2501
 
+ev_backend = auto
+
 log_type = console
 log_level = info
 log_path = /tmp/pgagroal-vault.log

--- a/doc/manual/dev-02-architecture.md
+++ b/doc/manual/dev-02-architecture.md
@@ -139,6 +139,29 @@ These files contain the definition and implementation of the event loop for the 
 Each process has its own event loop, such that the process only gets notified when data related only to that process
 is ready. The main loop handles the system wide "services" such as idle timeout checks and so on.
 
+### Event Loop Context Management
+
+The event loop system uses execution contexts to properly handle different pgagroal components:
+
+**Supported Contexts:**
+- `PGAGROAL_CONTEXT_MAIN`: Main pgagroal process context
+- `PGAGROAL_CONTEXT_VAULT`: pgagroal-vault HTTP server context
+
+**Context Setting:**
+Each process sets its context before initializing the event loop using `pgagroal_event_set_context()`. This ensures:
+- Correct configuration structure is accessed (main_configuration vs vault_configuration)  
+- Proper event backend selection based on the component's configuration
+- Isolated event loop behavior per component
+
+**Backend Configuration:**
+Both main and vault contexts support the same `ev_backend` configuration options:
+- `auto`: Selects best available backend automatically
+- `io_uring`: High-performance Linux backend (disabled with TLS)
+- `epoll`: Traditional Linux event notification
+- `kqueue`: BSD/macOS event mechanism
+
+The context approach prevents configuration structure mismatches and allows independent event backend configuration for different pgagroal components.
+
 ## Pipeline
 
 [**pgagroal**](https://github.com/agroal/pgagroal) has the concept of a pipeline that defines how communication is routed from the client through [**pgagroal**](https://github.com/agroal/pgagroal) to

--- a/doc/manual/user-12-vault.md
+++ b/doc/manual/user-12-vault.md
@@ -43,6 +43,7 @@ The available keys and their accepted values are reported in the table below.
 | log_disconnections | `off` | Bool | No | Log disconnects |
 | authentication_timeout | 5 | String | No | The amount of time the process will wait for valid credentials. If this value is specified without units, it is taken as seconds. It supports the following units as suffixes: 'S' for seconds (default), 'M' for minutes, 'H' for hours, 'D' for days, and 'W' for weeks. |
 | hugepage | `try` | String | No | Huge page support (`off`, `try`, `on`) |
+| ev_backend | auto | String | No | The event backend to use for the vault's I/O operations (`auto`, `io_uring`, `epoll`, `kqueue`). Default is `auto`, which selects the best available backend for the platform. On Linux, the preference order is: io_uring, epoll. On other platforms, kqueue is used if available. Note: io_uring is not supported when TLS is enabled. |
 | tls | `off` | Bool | No | Enable Transport Layer Security (TLS) |
 | tls_cert_file | | String | No | Certificate file for TLS. This file must be owned by either the user running pgagroal or root. |
 | tls_key_file | | String | No | Private key file for TLS. This file must be owned by either the user running pgagroal or root. Additionally permissions must be at least `0640` when owned by root or `0600` otherwise. |

--- a/doc/tutorial/07_vault.md
+++ b/doc/tutorial/07_vault.md
@@ -59,6 +59,8 @@ cat > pgagroal_vault.conf
 host = localhost
 port = 2500
 
+ev_backend = auto
+
 log_type = file
 log_level = info
 log_path = /tmp/pgagroal_vault.log

--- a/src/include/ev.h
+++ b/src/include/ev.h
@@ -61,6 +61,8 @@ extern "C" {
 #define EXPERIMENTAL_FEATURE_USE_HUGE_ENABLED       0
 #define EXPERIMENTAL_FEATURE_RECV_MULTISHOT_ENABLED 0
 #define EXPERIMENTAL_FEATURE_IOVECS                 0
+#define PGAGROAL_CONTEXT_MAIN  0
+#define PGAGROAL_CONTEXT_VAULT 1
 
 #define ALIGNMENT sysconf(_SC_PAGESIZE)
 #define MAX_EVENTS   32
@@ -423,6 +425,12 @@ pgagroal_event_prep_submit_recv_outside_loop(struct io_watcher* watcher, struct 
  */
 int
 pgagroal_wait_recv(void);
+
+/**
+ * Set the execution context for event loop initialization
+ * @param context PGAGROAL_CONTEXT_MAIN or PGAGROAL_CONTEXT_VAULT
+ */
+void pgagroal_event_set_context(int context);
 
 #ifdef __cplusplus
 }

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -523,7 +523,8 @@ struct vault_configuration
 {
    struct configuration common;      /**< Common base class */
    char users_path[MAX_PATH];        /**< The configuration path */
-   int number_of_users;              /**< The number of users */
+   int number_of_users;  /**< The number of users */
+   int ev_backend;          /**< Selected ev backend */
    struct vault_server vault_server; /**< The vault servers */
 } __attribute__ ((aligned (64)));
 

--- a/src/main.c
+++ b/src/main.c
@@ -981,7 +981,7 @@ read_superuser_path:
 #endif
       goto error;
    }
-
+   pgagroal_event_set_context(PGAGROAL_CONTEXT_MAIN);
    main_loop = pgagroal_event_loop_init();
    if (!main_loop)
    {

--- a/src/vault.c
+++ b/src/vault.c
@@ -584,7 +584,8 @@ read_users_path:
       exit(1);
    }
 
-   // -- Initialize the watcher and start loop --
+//-- Initialize the watcher and start loop --
+   pgagroal_event_set_context(PGAGROAL_CONTEXT_VAULT);
    main_loop = pgagroal_event_loop_init();
    if (!main_loop)
    {

--- a/test/testcases/pgagroal_test_1.c
+++ b/test/testcases/pgagroal_test_1.c
@@ -58,13 +58,13 @@ START_TEST(test_pgagroal_database_alias2)
 START_TEST(test_pgagroal_dual_connection)
 {
    int found1 = 0, found2 = 0;
-   
+
    // Connect with original name
    found1 = !pgagroal_tsclient_execute_pgbench("postgres", true, 0, 0, 0);
-   
-   // Connect with alias name  
+
+   // Connect with alias name
    found2 = !pgagroal_tsclient_execute_pgbench("pgalias1", true, 0, 0, 0);
-   
+
    ck_assert_msg(found1 && found2, "Both original and alias connections should work");
 }
 

--- a/test/testcases/pgagroal_test_2.c
+++ b/test/testcases/pgagroal_test_2.c
@@ -58,18 +58,15 @@ START_TEST(test_pgagroal_database_alias2)
 START_TEST(test_pgagroal_dual_connection)
 {
    int found1 = 0, found2 = 0;
-   
+
    // Connect with original name
    found1 = !pgagroal_tsclient_execute_pgbench("postgres", true, 1, 0, 5);
-   
-   // Connect with alias name  
+
+   // Connect with alias name
    found2 = !pgagroal_tsclient_execute_pgbench("pgalias1", true, 1, 0, 5);
-   
+
    ck_assert_msg(found1 && found2, "Both original and alias connections should work");
 }
-
-
-
 
 // high_clients template
 // START_TEST(test_pgagroal_high_clients)


### PR DESCRIPTION
This PR implements execution context tracking to fix pgagroal-vault startup crashes by safely distinguishing between [vault_configuration] and [main_configuration] structures during event loop initialization, while adding ev_backend configuration support to enable I/O performance optimization in the vault