### PR TITLE
[#742] Add O_NONBLOCK to systemd sockets

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -905,6 +905,13 @@ read_superuser_path:
          }
          else if (sd_is_socket(fd, AF_INET, 0, -1) || sd_is_socket(fd, AF_INET6, 0, -1))
          {
+            int flags = fcntl(fd, F_GETFL, 0);
+
+            if (flags != -1)
+            {
+               fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+            }
+
             main_fds[m] = fd;
             has_main_sockets = true;
             m++;


### PR DESCRIPTION
systemd passes sockets in blocking mode by default. pgagroal uses an asynchronous event loop (epoll/io_uring), calling accept() on a blocking socket can permanently deadlock the main thread if a client drops the connection just before the syscall.

explicitly applying the O_NONBLOCK flag via fcntl to all inherited systemd sockets during initialization fixes this 

fixes #742.