### PR TITLE
[#708] Fix connection pool emptying on abrupt client disconnect

### DIFF
--- a/src/libpgagroal/pipeline_perf.c
+++ b/src/libpgagroal/pipeline_perf.c
@@ -163,7 +163,7 @@ client_done:
    }
    else
    {
-      exit_code = WORKER_SERVER_FAILURE;
+      exit_code = WORKER_CLIENT_FAILURE;
    }
 
    pgagroal_event_loop_break();

--- a/src/libpgagroal/pipeline_session.c
+++ b/src/libpgagroal/pipeline_session.c
@@ -388,7 +388,7 @@ client_done:
    }
    else
    {
-      exit_code = WORKER_SERVER_FAILURE;
+      exit_code = WORKER_CLIENT_FAILURE;
    }
 
    pgagroal_event_loop_break();

--- a/src/libpgagroal/pipeline_transaction.c
+++ b/src/libpgagroal/pipeline_transaction.c
@@ -343,7 +343,7 @@ client_done:
    }
    else
    {
-      exit_code = WORKER_SERVER_FAILURE;
+      exit_code = WORKER_CLIENT_FAILURE;
    }
 
    pgagroal_event_loop_break();


### PR DESCRIPTION
When a client disconnects without sending the PostgreSQL Terminate ('X') message (e.g., during pgbench stress tests or network drops), the pipeline previously flagged this as a WORKER_SERVER_FAILURE.

This classification caused pgagroal to treat the backend connection as potentially corrupted, triggering pgagroal_kill_connection() instead of returning it to the pool. Under high concurrency, this led to the entire pool being drained unnecessarily.

This commit changes the exit code for missing 'X' messages from WORKER_SERVER_FAILURE to WORKER_CLIENT_FAILURE.

This ensures backend connections are safely recycled (returned to FREE state) when clients disconnect abruptly, stabilizing the pool under load.

#708