### PR TITLE
[#749] Introduce pgagroal_socket_nonblocking function

### DIFF
--- a/src/include/network.h
+++ b/src/include/network.h
@@ -141,6 +141,14 @@ int
 pgagroal_socket_has_error(int fd);
 
 /**
+ * Set a socket to non-blocking
+ * @param fd The descriptor
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgagroal_socket_nonblocking(int fd);
+
+/**
  * Read bytes from a socket to buffer
  * @param ssl The ssl
  * @param fd The descriptor

--- a/src/libpgagroal/network.c
+++ b/src/libpgagroal/network.c
@@ -501,6 +501,31 @@ pgagroal_tcp_nodelay(int fd)
 }
 
 int
+pgagroal_socket_nonblocking(int fd)
+{
+   int flags;
+
+   flags = fcntl(fd, F_GETFL);
+   if (flags == -1)
+   {
+      pgagroal_log_warn("socket_nonblocking: F_GETFL %d %s", fd, strerror(errno));
+      errno = 0;
+      return 1;
+   }
+
+   flags |= O_NONBLOCK;
+
+   if (fcntl(fd, F_SETFL, flags) == -1)
+   {
+      pgagroal_log_warn("socket_nonblocking: F_SETFL %d %s", fd, strerror(errno));
+      errno = 0;
+      return 1;
+   }
+
+   return 0;
+}
+
+int
 pgagroal_read_socket(SSL* ssl, int fd, char* buffer, size_t buffer_size)
 {
    int byte_read;

--- a/src/main.c
+++ b/src/main.c
@@ -908,18 +908,13 @@ read_superuser_path:
          {
             unix_pgsql_socket = fd;
             has_unix_socket = true;
+            pgagroal_socket_nonblocking(fd);
          }
          else if (sd_is_socket(fd, AF_INET, 0, -1) || sd_is_socket(fd, AF_INET6, 0, -1))
          {
-            int flags = fcntl(fd, F_GETFL, 0);
-
-            if (flags != -1)
-            {
-               fcntl(fd, F_SETFL, flags | O_NONBLOCK);
-            }
-
             main_fds[m] = fd;
             has_main_sockets = true;
+            pgagroal_socket_nonblocking(fd);
             m++;
          }
       }


### PR DESCRIPTION
Add pgagroal_socket_nonblocking() to network.c with error handling and logging. Use it for both AF_UNIX and AF_INET/AF_INET6 branches in systemd socket activation, replacing inline fcntl code and adding the missing non-blocking call for Unix sockets.