### PR TITLE
docs: add SECURITY.md vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## About pgagroal
+
+[pgagroal](https://github.com/pgagroal/pgagroal) is a high-performance protocol-native connection pool for [PostgreSQL](https://www.postgresql.org).
+
+---
+
+## Supported Versions
+
+Only the latest release of pgagroal receives security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest  | ✅ Yes             |
+| Older   | ❌ No              |
+
+---
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities, as this may expose the issue before a fix is available.
+
+Instead, please report them privately using one of the following methods:
+
+- 🔒 **GitHub Private Reporting** — Use the **"Report a vulnerability"** button in the [Security tab](https://github.com/pgagroal/pgagroal/security) of the repository
+- 📧 **Email** — If you prefer email, reach out to the project maintainers via the contacts listed in the [AUTHORS](./AUTHORS) file
+
+We will:
+- **Acknowledge** your report within **48 hours**
+- **Provide an update** on our investigation within **7 days**
+- **Aim to release a fix** within **90 days**, depending on severity and complexity
+
+---
+
+## Disclosure Policy
+
+- We follow a **responsible disclosure** model
+- Once a fix is released, we will publish a **security advisory** on GitHub
+- The reporter will be **credited** in the advisory unless they request anonymity
+- Please avoid publicly disclosing the vulnerability until we have released a patch
+
+---
+
+## Scope
+
+This policy applies to the **pgagroal** codebase and its official releases.  
+For vulnerabilities in **PostgreSQL** itself, please refer to the [PostgreSQL Security page](https://www.postgresql.org/support/security/).
+
+---
+
+## Thank You
+
+We appreciate the efforts of security researchers and the community in helping keep pgagroal safe. Responsible disclosure makes open source software better for everyone.


### PR DESCRIPTION
Closes #756

Adds a SECURITY.md file to the repository root so that:
- The GitHub Security tab displays a vulnerability reporting policy
- Security researchers know how to privately disclose issues
- The project follows standard open source security practices