### PR TITLE
[#711] Prevent process title truncation by preserving buffer capacity

### DIFF
--- a/src/libpgagroal/utils.c
+++ b/src/libpgagroal/utils.c
@@ -774,11 +774,8 @@ pgagroal_set_proc_title(int argc, char** argv, char* s1, char* s2)
       size = strlen(title) + 1;
    }
 
-   memcpy(*argv, title, size);
-   memset(*argv + size, 0, 1);
-
-   // keep track of how long is now the title
-   max_process_title_size = size;
+   memcpy(*argv, title, MIN(size, max_process_title_size));
+   memset(*argv + MIN(size, max_process_title_size), 0, 1);
 
 #else
    setproctitle("-pgagroal: %s%s%s",


### PR DESCRIPTION
This PR fixes a critical bug where max_process_title_size was incorrectly updated to the length of the current title instead of preserving the total argv buffer capacity.

The Issue: If the parent process sets a short title (pgagroal: main, length 14), max_process_title_size was permanently shrunk to 14. This caused two severe issues:

Buffer Overflow: In VERBOSE or MINIMAL modes, subsequent longer titles (e.g., from a worker) would be written into the artificially shrunk buffer without proper bounds checking. I verified this locally, a worker process wrote 100 characters into a buffer that pgagroal thought was only 14 bytes, corrupting adjacent memory.
Capacity Loss: Child processes inherited the shrunken capacity, preventing them from ever using the full allocated argv space.

The Fix:
Removed max_process_title_size = size; in pgagroal_set_proc_title.
The global variable now solely tracks the initial argv buffer capacity determined at startup and is never reduced.
Added MIN(size, max_process_title_size) to memcpy/memset to strictly enforce the true buffer limit in all modes.

Verification:
Strict Mode: Verified that worker titles are no longer truncated to the parent's short title length.
Verbose Mode/Default Mode: Verified that the buffer overflow no longer occurs via the new MIN() check, titles are safely truncated to the actual buffer limit (38 chars in local tests) instead of overwriting memory.

Fixes: #711 