### PR TITLE
[#710] Add address comparison function and enhance server validation

### DIFF
--- a/src/include/network.h
+++ b/src/include/network.h
@@ -162,6 +162,17 @@ pgagroal_read_socket(SSL* ssl, int fd, char* buffer, size_t buffer_size);
 int
 pgagroal_write_socket(SSL* ssl, int fd, char* buffer, size_t buffer_size);
 
+/**
+ * Check if two addresses are the same
+ * @param h1 The first host
+ * @param p1 The first port
+ * @param h2 The second host
+ * @param p2 The second port
+ * @return true if they resolve to the same address, otherwise false
+ */
+bool
+pgagroal_address_is_same(char* h1, int p1, char* h2, int p2);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/conf/07/pgagroal.conf
+++ b/test/conf/07/pgagroal.conf
@@ -1,0 +1,22 @@
+[pgagroal]
+host = localhost
+port = 2345
+
+log_type = file
+log_level = debug5
+log_path = test.log
+
+max_connections = 100
+idle_timeout = 600
+validation = off
+unix_socket_dir = /tmp/
+pipeline = performance
+ev_backend = io_uring
+
+[rachel]
+host = 127.0.0.1
+port = 5432
+
+[ross]
+host = localhost
+port = 5432

--- a/test/conf/07/pgagroal_hba.conf
+++ b/test/conf/07/pgagroal_hba.conf
@@ -1,0 +1,4 @@
+#
+# TYPE  DATABASE USER  ADDRESS  METHOD
+#
+host    all all all trust

--- a/test/conf/08/pgagroal.conf
+++ b/test/conf/08/pgagroal.conf
@@ -1,0 +1,22 @@
+[pgagroal]
+host = localhost
+port = 2345
+
+log_type = file
+log_level = debug5
+log_path = test.log
+
+max_connections = 100
+idle_timeout = 600
+validation = off
+unix_socket_dir = /tmp/
+pipeline = performance
+ev_backend = io_uring
+
+[primary]
+host = 127.0.0.1
+port = 5432
+
+[replica]
+host = 127.0.0.1
+port = 5433

--- a/test/conf/08/pgagroal_hba.conf
+++ b/test/conf/08/pgagroal_hba.conf
@@ -1,0 +1,4 @@
+#
+# TYPE  DATABASE USER  ADDRESS  METHOD
+#
+host    all all all trust


### PR DESCRIPTION
Adds network-level duplicate server detection to prevent configuring the same PostgreSQL server multiple times with different hostnames (e.g., `localhost` vs `127.0.0.1`).

## Changes

- Uses `getaddrinfo()` to resolve and compare server addresses
- Detects duplicates early in startup validation
- Fixes existing bug: `configuration_path[0]` -> `configuration_path`

## Testing

- **Config 07**: Duplicate servers (`localhost` vs `127.0.0.1`) -> Correctly rejected
- **Config 08**: Valid multi-server (same IP, different ports) -> Correctly accepted

Closes #710