### PR TITLE
[#727] test: redesign MCTF_FINISH to return mctf_errno

### DIFF
--- a/test/include/mctf.h
+++ b/test/include/mctf.h
@@ -322,14 +322,8 @@ mctf_format_error(const char* format, ...);
    while (0)
 
 /* Finish test macro */
-#define MCTF_FINISH()     \
-   do                     \
-   {                      \
-      mctf_errno = 0;     \
-      mctf_errmsg = NULL; \
-      return 0;           \
-   }                      \
-   while (0)
+#define MCTF_FINISH() \
+   return mctf_errno
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- fixes: #727 

Avoid nulling `mctf_errmsg` in `MCTF_FINISH()` so the test runner can still copy and free the error message in its `SKIP`/`FAIL` paths.