### PR TITLE
[#683] event: Refactor buffer management and improve I/O backend robustness

### DIFF
--- a/src/include/ev.h
+++ b/src/include/ev.h
@@ -142,6 +142,7 @@ struct io_watcher
       int __fds[2];
    } fds;                                  /**< Set of file descriptors used for I/O */
    bool ssl;                               /**< Indicates if SSL/TLS is used on this connection. */
+   struct message* msg;                    /**< Per-watcher message buffer to avoid global state races */
    void (*cb)(struct io_watcher* watcher); /**< Event callback. */
 };
 

--- a/src/include/message.h
+++ b/src/include/message.h
@@ -396,6 +396,14 @@ int
 pgagroal_recv_message(struct io_watcher* watcher, struct message** msg);
 
 /**
+ * Get the message buffer for a watcher
+ * @param watcher The watcher
+ * @return The message buffer
+ */
+struct message*
+pgagroal_get_watcher_message(struct io_watcher* watcher);
+
+/**
  * Write a message to a buffer (io_uring backend)
  * @param watcher The io_wacher used to send
  * @param msg The message to send

--- a/src/libpgagroal/message.c
+++ b/src/libpgagroal/message.c
@@ -97,9 +97,9 @@ pgagroal_write_socket_message(int socket, struct message* msg)
 }
 
 static int
-read_message_from_buffer(struct io_watcher* watcher __attribute__((unused)), struct message** msg_p)
+read_message_from_buffer(struct io_watcher* watcher, struct message** msg_p)
 {
-   struct message* msg = pgagroal_memory_message();
+   struct message* msg = pgagroal_get_watcher_message(watcher);
 
    if (msg->length == 0)
    {
@@ -1631,4 +1631,15 @@ ssl_write_message(SSL* ssl, struct message* msg)
    while (keep_write);
 
    return MESSAGE_STATUS_ERROR;
+}
+
+struct message*
+pgagroal_get_watcher_message(struct io_watcher* watcher)
+{
+   if (watcher != NULL && watcher->msg != NULL)
+   {
+      return watcher->msg;
+   }
+
+   return pgagroal_memory_message();
 }

--- a/src/libpgagroal/pipeline_transaction.c
+++ b/src/libpgagroal/pipeline_transaction.c
@@ -577,6 +577,13 @@ shutdown_mgt(struct event_loop* loop __attribute__((unused)))
    errno = 0;
    pgagroal_remove_unix_socket(config->unix_socket_dir, &p[0]);
    errno = 0;
+
+   if (server_io.io.msg)
+   {
+      free(server_io.io.msg->data);
+      free(server_io.io.msg);
+      server_io.io.msg = NULL;
+   }
 }
 
 static void

--- a/src/libpgagroal/worker.c
+++ b/src/libpgagroal/worker.c
@@ -264,18 +264,20 @@ pgagroal_worker(int client_fd, char* address, char** argv)
    {
       pgagroal_log_error("pgagroal_workers: Unable to get a transfer connection");
    }
-
-   if (pgagroal_connection_id_write(transfer_fd, CONNECTION_CLIENT_DONE))
+   else
    {
-      pgagroal_log_error("pgagroal_workers: Unable to write to a transfer connection");
-   }
+      if (pgagroal_connection_id_write(transfer_fd, CONNECTION_CLIENT_DONE))
+      {
+         pgagroal_log_error("pgagroal_workers: Unable to write to a transfer connection");
+      }
 
-   if (pgagroal_connection_pid_write(transfer_fd, getpid()))
-   {
-      pgagroal_log_error("pgagroal_workers: Unable to write to a transfer connection");
-   }
+      if (pgagroal_connection_pid_write(transfer_fd, getpid()))
+      {
+         pgagroal_log_error("pgagroal_workers: Unable to write to a transfer connection");
+      }
 
-   pgagroal_disconnect(transfer_fd);
+      pgagroal_disconnect(transfer_fd);
+   }
 
    if (client_ssl != NULL)
    {
@@ -304,6 +306,19 @@ pgagroal_worker(int client_fd, char* address, char** argv)
    free(address);
 
    pgagroal_tracking_event_basic(TRACKER_CLIENT_STOP, NULL, NULL);
+
+   if (client_io.io.msg)
+   {
+      free(client_io.io.msg->data);
+      free(client_io.io.msg);
+      client_io.io.msg = NULL;
+   }
+   if (server_io.io.msg)
+   {
+      free(server_io.io.msg->data);
+      free(server_io.io.msg);
+      server_io.io.msg = NULL;
+   }
 
    pgagroal_memory_destroy();
    pgagroal_stop_logging();


### PR DESCRIPTION


This commit addresses critical concurrency issues in the event loop and improves general robustness across all backends (io_uring, epoll, kqueue).

Key Changes:
- Implemented per-watcher message buffers for io_watchers, removing the reliance on the global pgagroal_memory_message() for receiving data. This eliminates possibility of buffer overwrite in io_uring paths.
- Centralized message buffer allocation in pgagroal_event_worker_init() to ensure all watchers have isolated memory by default.
- Enhanced ev.c stability:
    - Added fallback logic for PGAGROAL_EVENT_BACKEND_AUTO.
    - Improved signal safety with better NULL checks and signal masks.
    - Fixed potential epoll busy-wait loops on transient errors.
    - Resolved memory leaks in io_uring buffer setup.
    - Fixed watcher stop ordering to prevent inconsistent internal states.