### PR TITLE
[#757] Fix conf get/set crashes by initializing memory in child processes

### DIFF
--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -32,6 +32,7 @@
 #include <configuration.h>
 #include <logging.h>
 #include <management.h>
+#include <memory.h>
 #include <network.h>
 #include <pipeline.h>
 #include <security.h>
@@ -6527,6 +6528,7 @@ pgagroal_conf_get(SSL* ssl __attribute__((unused)), int client_fd, uint8_t compr
    int total_seconds;
 
    pgagroal_start_logging();
+   pgagroal_memory_init();
 
    start_time = time(NULL);
 
@@ -6560,6 +6562,7 @@ pgagroal_conf_get(SSL* ssl __attribute__((unused)), int client_fd, uint8_t compr
 
    pgagroal_disconnect(client_fd);
 
+   pgagroal_memory_destroy();
    pgagroal_stop_logging();
 
    exit(0);
@@ -6569,6 +6572,7 @@ error:
 
    pgagroal_disconnect(client_fd);
 
+   pgagroal_memory_destroy();
    pgagroal_stop_logging();
 
    exit(1);
@@ -6590,6 +6594,7 @@ pgagroal_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t compr
    struct config_key_info key_info;
 
    pgagroal_start_logging();
+   pgagroal_memory_init();
    start_time = time(NULL);
 
    // Initialize output parameters
@@ -6696,6 +6701,7 @@ pgagroal_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t compr
    free(elapsed);
 
    pgagroal_disconnect(client_fd);
+   pgagroal_memory_destroy();
    pgagroal_stop_logging();
 
    return;
@@ -6708,6 +6714,7 @@ error:
    }
 
    pgagroal_disconnect(client_fd);
+   pgagroal_memory_destroy();
    pgagroal_stop_logging();
 
    return;

--- a/src/libpgagroal/logging.c
+++ b/src/libpgagroal/logging.c
@@ -377,15 +377,26 @@ retry:
          else if (config->log_type == PGAGROAL_LOGGING_TYPE_FILE)
          {
             buf[strftime(buf, sizeof(buf), config->log_line_prefix, tm)] = '\0';
-            fprintf(log_file, "%s %-5s %s:%d ",
-                    buf, levels[level - 1], filename, line);
-            vfprintf(log_file, fmt, vl);
-            fprintf(log_file, "\n");
-            fflush(log_file);
-
-            if (log_rotation_required())
+            if (log_file != NULL)
             {
-               log_file_rotate();
+               fprintf(log_file, "%s %-5s %s:%d ",
+                       buf, levels[level - 1], filename, line);
+               vfprintf(log_file, fmt, vl);
+               fprintf(log_file, "\n");
+               fflush(log_file);
+
+               if (log_rotation_required())
+               {
+                  log_file_rotate();
+               }
+            }
+            else
+            {
+               fprintf(stderr, "%s %-5s %s:%d ",
+                       buf, levels[level - 1], filename, line);
+               vfprintf(stderr, fmt, vl);
+               fprintf(stderr, "\n");
+               fflush(stderr);
             }
          }
          else if (config->log_type == PGAGROAL_LOGGING_TYPE_SYSLOG)


### PR DESCRIPTION
adds the necessary memory initialization and teardown in configuration.c to properly send the payload and exit

and adds a safety fallback in logging.c to print to stderr if the log_file is NULL, preventing null pointer de references during early startup or after a crash


fixes #757 