### PR TITLE
[#678] ev: Fix io_uring CQE reuse race condition 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
             bridge-utils
           sudo systemctl start libvirtd
       - name: Setup FreeBSD VM
-        uses: vmactions/freebsd-vm@1885b78bae4c4c4b331b4b0461d23cc14cc72387
+        uses: vmactions/freebsd-vm@v1
         id: freebsd-vm
         with:
           release: "14.3"
@@ -247,7 +247,6 @@ jobs:
               sudo \
               libev \
               cmake \
-              llvm11 \
               postgresql17-server \
               postgresql17-contrib \
               zstd \


### PR DESCRIPTION
Read cqe->res into a local variable before calling io_uring_cqe_seen() to prevent the completion queue entry from being reused before we read the result. This mirrors an upstream PostgreSQL fix for the same issue in their io_uring implementation.

The window for this race is very narrow and the likelihood of it happening is low, but the consequences (corrupted result value) would be severe.

Also removed verbose per-recv trace logging that flooded log files at TRACE level.