### PR TITLE
[#703] fix memory leak in encrypt_decrypt_buffer error path

### DIFF
--- a/src/libpgagroal/aes.c
+++ b/src/libpgagroal/aes.c
@@ -353,10 +353,10 @@ error:
       EVP_CIPHER_CTX_free(ctx);
    }
 
-   if (master_key)
-   {
-      free(master_key);
-   }
+   free(master_key);
+
+   free(*res_buffer);
+   *res_buffer = NULL;
 
    return 1;
 }


### PR DESCRIPTION
when encryption/decryption fails, the allocated res_buffer was not being freed, causing a memory leak. this adds proper cleanup in the error handling section.

fixes: #703 