### PR TITLE
[#686] Improve failover workflow

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,3 +33,4 @@ Trevor Jacob Mathews <trevorjacobmathews@gmail.com>
 Abdelrhman Sersawy <abdelrhmansersawy@gmail.com>
 Zeyad Daowd <zeyaddaowd@yahoo.com>
 Somye Mahajan <mahajan.somye@gmail.com>
+Bhawesh Panwar <panwarbhawesh1112@gmail.com>

--- a/doc/FAILOVER.md
+++ b/doc/FAILOVER.md
@@ -40,3 +40,94 @@ exit 0
 
 The script is assumed successful if it has an exit code of 0. Otherwise both servers will be
 recorded as failed.
+The script is assumed successful if it has an exit code of 0. Otherwise both servers will be recorded as failed.
+
+
+#### Notifying remaining standbys
+
+After a successful failover, pgagroal can optionally run a notification script to reconfigure standby servers.
+
+**Configuration:**
+```sh
+failover_notify_script = /path/to/notify_script.sh
+```
+
+**Requirements:**
+- Requires `failover_script` to be configured
+- Runs only after `failover_script` exits with status `0`
+- Must be executable by the pgagroal process user
+
+**Script arguments:**
+
+The script receives server information as paired arguments:
+```
+$1 = old_primary_host
+$2 = old_primary_port
+$3 = new_primary_host
+$4 = new_primary_port
+$5 = standby1_host
+$6 = standby1_port
+$7 = standby2_host
+$8 = standby2_port
+...
+```
+
+If no standbys exist, only the first 4 arguments are passed.
+
+**Example:**
+```sh
+!/bin/sh
+
+LOGGER_TAG=pgagroal
+PGDATA_DIR=/mnt/pgdata 	     # Adjust this to your data directory
+REPLICATION_USER=replicator  # Adjust if different
+
+OLD_PRIMARY_HOST=$1
+OLD_PRIMARY_PORT=$2
+NEW_PRIMARY_HOST=$3
+NEW_PRIMARY_PORT=$4
+shift 4
+
+logger -s -t $LOGGER_TAG "Failover notification: ${OLD_PRIMARY_HOST}:${OLD_PRIMARY_PORT} -> ${NEW_PRIMARY_HOST}:${NEW_PRIMARY_PORT}"
+
+
+# Process each standby (host/port pairs)
+while [ $# -gt 1 ]; do
+    STANDBY_HOST=$1
+    STANDBY_PORT=$2
+    shift 2
+    
+    logger -s -t $LOGGER_TAG "Reconfiguring standby ${STANDBY_HOST}:${STANDBY_PORT} to follow new primary..."
+    
+    # Try pg_rewind first 
+    ssh postgres@${STANDBY_HOST} "
+        pg_ctl stop -D ${PGDATA_DIR} -m fast &&
+        pg_rewind -D ${PGDATA_DIR} --source-server='host=${NEW_PRIMARY_HOST} port=${NEW_PRIMARY_PORT} user=${REPLICATION_USER}' &&
+        pg_ctl start -D ${PGDATA_DIR}
+    " 2> /tmp/standby_rewind_${STANDBY_HOST}_$$.log
+    
+    if [ $? -eq 0 ]; then
+        logger -s -t $LOGGER_TAG "Standby ${STANDBY_HOST}:${STANDBY_PORT} reconfigured successfully"
+        continue
+    fi
+    
+    # Fallback to pg_basebackup if rewind fails
+    ssh postgres@${STANDBY_HOST} "
+        rm -rf ${PGDATA_DIR}/* &&
+        pg_basebackup -h ${NEW_PRIMARY_HOST} -p ${NEW_PRIMARY_PORT} -U ${REPLICATION_USER} -D ${PGDATA_DIR} -Fp -Xs -P -R &&
+        pg_ctl start -D ${PGDATA_DIR}
+    " 2> /tmp/standby_basebackup_${STANDBY_HOST}_$$.log
+    
+    if [ $? -ne 0 ]; then
+        logger -s -t $LOGGER_TAG "ERROR: Failed to reconfigure standby ${STANDBY_HOST}:${STANDBY_PORT}"
+        logger -s -t $LOGGER_TAG < /tmp/standby_basebackup_${STANDBY_HOST}_$$.log
+        exit 1
+    else
+        logger -s -t $LOGGER_TAG "Standby ${STANDBY_HOST}:${STANDBY_PORT} reconfigured successfully"
+    fi
+done
+
+logger -s -t $LOGGER_TAG "All standbys reconfigured successfully"
+exit 0
+
+```

--- a/doc/manual/en/16-failover.md
+++ b/doc/manual/en/16-failover.md
@@ -79,6 +79,136 @@ if pg_isready -h $OLD_PRIMARY_HOST -p $OLD_PRIMARY_PORT; then
 fi
 ```
 
+## Failover Notification Script
+
+After a successful failover, you can optionally configure a notification script to reconfigure standby servers to follow the new primary.
+
+### Configuration
+
+In `pgagroal.conf` add:
+```
+failover_notify_script = /path/to/notify_script.sh
+```
+
+**Important**: The `failover_notify_script` requires `failover_script` to be configured. The notification script runs only after a successful failover.
+
+The script runs with the same permissions as the pgagroal process and must be executable by that user.
+
+### Script Parameters
+
+The notification script receives server information as separate arguments:
+
+1. Old primary host
+2. Old primary port
+3. New primary host
+4. New primary port
+5. Standby host (if any)
+6. Standby port (if any)
+7. Additional standby host/port pairs...
+
+Arguments 5 onwards repeat in pairs (host, port) for each standby server that needs reconfiguration.
+
+### Example Notification Script
+
+A basic notification script to reconfigure standbys:
+```sh
+#!/bin/sh
+#
+# This is an example script for pgagroal failover notification.
+#
+# The script receives information about the old primary, new primary,
+# and remaining standby servers that need reconfiguration:
+# $1 = old primary hostname
+# $2 = old primary port
+# $3 = new primary hostname
+# $4 = new primary port
+# $5 onwards = standby hostname/port pairs
+#
+# This script reconfigures each standby to follow the new primary by:
+# 1. Stopping the standby
+# 2. Attempting pg_rewind to sync with new primary
+# 3. Falling back to pg_basebackup if pg_rewind fails
+# 4. Restarting the standby
+#
+# Adjust PGDATA_DIR to match your PostgreSQL data directory.
+# Ensure the postgres user can SSH without password to standby hosts.
+#
+# To configure pgagroal:
+# failover_notify_script = /path/to/notify_standbys.sh
+#
+
+LOGGER_TAG=pgagroal
+PGDATA_DIR=/mnt/pgdata 	     # Adjust this to your data directory
+REPLICATION_USER=replicator  # Adjust if different
+
+OLD_PRIMARY_HOST=$1
+OLD_PRIMARY_PORT=$2
+NEW_PRIMARY_HOST=$3
+NEW_PRIMARY_PORT=$4
+shift 4
+
+logger -s -t $LOGGER_TAG "Failover notification: ${OLD_PRIMARY_HOST}:${OLD_PRIMARY_PORT} -> ${NEW_PRIMARY_HOST}:${NEW_PRIMARY_PORT}"
+
+
+# Process each standby (host/port pairs)
+while [ $# -gt 1 ]; do
+    STANDBY_HOST=$1
+    STANDBY_PORT=$2
+    shift 2
+    
+    logger -s -t $LOGGER_TAG "Reconfiguring standby ${STANDBY_HOST}:${STANDBY_PORT} to follow new primary..."
+    
+    # Try pg_rewind first 
+    ssh postgres@${STANDBY_HOST} "
+        pg_ctl stop -D ${PGDATA_DIR} -m fast &&
+        pg_rewind -D ${PGDATA_DIR} --source-server='host=${NEW_PRIMARY_HOST} port=${NEW_PRIMARY_PORT} user=${REPLICATION_USER}' &&
+        pg_ctl start -D ${PGDATA_DIR}
+    " 2> /tmp/standby_rewind_${STANDBY_HOST}_$$.log
+    
+    if [ $? -eq 0 ]; then
+        logger -s -t $LOGGER_TAG "Standby ${STANDBY_HOST}:${STANDBY_PORT} reconfigured successfully"
+        continue
+    fi
+    
+    # Fallback to pg_basebackup if rewind fails
+    ssh postgres@${STANDBY_HOST} "
+        rm -rf ${PGDATA_DIR}/* &&
+        pg_basebackup -h ${NEW_PRIMARY_HOST} -p ${NEW_PRIMARY_PORT} -U ${REPLICATION_USER} -D ${PGDATA_DIR} -Fp -Xs -P -R &&
+        pg_ctl start -D ${PGDATA_DIR}
+    " 2> /tmp/standby_basebackup_${STANDBY_HOST}_$$.log
+    
+    if [ $? -ne 0 ]; then
+        logger -s -t $LOGGER_TAG "ERROR: Failed to reconfigure standby ${STANDBY_HOST}:${STANDBY_PORT}"
+        logger -s -t $LOGGER_TAG < /tmp/standby_basebackup_${STANDBY_HOST}_$$.log
+        exit 1
+    else
+        logger -s -t $LOGGER_TAG "Standby ${STANDBY_HOST}:${STANDBY_PORT} reconfigured successfully"
+    fi
+done
+
+logger -s -t $LOGGER_TAG "All standbys reconfigured successfully"
+exit 0
+
+```
+
+### Script Requirements
+
+- The script must exit with code 0 for success
+- Non-zero exit codes are logged as errors but don't affect failover completion
+- The script should handle cases where no standbys exist (only 4 arguments passed)
+- Consider implementing idempotent operations in case the script runs multiple times
+
+### When Notification Runs
+
+The notification script executes only when:
+
+- Failover completes successfully
+- `failover_notify_script` is configured
+- At least one standby server exists in the configuration
+
+If no standbys need reconfiguration (only primary and new primary exist), the script may still run but receives only the first 4 arguments.
+
+
 ## Monitoring Failover
 
 Monitor failover events through:

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -40,6 +40,7 @@ Trevor Jacob Mathews <trevorjacobmathews@gmail.com>
 Abdelrhman Sersawy <abdelrhmansersawy@gmail.com>
 Zeyad Daowd <zeyaddaowd@yahoo.com>
 Somye Mahajan <mahajan.somye@gmail.com>
+Bhawesh Panwar <panwarbhawesh1112@gmail.com>
 ```
 
 ## Committers

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -108,6 +108,7 @@ extern "C" {
 #define CONFIGURATION_ARGUMENT_AUTH_QUERY                       "auth_query"
 #define CONFIGURATION_ARGUMENT_FAILOVER                         "failover"
 #define CONFIGURATION_ARGUMENT_FAILOVER_SCRIPT                  "failover_script"
+#define CONFIGURATION_ARGUMENT_FAILOVER_NOTIFY_SCRIPT           "failover_notify_script"
 #define CONFIGURATION_ARGUMENT_TLS                              "tls"
 #define CONFIGURATION_ARGUMENT_TLS_CERT_FILE                    "tls_cert_file"
 #define CONFIGURATION_ARGUMENT_TLS_KEY_FILE                     "tls_key_file"

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -671,8 +671,9 @@ struct main_configuration
 
    int pipeline; /**< The pipeline type */
 
-   bool failover;                     /**< Is failover enabled */
-   char failover_script[MISC_LENGTH]; /**< The failover script */
+   bool failover;                            /**< Is failover enabled */
+   char failover_script[MISC_LENGTH];        /**< The failover script */
+   char failover_notify_script[MISC_LENGTH]; /**< The failover notify script */
 
    unsigned int update_process_title; /**< Behaviour for updating the process title */
 

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -147,6 +147,7 @@ pgagroal_init_configuration(void* shm)
    }
 
    config->failover = false;
+   memset(config->failover_notify_script, 0, MISC_LENGTH);
    config->common.tls = false;
    config->gracefully = false;
    config->keep_running = true;
@@ -566,6 +567,47 @@ pgagroal_validate_configuration(void* shm, bool has_unix_socket, bool has_main_s
       if (config->number_of_servers <= 1)
       {
          pgagroal_log_fatal("pgagroal: Failover requires at least 2 servers defined");
+         return 1;
+      }
+   }
+
+   if (strlen(config->failover_notify_script) > 0)
+   {
+      if (strlen(config->failover_script) == 0)
+      {
+         pgagroal_log_fatal("pgagroal: failover_notify_script requires failover_script to be configured");
+         return 1;
+      }
+
+      if (strcmp(config->failover_script, config->failover_notify_script) == 0)
+      {
+         pgagroal_log_fatal("pgagroal: failover_notify_script cannot be the same as failover_script");
+         return 1;
+      }
+
+      memset(&st, 0, sizeof(struct stat));
+
+      if (stat(config->failover_notify_script, &st) == -1)
+      {
+         pgagroal_log_error("pgagroal: Can't locate failover notify script: %s", config->failover_notify_script);
+         return 1;
+      }
+
+      if (!S_ISREG(st.st_mode))
+      {
+         pgagroal_log_error("pgagroal: Failover notify script is not a regular file: %s", config->failover_notify_script);
+         return 1;
+      }
+
+      if (st.st_uid != geteuid())
+      {
+         pgagroal_log_error("pgagroal: Failover notify script not owned by user: %s", config->failover_notify_script);
+         return 1;
+      }
+
+      if (!(st.st_mode & (S_IRUSR | S_IXUSR)))
+      {
+         pgagroal_log_error("pgagroal: Failover notify script must be executable: %s", config->failover_notify_script);
          return 1;
       }
    }
@@ -3456,6 +3498,7 @@ transfer_configuration(struct main_configuration* config, struct main_configurat
 
    config->failover = reload->failover;
    memcpy(config->failover_script, reload->failover_script, MISC_LENGTH);
+   memcpy(config->failover_notify_script, reload->failover_notify_script, MISC_LENGTH);
 
    /* log_type */
    if (restart_int("log_type", config->common.log_type, reload->common.log_type))
@@ -4618,6 +4661,10 @@ pgagroal_write_config_value(char* buffer, char* config_key, size_t buffer_size)
       {
          return to_string(buffer, config->failover_script, buffer_size);
       }
+      else if (!strncmp(key, "failover_notify_script", MISC_LENGTH))
+      {
+         return to_string(buffer, config->failover_notify_script, buffer_size);
+      }
       else if (!strncmp(key, "tls", MISC_LENGTH))
       {
          return to_bool(buffer, config->common.tls);
@@ -5512,6 +5559,18 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
       }
       memcpy(config->failover_script, value, max);
    }
+   else if (key_in_section("failover_notify_script", section, key, true, &unknown))
+   {
+      max = strlen(value);
+      if (max > MISC_LENGTH - 1)
+      {
+         fprintf(stderr, "Error: failover_notify_script path too long\n");
+      }
+      else
+      {
+         memcpy(config->failover_notify_script, value, max);
+      }
+   }
    else if (key_in_section("auth_query", section, key, true, &unknown))
    {
       if (as_bool(value, &config->authquery))
@@ -6381,6 +6440,7 @@ add_configuration_response(struct json* res)
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_AUTH_QUERY, (uintptr_t)config->authquery, ValueBool);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_FAILOVER, (uintptr_t)config->failover, ValueBool);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_FAILOVER_SCRIPT, (uintptr_t)config->failover_script, ValueString);
+   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_FAILOVER_NOTIFY_SCRIPT, (uintptr_t)config->failover_notify_script, ValueString);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_TLS, (uintptr_t)config->common.tls, ValueBool);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_TLS_CERT_FILE, (uintptr_t)config->common.tls_cert_file, ValueString);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_TLS_KEY_FILE, (uintptr_t)config->common.tls_key_file, ValueString);

--- a/src/libpgagroal/server.c
+++ b/src/libpgagroal/server.c
@@ -382,6 +382,90 @@ pgagroal_server_switch(char* server)
    }
 }
 
+static void
+notify_standbys(int old_primary, int new_primary)
+{
+   pid_t pid;
+   int status;
+   struct main_configuration* config = (struct main_configuration*)shmem;
+
+   pid = fork();
+   if (pid == -1)
+   {
+      pgagroal_log_error("Notify: Unable to fork notify script");
+      return;
+   }
+   else if (pid > 0)
+   {
+      waitpid(pid, &status, 0);
+
+      if (WIFEXITED(status) && WEXITSTATUS(status) == 0)
+      {
+         pgagroal_log_info("Notify: Standbys notified successfully");
+      }
+      else
+      {
+         pgagroal_log_error("Notify: Error from notify script");
+      }
+   }
+   else
+   {
+      int max_args = 5 + (config->number_of_servers * 2) + 1;
+      char** args = malloc(max_args * sizeof(char*));
+
+      if (!args)
+      {
+         pgagroal_log_error("Notify: Out of memory");
+         exit(1);
+      }
+
+      int idx = 0;
+      bool has_standbys = false;
+
+      args[idx++] = "pgagroal_failover_notify_standbys";
+
+      char* old_port = malloc(6);
+      snprintf(old_port, 6, "%d", config->servers[old_primary].port);
+      args[idx++] = config->servers[old_primary].host;
+      args[idx++] = old_port;
+
+      char* new_port = malloc(6);
+      snprintf(new_port, 6, "%d", config->servers[new_primary].port);
+      args[idx++] = config->servers[new_primary].host;
+      args[idx++] = new_port;
+
+      for (int i = 0; i < config->number_of_servers; i++)
+      {
+         if (i == old_primary || i == new_primary)
+            continue;
+
+         signed char state = atomic_load(&config->servers[i].state);
+         if (state == SERVER_REPLICA || state == SERVER_NOTINIT || state == SERVER_NOTINIT_PRIMARY)
+         {
+            has_standbys = true;
+
+            char* port = malloc(6);
+            snprintf(port, 6, "%d", config->servers[i].port);
+            args[idx++] = config->servers[i].host;
+            args[idx++] = port;
+         }
+      }
+
+      args[idx] = NULL;
+
+      if (!has_standbys)
+      {
+         pgagroal_log_warn("Notify: No standbys to notify");
+         exit(0);
+      }
+
+      execv(config->failover_notify_script, args);
+
+      pgagroal_log_error("Notify: execv() failed");
+      exit(1);
+   }
+}
+
 static int
 failover(int old_primary)
 {
@@ -429,6 +513,11 @@ failover(int old_primary)
          pgagroal_log_info("Failover: New primary is %s (%s:%d)", config->servers[new_primary].name, config->servers[new_primary].host, config->servers[new_primary].port);
          atomic_store(&config->servers[old_primary].state, SERVER_FAILED);
          atomic_store(&config->servers[new_primary].state, SERVER_PRIMARY);
+
+         if (config->failover_notify_script[0] != '\0')
+         {
+            notify_standbys(old_primary, new_primary);
+         }
       }
       else
       {

--- a/test/check.sh
+++ b/test/check.sh
@@ -63,6 +63,14 @@ USER=$(whoami)
 MODE="dev"
 PORT=6432
 
+# Ports for failover cluster
+PRIMARY_PORT=7432
+STANDBY1_PORT=7433
+STANDBY2_PORT=7434
+
+# Use existing PGAGROAL_PORT if already set, otherwise default
+PGAGROAL_PORT=${PGAGROAL_PORT:-6432}
+
 # Detect container engine: Docker or Podman
 if command -v podman &> /dev/null; then
   CONTAINER_ENGINE="podman"
@@ -570,6 +578,7 @@ usage() {
   echo "  setup                  Install dependencies and build PostgreSQL image (one-time setup)"
   echo "  clean                  Clean up test suite environment and remove PostgreSQL image"
   echo "  run-configs            Run the testsuite on multiple pgagroal configurations (containerized)"
+  echo "  failover-tests         Run failover notify script tests" 
   echo "  ci                     Run in CI mode (local PostgreSQL, no container)"
   echo "  run-configs-ci         Run multiple configuration tests using local PostgreSQL (like ci + run-configs)"
   echo "  ci-nonbuild            Run in CI mode (local PostgreSQL, skip build step)"
@@ -587,6 +596,388 @@ usage() {
   echo "  $0 -t connection        Run test matching 'connection'"
   echo "  $0 -m connection        Run all tests in module 'connection'"
   exit 1
+}
+
+failover_container_name() {
+  echo "pgagroal-test-postgresql${ENV_PGVERSION}-$1"
+}
+
+failover_prepare_dirs() {
+  local FAILOVER_BASE="$1"
+  
+  mkdir -p "$FAILOVER_BASE/log"
+  mkdir -p "$FAILOVER_BASE/conf"
+  mkdir -p "$FAILOVER_BASE/pglog"/{primary,standby1,standby2}
+
+  POSTGRES_UID=$($CONTAINER_ENGINE run --rm $IMAGE_NAME id -u postgres 2>/dev/null || echo "26")
+
+  for dir in "$FAILOVER_BASE/pglog" "$FAILOVER_BASE/pglog/primary" "$FAILOVER_BASE/pglog/standby1" "$FAILOVER_BASE/pglog/standby2"; do
+    if [ -d "$dir" ]; then
+      $CONTAINER_ENGINE unshare chown -R ${POSTGRES_UID}:${POSTGRES_UID} "$dir" 2>/dev/null || \
+      sudo chown -R ${POSTGRES_UID}:${POSTGRES_UID} "$dir" 2>/dev/null || \
+      echo "Warning: Could not change ownership of $dir"
+    fi
+  done
+}
+
+failover_start_container() {
+
+  local name=$1
+  local host_port=$2
+  local container_port=$3
+  local FAILOVER_PG_LOG_DIR=$4
+
+  local cname
+  cname=$(failover_container_name "$name")
+
+  $CONTAINER_ENGINE rm -f "$cname" >/dev/null 2>&1 || true
+
+  $CONTAINER_ENGINE run -d \
+    --name "$cname" \
+    -p ${host_port}:${container_port} \
+    -v "$FAILOVER_PG_LOG_DIR/$name:/pglog:Z" \
+    -e PG_DATABASE="mydb" \
+    -e PG_USER_NAME="myuser" \
+    -e PG_USER_PASSWORD="yourpassword" \
+    -e PG_REPL_USER_NAME="myrepl" \
+    -e PG_REPL_PASSWORD="replpass" \
+    -e PG_UTF8_USER_NAME="utf8user" \
+    -e PG_UTF8_USER_PASSWORD="yourpassword" \
+    -e PG_UTF8_DATABASE="myutf8db" \
+    -e PG_LOG_LEVEL=debug5 \
+    $IMAGE_NAME
+}
+
+failover_wait_ready() {
+
+  local cname=$1
+
+  for attempt in {1..20}; do
+    if $CONTAINER_ENGINE exec "$cname" \
+      /usr/pgsql-${ENV_PGVERSION}/bin/pg_isready -h localhost -p 5432 \
+      >/dev/null 2>&1
+    then
+      echo "$cname ready"
+      return
+    fi
+    sleep 2
+  done
+
+  echo "$cname failed to start"
+  $CONTAINER_ENGINE logs "$cname"
+  exit 1
+}
+
+failover_start_postgresql_cluster() {
+  local FAILOVER_PG_LOG_DIR=$1
+
+  echo ""
+  echo "Starting PostgreSQL cluster..."
+
+  failover_start_container primary $PRIMARY_PORT 5432 "$FAILOVER_PG_LOG_DIR"
+  failover_start_container standby1 $STANDBY1_PORT 5433 "$FAILOVER_PG_LOG_DIR"
+  failover_start_container standby2 $STANDBY2_PORT 5434 "$FAILOVER_PG_LOG_DIR"
+
+  failover_wait_ready "$(failover_container_name primary)"
+  failover_wait_ready "$(failover_container_name standby1)"
+  failover_wait_ready "$(failover_container_name standby2)"
+}
+
+failover_stop_postgresql_cluster() {
+
+  echo "Stopping PostgreSQL cluster"
+
+  for name in primary standby1 standby2
+  do
+    $CONTAINER_ENGINE rm -f "$(failover_container_name $name)" \
+      >/dev/null 2>&1 || true
+  done
+}
+
+failover_create_script() {
+
+  local script_path=$1
+  local exit_code=$2
+  local log_file=$3
+
+  cat > "$script_path" <<EOF
+#!/bin/bash
+echo "\$(date): Script called with \$# arguments" >> $log_file
+echo "\$(date): Args: \$@" >> $log_file
+exit $exit_code
+EOF
+
+  chmod +x "$script_path"
+}
+
+failover_create_config() {
+
+  local notify_script=$1
+  local FAILOVER_CONF_DIR=$2
+  local FAILOVER_LOG_DIR=$3
+  local failover_script="/tmp/failover.sh"
+
+  failover_create_script "$failover_script" 0 "/tmp/failover_test.log"
+
+  cat > "$FAILOVER_CONF_DIR/pgagroal.conf" <<EOF
+[pgagroal]
+host = *
+port = $PGAGROAL_PORT
+
+log_type = file
+log_level = debug
+log_path = $FAILOVER_LOG_DIR/pgagroal.log
+
+failover = on
+failover_script = $failover_script
+failover_notify_script = $notify_script
+
+unix_socket_dir = /tmp/
+
+[primary]
+host = localhost
+port = 7432
+
+[standby1]
+host = localhost
+port = 7433
+
+[standby2]
+host = localhost
+port = 7434
+EOF
+
+  cat > "$FAILOVER_CONF_DIR/pgagroal_hba.conf" <<EOF
+host all all all all
+EOF
+}
+
+failover_stop_pgagroal() {
+
+  pkill -f pgagroal >/dev/null 2>&1 || true
+  sleep 2
+  pkill -9 -f pgagroal >/dev/null 2>&1 || true
+  rm -f /tmp/pgagroal.*.pid
+}
+
+test_failover_notify_success() {
+
+  local FAILOVER_BASE=$1
+  local FAILOVER_LOG_DIR="$FAILOVER_BASE/log"
+  local FAILOVER_CONF_DIR="$FAILOVER_BASE/conf"
+  local FAILOVER_PG_LOG_DIR="$FAILOVER_BASE/pglog"
+
+  echo ""
+  echo "=========================================="
+  echo "Test 1: Failover Notify Success"
+  echo "=========================================="
+
+  local notify_script="/tmp/test_notify_success.sh"
+  local log_file="/tmp/failover_notify_test.log"
+
+  rm -f "$notify_script" "$log_file"
+
+  failover_create_script "$notify_script" 0 "$log_file"
+
+  failover_start_postgresql_cluster "$FAILOVER_PG_LOG_DIR"  
+
+  failover_create_config "$notify_script" "$FAILOVER_CONF_DIR" "$FAILOVER_LOG_DIR"
+
+  echo "Starting pgagroal..."
+
+  $EXECUTABLE_DIRECTORY/pgagroal \
+    -c "$FAILOVER_CONF_DIR/pgagroal.conf" \
+    -a "$FAILOVER_CONF_DIR/pgagroal_hba.conf" \
+    -d
+
+  sleep 5
+
+  echo "Testing connection"
+
+  PGPASSWORD="yourpassword" \
+  timeout 5 psql -h localhost -p $PGAGROAL_PORT \
+  -U myuser -d mydb \
+  -c "SELECT 1" >/dev/null 2>&1 || true
+
+  echo ""
+  echo "Simulating primary failure"
+
+  $CONTAINER_ENGINE stop "$(failover_container_name primary)"
+
+  PGPASSWORD="yourpassword" \
+  timeout 5 psql -h localhost -p $PGAGROAL_PORT \
+  -U myuser -d mydb \
+  -c "CREATE TABLE failover_test(id int);" \
+  >/dev/null 2>&1 || true
+
+  sleep 15
+
+  if [ -f "$log_file" ]; then
+    echo "Notify script executed"
+    cat "$log_file"
+  else
+    echo "Notify script not executed"
+    tail -20 "$FAILOVER_LOG_DIR/pgagroal.log"
+  fi
+
+  failover_stop_pgagroal
+  failover_stop_postgresql_cluster
+}
+
+test_failover_notify_failure() {
+  local FAILOVER_BASE=$1
+  local FAILOVER_LOG_DIR="$FAILOVER_BASE/log"
+  local FAILOVER_CONF_DIR="$FAILOVER_BASE/conf"
+  local FAILOVER_PG_LOG_DIR="$FAILOVER_BASE/pglog"
+
+  echo ""
+  echo "=========================================="
+  echo "Test 2: Failover Notify Failure"
+  echo "=========================================="
+
+  local notify_script="/tmp/test_notify_fail.sh"
+  local log_file="/tmp/failover_notify_test.log"
+
+  rm -f "$notify_script" "$log_file"
+
+  failover_create_script "$notify_script" 1 "$log_file"
+
+  failover_start_postgresql_cluster "$FAILOVER_PG_LOG_DIR"
+
+  failover_create_config "$notify_script" "$FAILOVER_CONF_DIR" "$FAILOVER_LOG_DIR"
+
+  $EXECUTABLE_DIRECTORY/pgagroal \
+    -c "$FAILOVER_CONF_DIR/pgagroal.conf" \
+    -a "$FAILOVER_CONF_DIR/pgagroal_hba.conf" \
+    -d
+
+  sleep 5
+
+  $CONTAINER_ENGINE stop "$(failover_container_name primary)"
+
+  PGPASSWORD="yourpassword" \
+  timeout 5 psql -h localhost -p $PGAGROAL_PORT \
+  -U myuser -d mydb \
+  -c "CREATE TABLE failover_test(id int);" \
+  >/dev/null 2>&1 || true
+
+  sleep 15
+
+  if [ -f "$log_file" ]; then
+    echo "Notify script executed"
+    cat "$log_file"
+  fi
+
+  if grep -q "Error from notify script" "$LOG_DIR/pgagroal.log"; then
+    echo "Error correctly logged"
+  fi
+
+  failover_stop_pgagroal
+  failover_stop_postgresql_cluster
+}
+
+failover_cleanup() {
+  local FAILOVER_BASE=$1
+
+  echo ""
+  echo "=========================================="
+  echo "Cleaning up"
+  echo "=========================================="
+
+  set +e 
+  
+  for name in primary standby1 standby2
+  do
+    cname="pgagroal-test-postgresql${ENV_PGVERSION}-$name"
+    $CONTAINER_ENGINE stop "$cname" >/dev/null 2>&1 || true
+    $CONTAINER_ENGINE rm -f "$cname" >/dev/null 2>&1 || true
+  done
+
+  rm -f "$HOME/.pgagroal/master.key" 2>/dev/null || true
+  rm -f /tmp/pgagroal.*.key 2>/dev/null || true
+
+  pkill -9 -f pgagroal >/dev/null 2>&1 || true
+  sleep 2
+
+  rm -f /tmp/test_notify_*.sh 2>/dev/null || true
+  rm -f /tmp/failover*.sh 2>/dev/null || true
+  rm -f /tmp/failover_notify_test.log 2>/dev/null || true
+  rm -f /tmp/failover_test.log 2>/dev/null || true
+  rm -f /tmp/pgagroal.*.pid 2>/dev/null || true
+
+  if [ -d "$FAILOVER_BASE" ]; then
+    rm -rf "$FAILOVER_BASE" 2>/dev/null || {
+      echo "Warning: Could not remove $FAILOVER_BASE, trying with sudo..."
+      sudo rm -rf "$FAILOVER_BASE" 2>/dev/null || true
+    }
+  fi
+  
+  set -e
+}
+
+
+run_failover_tests() {
+
+  local FAILOVER_BASE="/tmp/pgagroal-failover-test"
+
+  echo "Checking environment before starting failover tests..."
+
+  set +e
+
+  # Check required ports
+  for port in $PRIMARY_PORT $STANDBY1_PORT $STANDBY2_PORT $PGAGROAL_PORT
+  do
+    if ss -tuln | grep -q ":$port "; then
+      echo "WARNING: Port $port is already in use. Attempting to continue..."
+    fi
+  done
+
+  # Clean up any existing containers first
+  echo "Cleaning up any existing containers..."
+  for name in primary standby1 standby2
+  do
+    cname="pgagroal-test-postgresql${ENV_PGVERSION}-$name"
+    $CONTAINER_ENGINE stop "$cname" 2>/dev/null || true
+    $CONTAINER_ENGINE rm -f "$cname" 2>/dev/null || true
+  done
+
+  # Clean up any existing pgagroal processes
+  pkill -f pgagroal 2>/dev/null || true
+  sleep 2
+  pkill -9 -f pgagroal 2>/dev/null || true
+  rm -f /tmp/pgagroal.*.pid 2>/dev/null || true
+
+  echo "Environment checks passed."
+
+  echo ""
+  echo "=========================================="
+  echo "Running Failover Notification Tests"
+  echo "=========================================="
+
+  failover_prepare_dirs "$FAILOVER_BASE" || {
+    echo "Failed to prepare directories"
+    set -e
+    return 1
+  }
+
+  if ! $CONTAINER_ENGINE image inspect "$IMAGE_NAME" >/dev/null 2>&1
+  then
+    echo "Building PostgreSQL image"
+    build_postgresql_image || {
+      echo "Failed to build PostgreSQL image"
+      set -e
+      return 1
+    }
+  fi
+
+  test_failover_notify_success "$FAILOVER_BASE" || echo "Test 1 failed but continuing..."
+  test_failover_notify_failure "$FAILOVER_BASE" || echo "Test 2 failed but continuing..."
+
+  failover_cleanup "$FAILOVER_BASE"
+
+  echo ""
+  echo "Failover tests completed"
+  set -e
 }
 
 do_setup() {
@@ -739,6 +1130,10 @@ while [[ $# -gt 0 ]]; do
          [[ -n "$SUBCOMMAND" ]] && usage
          SUBCOMMAND="run-configs"
          shift
+         ;;
+      failover-tests)
+         run_failover_tests
+         exit 0
          ;;
       ci)
          [[ -n "$SUBCOMMAND" ]] && usage


### PR DESCRIPTION
closes [#686]

This PR improves the automatic failover workflow in pgagroal by introducing a second, optional, configurable hook that is executed *after* a successful primary promotion.

Currently, pgagroal supports a single `failover_script` that promotes a new primary. However, there is no mechanism to notify or reconfigure remaining standby servers after the promotion completes.

This change adds support for a follow-up executable that allows users to reconfigure or attach remaining standbys to the newly promoted primary.

## Summary of changes

- pgagroal now waits for the exit status of `failover_script`
- If the failover script exits successfully (`exit code 0`), a second
  configurable script is executed
- Introduced new configuration key:
  - `failover_notify_script`
- The notify script receives information about:
  - the demoted primary
  - the promoted primary
  - all remaining standbys (via `config->servers[]`)
- No scripts are added to the repository; executables are fully user-provided

This preserves backward compatibility: if `failover_notify_script` is not configured, pgagroal behaves exactly as before.

## Testing

The feature was tested locally using two PostgreSQL instances and pgagroal.

### Setup
  ```ini
- PostgreSQL primary running on `localhost:5432`
- PostgreSQL standby running on `localhost:5433`
- pgagroal listening on port `2345`
```
Configuration:
  ```ini
  failover = on
  failover_script = /etc/pgagroal/pgagroal_failover.sh
  failover_notify_script = /etc/pgagroal/pgagroal_failover_notify_standbys.sh
```

### Observed behavior

- The client connection was terminated due to primary shutdown
- pgagroal detected the failure and selected a new primary
- pgagroal_failover.sh was executed successfully
- After successful promotion, pgagroal_failover_notify_standbys.sh was executed
- The client was reconnected to the new primary automatically

Evidence
  ```ini
/tmp/pgagroal_failover.log:
FAILOVER called: localhost 5432 localhost 5433

/tmp/pgagroal_notify.log:
NOTIFY called with args: ...
```