### PR TITLE
[#504] Optimizing Salt by removing need to reinitialize HMAC

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,3 +31,4 @@ Mazen Kamal <mazenkamal212@gmail.com>
 Shashidhar B M <shashidhar.i.0119@gmail.com>
 Trevor Jacob Mathews <trevorjacobmathews@gmail.com>
 Abdelrhman Sersawy <abdelrhmansersawy@gmail.com>
+Zeyad Daowd <zeyaddaowd@yahoo.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -38,7 +38,7 @@ Mazen Kamal <mazenkamal212@gmail.com>
 Shashidhar B M <shashidhar.i.0119@gmail.com>
 Trevor Jacob Mathews <trevorjacobmathews@gmail.com>
 Abdelrhman Sersawy <abdelrhmansersawy@gmail.com>
-
+Zeyad Daowd <zeyaddaowd@yahoo.com>
 ```
 
 ## Committers

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -4023,12 +4023,8 @@ salted_password(char* password, char* salt, int salt_length, int iterations, uns
 
    for (int i = 2; i <= iterations; i++)
    {
-      if (HMAC_CTX_reset(ctx) != 1)
-      {
-         goto error;
-      }
-
-      if (HMAC_Init_ex(ctx, password, password_length, EVP_sha256(), NULL) != 1)
+      /* passing nulls cause function to reuse the same key / password in the context */
+      if (HMAC_Init_ex(ctx, NULL, 0, NULL, NULL) != 1)
       {
          goto error;
       }


### PR DESCRIPTION
**The Modification: HMAC Context Reuse**

The Issue: The original implementation re-initializes the HMAC context with the password in every iteration (4,096 times).
The Fix: Following OpenSSL's documentation, I modified the loop to use HMAC_Init_ex(ctx, NULL, 0, NULL, NULL). and removed the HMAC_CTX_reset from the loop since it is no longer necessary.

This was based on the following openssl’s documentation page https://docs.openssl.org/3.0/man3/HMAC/#description

<img width="1644" height="230" alt="image" src="https://github.com/user-attachments/assets/0aec938a-23f1-4b9c-88f9-cbab7f544b42" />

Why it matters: Passing NULL as the key and message digest tells OpenSSL to reuse the pre-processed key state already in the context, skipping the expensive re-initialization and resetting context is no longer necessary.

**Benchmarking & Performance Analysis:**

I isolated the salted_password function in a standalone file to be able to benchmark it smoothly,
I benchmarked the change by calling salted_password 1,000 times (at 4,096 iterations each) to try to minimize noise of running from a time to time.

Correctness: I verified that the optimized version produces the exact same hex output as the original implementation.

CPU Profiling: I used perf to be able to gain an estimate of where the bottleneck is to try to optimize.

Before: HMAC_Init_ex was responsible for ~66.6% of total CPU overhead which was more than hashing itself.

<img width="2482" height="360" alt="image" src="https://github.com/user-attachments/assets/e63de4f1-c34a-4d85-b73f-6058107fe816" />

After: Overhead dropped to ~14%, with the CPU now spending the majority of its time on hashing itself 
<img width="2450" height="622" alt="image" src="https://github.com/user-attachments/assets/90b615b6-d92d-4409-8cf3-1daca4004303" />

Total Speedup: The optimized function is nearly 5x faster (reducing local execution time from ~2600ms to 577ms for calling the function 1000 times).

before:
<img width="2446" height="340" alt="image" src="https://github.com/user-attachments/assets/6b6b60dd-2b35-44e6-add1-e40a6789b35c" />


after:<img width="2450" height="362" alt="image" src="https://github.com/user-attachments/assets/8efe5246-f7d3-4191-953b-1739cdae1fb9" />



This ~4.5x improvement can allow us to increase iterations count by a factor of 4, which from my understanding results in better security, and still if this is wanted.

I have also tried to increase the iterations count and it resulted in less time than the original 4096 iteration without the modification
<img width="2474" height="336" alt="image" src="https://github.com/user-attachments/assets/cb2ca6b0-da7f-4f37-b0e4-12e005961273" />
Note: I haven't increased the iteration count in the PR since I believe this requires approval
Closes #504