### PR TITLE
[#688]  feat: include PostgreSQL server connectivity in ping and status responses

### DIFF
--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -66,8 +66,7 @@ pgagroal-cli flush pgbench   # pgagroal-cli flush gracefully pgbench
 ```
 
 ### ping
-The `ping` command checks if [**pgagroal**](https://github.com/pgagroal/pgagroal) is running.
-In case of success, the command does not print anything on the standard output unless the `--verbose` flag is used.
+The `ping` command checks if [**pgagroal**](https://github.com/pgagroal/pgagroal) is running and verifies connectivity to configured PostgreSQL servers.
 
 Command
 
@@ -88,6 +87,10 @@ In the case [**pgagroal**](https://github.com/pgagroal/pgagroal) is not running,
 pgagroal-cli ping          # $? = 1
 Connection error on /tmp
 ```
+
+With **JSON** output (`-F json` / `--format json`), the response includes a **`Servers`** object: one entry per configured backend. For each server you get **`Host`**, **`Port`**, **`Status`** (`Running` if PostgreSQL accepted the connectivity check, else `Down`), and **`Primary`** (`Yes`, `No`, or `Unknown`).
+
+**`Behind`**: only on **standby** (replica) backends—replication lag in **bytes** (WAL received but not yet replayed there). **`0`** means caught up. **Omitted** for primaries, when the server is down, or when lag cannot be read (for example, authentication failure). For password methods (SCRAM, MD5), configure **`health_check_user`** and the matching entry in **`pgagroal_users.conf`** so the check can log in.
 
 ### enable
 Enables a database (or all databases).
@@ -163,6 +166,8 @@ pgagroal-cli status
 ```
 
 With the `details` subcommand, a more verbose output is printed with a detail about every connection.
+
+For each configured PostgreSQL server, **`status`** and **`status details`** include the same connectivity summary as **`ping`** (host, port, running/down, primary vs standby, and **`Behind`** on standbys—see [ping](#ping)).
 
 Example
 

--- a/doc/man/pgagroal-cli.1.rst
+++ b/doc/man/pgagroal-cli.1.rst
@@ -71,7 +71,8 @@ flush [mode] [database]
   If no [database] name is specified, applies to all databases.
 
 ping
-  Verifies if pgagroal is up and running
+  Verifies if pgagroal is up and running and checks connectivity to configured PostgreSQL servers.
+  With JSON output, the response includes per-server Host, Port, Status, Primary, and **Behind** on standbys.
 
 enable [database]
   Enable the specified database, or all databases if not specified
@@ -86,7 +87,7 @@ shutdown [mode]
     - 'cancel': avoid a previously issued 'shutdown gracefully'
 
 status [details]
-  Status of pgagroal, with optional details
+  Status of pgagroal, with optional details. Per-server fields match **ping**. **details** adds limits and per-connection rows.
 
 switch-to <server>
   Switches to the specified primary server

--- a/doc/manual/en/14-cli-tools.md
+++ b/doc/manual/en/14-cli-tools.md
@@ -66,8 +66,7 @@ pgagroal-cli flush pgbench   # pgagroal-cli flush gracefully pgbench
 ```
 
 #### ping
-The `ping` command checks if [**pgagroal**][pgagroal] is running.
-In case of success, the command does not print anything on the standard output unless the `--verbose` flag is used.
+The `ping` command checks if [**pgagroal**][pgagroal] is running and verifies connectivity to configured PostgreSQL servers.
 
 Command:
 ```
@@ -79,6 +78,10 @@ Example:
 pgagroal-cli ping --verbose  # pgagroal-cli: Success (0)
 pgagroal-cli ping            # $? = 0
 ```
+
+With **JSON** output (`-F json` / `--format json`), the response includes a **`Servers`** object: one entry per configured backend. For each server you get **`Host`**, **`Port`**, **`Status`** (`Running` if PostgreSQL accepted the connectivity check, else `Down`), and **`Primary`** (`Yes`, `No`, or `Unknown`).
+
+**`Behind`**: only on **standby** (replica) backends—replication lag in **bytes** (WAL received but not yet replayed there). **`0`** means caught up. **Omitted** for primaries, when the server is down, or when lag cannot be read (for example, authentication failure). For password methods (SCRAM, MD5), configure **`health_check_user`** and the matching entry in **`pgagroal_users.conf`** so the check can log in.
 
 #### enable
 Enables a database (or all databases).
@@ -116,6 +119,8 @@ pgagroal-cli status [details]
 ```
 
 With the `details` subcommand, a more verbose output is printed with a detail about every connection.
+
+For each configured PostgreSQL server, **`status`** and **`status details`** include the same connectivity summary as **`ping`** (host, port, running/down, primary vs standby, and **`Behind`** on standbys—see [ping](#ping)).
 
 Example:
 ```

--- a/src/cli.c
+++ b/src/cli.c
@@ -356,7 +356,7 @@ usage(void)
    printf("                           - 'idle' to flush only idle connections\n");
    printf("                           - 'all' to flush all connections. USE WITH CAUTION!\n");
    printf("                           If no [database] name is specified, applies to all databases.\n");
-   printf("  ping                     Verifies if pgagroal is up and running\n");
+   printf("  ping                     Verifies if pgagroal is up and checks PostgreSQL server connectivity\n");
    printf("  enable   [database]      Enables the specified databases (or all databases)\n");
    printf("  disable  [database]      Disables the specified databases (or all databases)\n");
    printf("  shutdown [mode]          Stops pgagroal pooler. The [mode] can be:\n");

--- a/src/include/management.h
+++ b/src/include/management.h
@@ -97,6 +97,7 @@ extern "C" {
  */
 #define MANAGEMENT_ARGUMENT_ACTIVE_CONNECTIONS  "ActiveConnections"
 #define MANAGEMENT_ARGUMENT_APPNAME             "AppName"
+#define MANAGEMENT_ARGUMENT_BEHIND              "Behind"
 #define MANAGEMENT_ARGUMENT_CLIENT_VERSION      "ClientVersion"
 #define MANAGEMENT_ARGUMENT_COMMAND             "Command"
 #define MANAGEMENT_ARGUMENT_COMPRESSION         "Compression"
@@ -121,6 +122,7 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_PASSWORD            "Password"
 #define MANAGEMENT_ARGUMENT_PID                 "PID"
 #define MANAGEMENT_ARGUMENT_PORT                "Port"
+#define MANAGEMENT_ARGUMENT_PRIMARY             "Primary"
 #define MANAGEMENT_ARGUMENT_RESTART             "Restart"
 #define MANAGEMENT_ARGUMENT_SERVER              "Server"
 #define MANAGEMENT_ARGUMENT_SERVERS             "Servers"
@@ -131,7 +133,6 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_HEALTH              "Health"
 #define MANAGEMENT_ARGUMENT_STATUS              "Status"
 #define MANAGEMENT_ARGUMENT_TIME                "Time"
-#define MANAGEMENT_ARGUMENT_TIMESTAMP           "Timestamp"
 #define MANAGEMENT_ARGUMENT_TIMESTAMP           "Timestamp"
 #define MANAGEMENT_ARGUMENT_TOTAL_CONNECTIONS   "TotalConnections"
 #define MANAGEMENT_ARGUMENT_USERNAME            "Username"

--- a/src/include/queries.h
+++ b/src/include/queries.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 The pgagroal community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGAGROAL_QUERIES_H
+#define PGAGROAL_QUERIES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+
+/**
+ * SQL for startup validation: cluster id and pg_control version.
+ * @return Static query string (do not free)
+ */
+const char*
+pgagroal_queries_system_identifier(void);
+
+/**
+ * SQL for standby recovery state (single scalar).
+ * @return Static query string (do not free)
+ */
+const char*
+pgagroal_queries_is_in_recovery(void);
+
+/**
+ * SQL for replication lag in bytes on a standby (single bigint).
+ * @return Static query string (do not free)
+ */
+const char*
+pgagroal_queries_replication_lag_bytes(void);
+
+/**
+ * Read PostgreSQL wire-protocol messages from fd until ReadyForQuery, and fill
+ * @a value with the text of the first column of the first DataRow ('D').
+ *
+ * @param fd Open server connection after a query was sent
+ * @param value Output buffer (NUL-terminated on success)
+ * @param value_size Size of @a value including space for NUL
+ * @return 0 if a value was read (possibly empty), 1 on error or no DataRow
+ */
+int
+pgagroal_read_query_first_column_text(int fd, char* value, size_t value_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -115,6 +115,18 @@ pgagroal_check_server_identifiers(void);
 int
 pgagroal_server_query_execute(int server_idx, char* user, char* database, char* query, int* auth_type, int* fd_out);
 
+/**
+ * Get live PostgreSQL connectivity, role, and replication lag for one configured server.
+ *
+ * @param server       The server index into config->servers[]
+ * @param status       Output: "Running" or "Down"  (static string, do not free)
+ * @param primary      Output: "Yes", "No", or "Unknown" (static string, do not free)
+ * @param behind_bytes Output: replication lag in bytes (>= 0 for standbys; -1 if N/A or unavailable)
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgagroal_server_get_connectivity_info(int server, char** status, char** primary, int64_t* behind_bytes);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libpgagroal/queries.c
+++ b/src/libpgagroal/queries.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2026 The pgagroal community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <pgagroal.h>
+#include <message.h>
+#include <queries.h>
+#include <utils.h>
+#include <string.h>
+
+const char*
+pgagroal_queries_system_identifier(void)
+{
+   return "SELECT system_identifier, pg_control_version FROM pg_control_system()";
+}
+
+const char*
+pgagroal_queries_is_in_recovery(void)
+{
+   return "SELECT pg_is_in_recovery();";
+}
+
+const char*
+pgagroal_queries_replication_lag_bytes(void)
+{
+   return "SELECT COALESCE(pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn()), 0)::bigint;";
+}
+
+int
+pgagroal_read_query_first_column_text(int fd, char* value, size_t value_size)
+{
+   int status;
+   int offset = 0;
+   bool has_value = false;
+   struct message* msg = NULL;
+
+   if (value == NULL || value_size == 0)
+   {
+      return 1;
+   }
+
+   value[0] = '\0';
+
+   while (true)
+   {
+      status = pgagroal_read_timeout_message(NULL, fd, 5, &msg);
+      if (status != MESSAGE_STATUS_OK || msg == NULL)
+      {
+         goto error;
+      }
+
+      offset = 0;
+      while (offset < msg->length)
+      {
+         char kind = pgagroal_read_byte(msg->data + offset);
+         int len = pgagroal_read_int32(msg->data + offset + 1);
+
+         if (len <= 0)
+         {
+            goto error;
+         }
+
+         if (kind == 'D')
+         {
+            int dr_offset = offset + 5;
+            int num_cols = pgagroal_read_int16(msg->data + dr_offset);
+            dr_offset += 2;
+
+            if (num_cols >= 1)
+            {
+               int col_len = pgagroal_read_int32(msg->data + dr_offset);
+               dr_offset += 4;
+
+               if (col_len == -1)
+               {
+                  value[0] = '\0';
+                  has_value = true;
+               }
+               else if (col_len == 0)
+               {
+                  value[0] = '\0';
+                  has_value = true;
+               }
+               else if (col_len > 0)
+               {
+                  if ((size_t)col_len >= value_size)
+                  {
+                     goto error;
+                  }
+
+                  memcpy(value, msg->data + dr_offset, (size_t)col_len);
+                  value[col_len] = '\0';
+                  has_value = true;
+               }
+            }
+         }
+         else if (kind == 'E')
+         {
+            goto error;
+         }
+         else if (kind == 'Z')
+         {
+            pgagroal_clear_message(msg);
+            return has_value ? 0 : 1;
+         }
+
+         offset += 1 + len;
+      }
+
+      pgagroal_clear_message(msg);
+      msg = NULL;
+   }
+
+error:
+   pgagroal_clear_message(msg);
+   return 1;
+}

--- a/src/libpgagroal/server.c
+++ b/src/libpgagroal/server.c
@@ -32,9 +32,9 @@
 #include <logging.h>
 #include <message.h>
 #include <pool.h>
+#include <queries.h>
 #include <security.h>
 #include <server.h>
-#include <message.h>
 #include <network.h>
 #include <utils.h>
 #include <value.h>
@@ -393,7 +393,6 @@ query_system_identifier(int server_idx, char* identifier, size_t id_size, int* p
    int status;
    bool query_ready = false;
    int offset_q;
-   char buffer[8];
 
    config = (struct main_configuration*)shmem;
    srv = &config->servers[server_idx];
@@ -401,7 +400,7 @@ query_system_identifier(int server_idx, char* identifier, size_t id_size, int* p
    if (pgagroal_server_query_execute(server_idx,
                                      config->health_check_user,
                                      config->health_check_user,
-                                     "SELECT system_identifier, pg_control_version FROM pg_control_system()",
+                                     (char*)pgagroal_queries_system_identifier(),
                                      NULL, &fd) != 0)
    {
       return 1;
@@ -489,11 +488,7 @@ query_system_identifier(int server_idx, char* identifier, size_t id_size, int* p
       }
    }
 
-   /* Send Terminate */
-   buffer[0] = 'X';
-   pgagroal_write_int32(buffer + 1, 4);
-   pgagroal_write_socket(NULL, fd, buffer, 5);
-
+   (void)pgagroal_write_terminate(NULL, fd);
    pgagroal_disconnect(fd);
 
    pgagroal_log_debug("system_identifier: Server [%s] (%s:%d) = %s, pg_control_version = %d",
@@ -512,6 +507,102 @@ error:
       pgagroal_disconnect(fd);
    }
    return 1;
+}
+
+int
+pgagroal_server_get_connectivity_info(int server, char** status, char** primary, int64_t* behind_bytes)
+{
+   int fd = -1;
+   bool in_recovery = false;
+   char recovery_value[16];
+   char behind_value[64];
+   char* endptr = NULL;
+   struct main_configuration* config = (struct main_configuration*)shmem;
+
+   *status = "Down";
+   *primary = "Unknown";
+   *behind_bytes = -1;
+
+   if (server < 0 || server >= config->number_of_servers)
+   {
+      return 1;
+   }
+
+   if (strlen(config->health_check_user) == 0)
+   {
+      pgagroal_log_debug("ping/status: health_check_user is not configured, cannot perform complete server connectivity checks");
+      return 0;
+   }
+
+   if (pgagroal_server_query_execute(server,
+                                     config->health_check_user,
+                                     config->health_check_user,
+                                     (char*)pgagroal_queries_is_in_recovery(),
+                                     NULL, &fd))
+   {
+      goto done;
+   }
+
+   *status = "Running";
+
+   if (pgagroal_read_query_first_column_text(fd, recovery_value, sizeof(recovery_value)))
+   {
+      (void)pgagroal_write_terminate(NULL, fd);
+      pgagroal_disconnect(fd);
+      fd = -1;
+      goto done;
+   }
+
+   in_recovery = (recovery_value[0] == 't');
+   *primary = in_recovery ? "No" : "Yes";
+   (void)pgagroal_write_terminate(NULL, fd);
+   pgagroal_disconnect(fd);
+   fd = -1;
+
+   if (!in_recovery)
+   {
+      return 0;
+   }
+
+   if (pgagroal_server_query_execute(server,
+                                     config->health_check_user,
+                                     config->health_check_user,
+                                     (char*)pgagroal_queries_replication_lag_bytes(),
+                                     NULL, &fd))
+   {
+      return 0;
+   }
+
+   if (pgagroal_read_query_first_column_text(fd, behind_value, sizeof(behind_value)))
+   {
+      *behind_bytes = -1;
+   }
+   else if (behind_value[0] == '\0')
+   {
+      *behind_bytes = -1;
+   }
+   else
+   {
+      errno = 0;
+      *behind_bytes = (int64_t)strtoll(behind_value, &endptr, 10);
+      if (errno != 0 || endptr == behind_value || *endptr != '\0')
+      {
+         *behind_bytes = -1;
+      }
+   }
+
+   (void)pgagroal_write_terminate(NULL, fd);
+   pgagroal_disconnect(fd);
+   fd = -1;
+
+done:
+   if (fd != -1)
+   {
+      (void)pgagroal_write_terminate(NULL, fd);
+      pgagroal_disconnect(fd);
+   }
+
+   return 0;
 }
 
 int

--- a/src/libpgagroal/status.c
+++ b/src/libpgagroal/status.c
@@ -33,6 +33,7 @@
 #include <management.h>
 #include <memory.h>
 #include <network.h>
+#include <server.h>
 #include <status.h>
 #include <utils.h>
 
@@ -198,11 +199,21 @@ status_details(bool details, struct json* response)
       struct json* js = NULL;
       const char* health_str = "UNKNOWN";
       int health_state = atomic_load(&config->servers[i].health_state);
+      char* srv_status = NULL;
+      char* srv_primary = NULL;
+      int64_t behind_bytes = -1;
+
+      if (strlen(config->servers[i].name) == 0)
+      {
+         continue;
+      }
 
       if (health_state == SERVER_HEALTH_UP)
          health_str = "UP";
       else if (health_state == SERVER_HEALTH_DOWN)
          health_str = "DOWN";
+
+      pgagroal_server_get_connectivity_info(i, &srv_status, &srv_primary, &behind_bytes);
 
       pgagroal_json_create(&js);
 
@@ -213,8 +224,12 @@ status_details(bool details, struct json* response)
       pgagroal_json_put(js, MANAGEMENT_ARGUMENT_HEALTH, (uintptr_t)health_str, ValueString);
       pgagroal_json_put(js, MANAGEMENT_ARGUMENT_MAJOR_VERSION, (uintptr_t)config->servers[i].version, ValueInt32);
       pgagroal_json_put(js, MANAGEMENT_ARGUMENT_SYSTEM_IDENTIFIER, (uintptr_t)config->servers[i].system_identifier, ValueString);
+      pgagroal_json_put(js, MANAGEMENT_ARGUMENT_STATUS, (uintptr_t)srv_status, ValueString);
+      pgagroal_json_put(js, MANAGEMENT_ARGUMENT_PRIMARY, (uintptr_t)srv_primary, ValueString);
+      if (behind_bytes >= 0)
+         pgagroal_json_put(js, MANAGEMENT_ARGUMENT_BEHIND, (uintptr_t)behind_bytes, ValueInt64);
 
-      pgagroal_json_append(servers, (uintptr_t)js, ValueJSON);
+      pgagroal_json_put(servers, config->servers[i].name, (uintptr_t)js, ValueJSON);
    }
 
    pgagroal_json_put(response, MANAGEMENT_ARGUMENT_SERVERS, (uintptr_t)servers, ValueJSON);

--- a/src/main.c
+++ b/src/main.c
@@ -1943,12 +1943,43 @@ accept_mgt_cb(struct io_watcher* watcher)
    else if (id == MANAGEMENT_PING)
    {
       struct json* response = NULL;
+      struct json* servers = NULL;
 
       pgagroal_log_debug("pgagroal: Management ping");
 
       start_time = time(NULL);
 
       pgagroal_management_create_response(payload, -1, &response);
+      pgagroal_json_create(&servers);
+
+      for (int i = 0; i < config->number_of_servers; i++)
+      {
+         struct json* sobj = NULL;
+         char* srv_status = NULL;
+         char* srv_primary = NULL;
+         int64_t behind_bytes = -1;
+
+         if (strlen(config->servers[i].name) == 0)
+         {
+            continue;
+         }
+
+         pgagroal_server_get_connectivity_info(i, &srv_status, &srv_primary, &behind_bytes);
+
+         pgagroal_json_create(&sobj);
+         pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_HOST, (uintptr_t)config->servers[i].host, ValueString);
+         pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_PORT, (uintptr_t)config->servers[i].port, ValueInt32);
+         pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_STATUS, (uintptr_t)srv_status, ValueString);
+         pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_PRIMARY, (uintptr_t)srv_primary, ValueString);
+         if (behind_bytes >= 0)
+         {
+            pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_BEHIND, (uintptr_t)behind_bytes, ValueInt64);
+         }
+
+         pgagroal_json_put(servers, config->servers[i].name, (uintptr_t)sobj, ValueJSON);
+      }
+
+      pgagroal_json_put(response, MANAGEMENT_ARGUMENT_SERVERS, (uintptr_t)servers, ValueJSON);
 
       end_time = time(NULL);
 


### PR DESCRIPTION
- Closes #688


#### example output:  (as per latest changes)
```
  ServerVersion: 2.1.0
  Servers:
    primary:
      Host: 127.0.0.1
      Port: 5433
      Primary: Yes
      Status: Running
    standby:
      Behind: 5041040
      Host: 127.0.0.1
      Port: 5434
      Primary: No
      Status: Running
