### PR TITLE
[#51]Replace ASCII password validation with UTF-8 validation across CLI, vault, and master key input.

### DIFF
--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -85,6 +85,7 @@ extern "C" {
 #define DEFAULT_PASSWORD_LENGTH 64
 #define MIN_PASSWORD_LENGTH      8
 #define MAX_PASSWORD_LENGTH   1024
+#define MAX_PASSWORD_CHARS     256
 #define MAX_APPLICATION_NAME    64
 #define MAX_ALIASES              8
 #define MAX_CERTIFICATES        70

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -62,8 +62,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#define MAX_PASSWORD_CHARS 256  /* Maximum UTF-8 characters in password */
-
 static int get_auth_type(struct message* msg, int* auth_type);
 static int compare_auth_response(struct message* orig, struct message* response, int auth_type);
 


### PR DESCRIPTION
This PR replaces the ASCII validation checks with UTF-8 checks in the CLI , vault and in the master key logic.
These updates should have been included in the earlier UTF-8 implementation PR.https://github.com/agroal/pgagroal/pull/640
Apologies for the oversight in missing them previously.