### PR TITLE
[#736] pgagroal.socket only works on the 2nd connection

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -145,6 +145,13 @@ int main(void) { return 0; }
     ${PGAGROAL_IO_URING_LIBRARIES}
   )
 
+  if (SYSTEMD_FOUND)
+    add_compile_options(-DHAVE_SYSTEMD)
+
+    include_directories(${SYSTEMD_INCLUDE_DIRS})
+    link_libraries(${SYSTEMD_LIBRARIES})
+  endif()
+
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
   find_program(HOMEBREW_EXECUTABLE brew)
@@ -218,12 +225,6 @@ else()
      add_compile_options(-DHAVE_FREEBSD)
   endif()
 
-  if (SYSTEMD_FOUND)
-  add_compile_options(-DHAVE_SYSTEMD)
-
-  include_directories(${SYSTEMD_INCLUDE_DIRS})
-  link_libraries(${SYSTEMD_LIBRARIES})
-  endif()
 
   #
   # Include directories


### PR DESCRIPTION
fully resolve #736 and restores systemd socket activation functionality

when the first connection arrived the daemon forked a child process. during initialization, the child process called shutdown_ports(), which executed an unlink() on the main UNIX socket.

this literally deleted the systemd-provided socket from the filesystem while the parent was still trying to use it. The parent daemon survived by natively rebinding a new socket after the failure, which is why the second connection attempt always succeeded.

compiled on Linux with systemd support explicitly enabled.

simulated systemd socket passing (using a UNIX socket and socat) with min_connections=1 to guarantee prefiller creation.

attempt 1: connected via socat. the daemon started successfully, and crucially, the socket file (.s.PGSQL.2345) remained untouched on the disk.
attempt 2: connected via socat immediately after. the connection was accepted perfectly with zero hangs or dropped sockets.
