### PR TITLE
[#705] Add coverage summary display to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,23 @@ jobs:
             pandoc texlive texlive-latex-extra texlive-fonts-extra texlive-xetex \
             texlive-luatex texlive-science texlive-extra-utils
 
+      - name: Install LLVM/Clang Toolchain
+        run: |
+          sudo apt update -y
+          sudo apt install -y lsb-release wget software-properties-common gnupg
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/llvm-snapshot.gpg
+          echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-21 main" | sudo tee /etc/apt/sources.list.d/llvm.list
+          sudo apt update -y
+          sudo apt install -y clang-21 clang-tools-21 llvm-21
+          
+          # Create symlinks for the compiler
+          sudo ln -sf /usr/bin/clang-21 /usr/bin/clang
+          sudo ln -sf /usr/bin/clang++-21 /usr/bin/clang++
+          
+          # Create symlinks for coverage tools
+          sudo ln -sf /usr/bin/llvm-cov-21 /usr/bin/llvm-cov
+          sudo ln -sf /usr/bin/llvm-profdata-21 /usr/bin/llvm-profdata
+          
       - name: Install Eisvogel template for Pandoc
         run: |
           wget https://github.com/Wandmalfarbe/pandoc-latex-template/releases/download/v3.3.0/Eisvogel-3.3.0.tar.gz
@@ -110,6 +127,9 @@ jobs:
       - name: Testsuite
         id: test
         run: |
+          if [ "${{ matrix.compiler }}" = "clang" ] && [ "${{ matrix.build_type }}" = "Debug" ]; then
+             export LLVM_PROFILE_FILE="/tmp/pgagroal-test/coverage/code-%p.profraw"
+          fi
           if [ "${{ matrix.compiler }}" = "gcc" ] && [ "${{ matrix.build_type }}" = "Debug" ]; then
             ASAN_LIB=$(gcc -print-file-name=libasan.so)
             if [ -n "$ASAN_LIB" ] && [ -f "$ASAN_LIB" ]; then
@@ -122,43 +142,21 @@ jobs:
           $(which bash) ./check.sh run-configs-ci-nonbuild
         working-directory: /home/runner/work/pgagroal/pgagroal/build
 
-      # === Generate coverage reports ===
-      - name: Generate Detailed HTML Coverage Report
-        if: matrix.compiler == 'gcc' && matrix.build_type == 'Debug'
-        uses: threeal/gcovr-action@v1.1.0
-        with:
-          root: /home/runner/work/pgagroal/pgagroal
-          html-details: true
-          html-out: coverage.html
-
-      - name: Generate Cobertura Report
-        if: matrix.compiler == 'gcc' && matrix.build_type == 'Debug'
-        uses: threeal/gcovr-action@v1.1.0
-        with:
-          xml-out: cobertura.xml
-
-      - name: Generate Coveralls JSON Report and Upload
-        if: matrix.compiler == 'gcc' && matrix.build_type == 'Debug'
-        uses: threeal/gcovr-action@v1.1.0
-        with:
-          root: /home/runner/work/pgagroal/pgagroal
-          coveralls-out: coveralls.json
-
-      - name: Bundle All Coverage Reports
-        if: matrix.compiler == 'gcc' && matrix.build_type == 'Debug'
+      - name: Report coverage summary
+        if: matrix.compiler == 'clang' && matrix.build_type == 'Debug'
         run: |
-          mkdir -p coverage-report
-          mv *.html coverage-report/
-          mv cobertura.xml coverage-report/
-          mv coveralls.json coverage-report/
-
+          echo "## Coverage Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat /tmp/pgagroal-test/coverage/coverage-report-*.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload All Coverage Reports as Artifact
-        if: matrix.compiler == 'gcc' && matrix.build_type == 'Debug'
+        if: matrix.compiler == 'clang' && matrix.build_type == 'Debug'
         uses: actions/upload-artifact@v5
         with:
           name: coverage-reports-${{ matrix.compiler }}-${{ matrix.build_type }}
-          path: coverage-report
+          path: /tmp/pgagroal-test/coverage
           retention-days: 90
 
       - name: Upload Build and Run Logs as Artifacts

--- a/AUTHORS
+++ b/AUTHORS
@@ -27,3 +27,4 @@ Sara Nabih <nabihsara8@gmail.com>
 Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
 Ankush Mondal <mondalankush9851@gmail.com>
 Shashank Singh <shashanksgh3@gmail.com>
+Mazen Kamal <mazenkamal212@gmail.com>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,26 @@ message(STATUS "pgagroal ${VERSION_STRING}")
 set(check TRUE)
 set(container FALSE)
 
+#
+# Enable LLVM coverage when running tests with Clang
+#
+if (check AND CMAKE_C_COMPILER_ID STREQUAL "Clang")
+  message(STATUS "LLVM coverage enabled")
+
+  add_compile_options(
+    -fprofile-instr-generate
+    -fcoverage-mapping
+    -O0
+  )
+
+  add_link_options(
+    -fprofile-instr-generate
+    -fcoverage-mapping
+  )
+
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_FLAGS}")
+endif()
+
 include(CheckCCompilerFlag)
 include(CheckCSourceCompiles)
 include(CheckIncludeFile)

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -33,6 +33,7 @@ Sara Nabih <nabihsara8@gmail.com>
 Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
 Ankush Mondal <mondalankush9851@gmail.com>
 Shashank Singh <shashanksgh3@gmail.com>
+Mazen Kamal <mazenkamal212@gmail.com>
 
 ```
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -89,19 +89,31 @@ if (check)
     endif()
   endif()
 
-  add_executable(pgagroal_test runner.c ${SOURCES})
-  target_include_directories(pgagroal_test PRIVATE ${CMAKE_SOURCE_DIR}/src/include ${CMAKE_SOURCE_DIR}/test/include)
+  add_executable(pgagroal-test runner.c ${SOURCES})
+    if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    target_compile_options(pgagroal-test PRIVATE
+      -fprofile-instr-generate
+      -fcoverage-mapping
+      -O0
+    )
+    target_link_options(pgagroal-test PRIVATE
+      -fprofile-instr-generate
+      -fcoverage-mapping
+    )
+endif()
+
+  target_include_directories(pgagroal-test PRIVATE ${CMAKE_SOURCE_DIR}/src/include ${CMAKE_SOURCE_DIR}/test/include)
 
   if(EXISTS "/etc/debian_version")
-    target_link_libraries(pgagroal_test Check::check subunit pthread rt m pgagroal)
+    target_link_libraries(pgagroal-test Check::check subunit pthread rt m pgagroal)
   elseif(APPLE)
-    target_link_libraries(pgagroal_test Check::check m pgagroal)
+    target_link_libraries(pgagroal-test Check::check m pgagroal)
   else()
-    target_link_libraries(pgagroal_test Check::check pthread rt m pgagroal)
+    target_link_libraries(pgagroal-test Check::check pthread rt m pgagroal)
   endif()
 
   add_custom_target(custom_clean
-    COMMAND ${CMAKE_COMMAND} -E remove -f *.o pgagroal_test
+    COMMAND ${CMAKE_COMMAND} -E remove -f *.o pgagroal-test
     COMMENT "Cleaning up..."
   )
 endif()

--- a/test/check.sh
+++ b/test/check.sh
@@ -171,41 +171,51 @@ cleanup() {
       
       # Generate LLVM coverage reports
       if [[ $COVERAGE == "YES" ]]; then
-         if ls "$COVERAGE_DIR"/*.profraw >/dev/null 2>&1; then
+         if ls "$COVERAGE_DIR"/*-*.profraw >/dev/null 2>&1; then
           echo "Generating coverage report, expect error when the binary is not covered at all"
-          llvm-profdata merge -sparse $COVERAGE_DIR/*.profraw -o $COVERAGE_DIR/coverage.profdata
+          llvm-profdata merge -sparse $COVERAGE_DIR/*-*.profraw -o $COVERAGE_DIR/coverage.profdata
+  
+         if [[ -f "$EXECUTABLE_DIRECTORY/libpgagroal.so" ]]; then
+             BIN_PATH="$EXECUTABLE_DIRECTORY"
+         elif [[ -f "$EXECUTABLE_DIRECTORY/pgagroal/libpgagroal.so" ]]; then
+             BIN_PATH="$EXECUTABLE_DIRECTORY/pgagroal"
+         else
+             echo "ERROR: Could not find libpgagroal.so in $EXECUTABLE_DIRECTORY or subdirectory."
+             ls -R "$EXECUTABLE_DIRECTORY" # Debug: list files to see where they are
+             exit 1
+         fi
 
           echo "Generating $COVERAGE_DIR/coverage-report-libpgagroal.txt"
-          llvm-cov report $EXECUTABLE_DIRECTORY/libpgagroal.so \
+          llvm-cov report "$BIN_PATH/libpgagroal.so" \
             --instr-profile=$COVERAGE_DIR/coverage.profdata \
-            --format=text > $COVERAGE_DIR/coverage-report-libpgagroal.txt
+            --format=text > $COVERAGE_DIR/coverage-report-libpgagroal.txt 2>&1
           echo "Generating $COVERAGE_DIR/coverage-report-pgagroal.txt"
-          llvm-cov report $EXECUTABLE_DIRECTORY/pgagroal \
+          llvm-cov report "$BIN_PATH/pgagroal" \
             --instr-profile=$COVERAGE_DIR/coverage.profdata \
-            --format=text > $COVERAGE_DIR/coverage-report-pgagroal.txt
+            --format=text > $COVERAGE_DIR/coverage-report-pgagroal.txt 2>&1
          echo "Generating $COVERAGE_DIR/coverage-report-pgagroal-cli.txt"
-         llvm-cov report $EXECUTABLE_DIRECTORY/pgagroal-cli \
+         llvm-cov report "$BIN_PATH/pgagroal-cli" \
             --instr-profile=$COVERAGE_DIR/coverage.profdata \
-            --format=text > $COVERAGE_DIR/coverage-report-pgagroal-cli.txt
+            --format=text > $COVERAGE_DIR/coverage-report-pgagroal-cli.txt 2>&1
          echo "Generating $COVERAGE_DIR/coverage-report-pgagroal-admin.txt"
-         llvm-cov report $EXECUTABLE_DIRECTORY/pgagroal-admin \
+         llvm-cov report "$BIN_PATH/pgagroal-admin" \
             --instr-profile=$COVERAGE_DIR/coverage.profdata \
-            --format=text > $COVERAGE_DIR/coverage-report-pgagroal-admin.txt
+            --format=text > $COVERAGE_DIR/coverage-report-pgagroal-admin.txt 2>&1
 
           echo "Generating $COVERAGE_DIR/coverage-libpgagroal.txt"
-          llvm-cov show $EXECUTABLE_DIRECTORY/libpgagroal.so \
+          llvm-cov show $BIN_PATH/libpgagroal.so \
             --instr-profile=$COVERAGE_DIR/coverage.profdata \
             --format=text > $COVERAGE_DIR/coverage-libpgagroal.txt
           echo "Generating $COVERAGE_DIR/coverage-pgagroal.txt"
-          llvm-cov show $EXECUTABLE_DIRECTORY/pgagroal \
+          llvm-cov show $BIN_PATH/pgagroal \
             --instr-profile=$COVERAGE_DIR/coverage.profdata \
             --format=text > $COVERAGE_DIR/coverage-pgagroal.txt
          echo "Generating $COVERAGE_DIR/coverage-pgagroal-cli.txt"
-         llvm-cov show $EXECUTABLE_DIRECTORY/pgagroal-cli \
+         llvm-cov show $BIN_PATH/pgagroal-cli \
             --instr-profile=$COVERAGE_DIR/coverage.profdata \
             --format=text > $COVERAGE_DIR/coverage-pgagroal-cli.txt
          echo "Generating $COVERAGE_DIR/coverage-pgagroal-admin.txt"
-         llvm-cov show $EXECUTABLE_DIRECTORY/pgagroal-admin \
+         llvm-cov show $BIN_PATH/pgagroal-admin \
             --instr-profile=$COVERAGE_DIR/coverage.profdata \
             --format=text > $COVERAGE_DIR/coverage-pgagroal-admin.txt
          
@@ -424,7 +434,7 @@ execute_testcases() {
    fi
 
    echo "Start running tests for $config_name"
-  $TEST_DIRECTORY/pgagroal_test $PROJECT_DIRECTORY $PG_USER_NAME $PG_DATABASE
+  $TEST_DIRECTORY/pgagroal-test $PROJECT_DIRECTORY $PG_USER_NAME $PG_DATABASE
    test_result=$?
    
    


### PR DESCRIPTION
closes #705 

similar changes to [pgexporter/392](https://github.com/pgexporter/pgexporter/pull/392)

Adds coverage report summary to summary tab in CI for viewing without the need to download.