### PR TITLE
Fix accept EBADF loop during configuration reload

### DIFF
--- a/src/libpgagroal/ev.c
+++ b/src/libpgagroal/ev.c
@@ -1478,11 +1478,18 @@ ev_epoll_io_handler(struct io_watcher* watcher)
          client_fd = accept(watcher->fds.main.listen_fd, NULL, NULL);
          if (client_fd == -1)
          {
-            if (errno != EAGAIN && errno != EWOULDBLOCK)
+            if (errno == EAGAIN || errno == EWOULDBLOCK)
             {
-               pgagroal_log_error("accept error: %s", strerror(errno));
-               return PGAGROAL_EVENT_RC_ERROR;
+               return PGAGROAL_EVENT_RC_OK;
             }
+
+            if (errno == EBADF || errno == ENOTSOCK)
+            {
+               return PGAGROAL_EVENT_RC_OK;
+            }
+
+            pgagroal_log_error("accept error: %s", strerror(errno));
+            return PGAGROAL_EVENT_RC_ERROR;
          }
          else
          {

--- a/src/libpgagroal/ev.c
+++ b/src/libpgagroal/ev.c
@@ -480,9 +480,7 @@ pgagroal_io_stop(struct io_watcher* watcher)
 
    if (i >= loop->events_nr)
    {
-      pgagroal_log_warn("pgagroal_io_stop: watcher not found in events list (fd rcv=%d, snd=%d, events_nr=%d) - possible double-stop",
-                        watcher->fds.worker.rcv_fd, watcher->fds.worker.snd_fd, loop->events_nr);
-      return PGAGROAL_EVENT_RC_ERROR;
+     return PGAGROAL_EVENT_RC_OK;
    }
 
    int rc = io_stop(watcher);

--- a/src/libpgagroal/ev.c
+++ b/src/libpgagroal/ev.c
@@ -1083,21 +1083,30 @@ ev_io_uring_handler(struct io_uring_cqe* cqe)
       case PGAGROAL_EVENT_TYPE_MAIN:
          io = (struct io_watcher*)watcher;
          if (cqe->res < 0)
-         {
-            pgagroal_log_error("io_uring: accept error: %s", strerror(-cqe->res));
-            if (pgagroal_event_loop_is_running())
-            {
+	 {
+   	    int err = -cqe->res;
+  	    if (err == EBADF || err == ENOTSOCK || err == ECANCELED)
+   	    {
+      	       pgagroal_log_debug("io_uring: accept ignored during reload: %s", strerror(err));
+               return PGAGROAL_EVENT_RC_OK;
+   	    }
+
+   	    pgagroal_log_error("io_uring: accept error: %s", strerror(err));
+
+   	    if (pgagroal_event_loop_is_running())
+   	    {
                ev_io_uring_io_start(io);
-            }
-            return PGAGROAL_EVENT_RC_OK;
-         }
+   	    }
+	
+   	    return PGAGROAL_EVENT_RC_OK;
+	 }																										
          io->fds.main.client_fd = cqe->res;
          io->cb(io);
 
          if (!(cqe->flags & IORING_CQE_F_MORE))
          {
             pgagroal_log_debug("io_uring: multishot accept ended: rearming");
-            if (pgagroal_event_loop_is_running())
+            if (pgagroal_event_loop_is_running() && io->fds.main.listen_fd != -1)
             {
                ev_io_uring_io_start(io);
             }

--- a/src/main.c
+++ b/src/main.c
@@ -205,13 +205,16 @@ shutdown_uds(bool remove)
    memset(&pgsql, 0, sizeof(pgsql));
    snprintf(&pgsql[0], sizeof(pgsql), ".s.PGSQL.%d", config->common.port);
 
-   pgagroal_disconnect(unix_pgsql_socket);
-   errno = 0;
+   if (unix_pgsql_socket >= 0)
+   {
+      pgagroal_disconnect(unix_pgsql_socket);
+      unix_pgsql_socket = -1;
+   }
+
    if (remove)
    {
       pgagroal_remove_unix_socket(config->unix_socket_dir, &pgsql[0]);
    }
-   errno = 0;
 }
 
 static void
@@ -260,8 +263,11 @@ shutdown_metrics(void)
 {
    for (int i = 0; i < metrics_fds_length; i++)
    {
-      pgagroal_disconnect(io_metrics[i].socket);
-      errno = 0;
+      if (io_metrics[i].socket >= 0)
+      {
+         pgagroal_disconnect(io_metrics[i].socket);
+         io_metrics[i].socket = -1;
+      }
    }
 }
 
@@ -285,8 +291,11 @@ shutdown_management(bool remove __attribute__((unused)))
 {
    for (int i = 0; i < management_fds_length; i++)
    {
-      pgagroal_disconnect(io_management[i].socket);
-      errno = 0;
+      if (io_management[i].socket >= 0)
+      {
+         pgagroal_disconnect(io_management[i].socket);
+         io_management[i].socket = -1;
+      }
    }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -147,15 +147,22 @@ shutdown_mgt(bool remove)
 
    config = (struct main_configuration*)shmem;
 
-   pgagroal_io_stop(&io_mgt.watcher);
-   pgagroal_disconnect(unix_management_socket);
-   errno = 0;
+   if (io_mgt.watcher.fds.worker.rcv_fd != -1 ||
+       io_mgt.watcher.fds.worker.snd_fd != -1)
+   {
+      pgagroal_io_stop(&io_mgt.watcher);
+   }
+   if (unix_management_socket != -1)
+   {
+      pgagroal_disconnect(unix_management_socket);
+      unix_management_socket = -1;
+   }
+  
    if (remove)
    {
       pgagroal_remove_unix_socket(config->unix_socket_dir, MAIN_UDS);
    }
-   errno = 0;
-}
+  }
 
 static void
 start_transfer(void)
@@ -174,14 +181,20 @@ shutdown_transfer(bool remove)
 
    config = (struct main_configuration*)shmem;
 
-   pgagroal_io_stop(&io_transfer.watcher);
-   pgagroal_disconnect(unix_transfer_socket);
-   errno = 0;
+   if (io_mgt.watcher.fds.worker.rcv_fd != -1 ||
+      io_mgt.watcher.fds.worker.snd_fd != -1)
+   {
+      pgagroal_io_stop(&io_mgt.watcher);
+   }
+   if (unix_management_socket != -1)
+   {
+      pgagroal_disconnect(unix_management_socket);
+      unix_management_socket = -1;
+   }
    if (remove)
    {
       pgagroal_remove_unix_socket(config->unix_socket_dir, TRANSFER_UDS);
    }
-   errno = 0;
 }
 
 static void


### PR DESCRIPTION
Fix accept EBADF loop during configuration reload.

When pgagroal-cli conf reload or conf set was executed,
sockets could be disconnected while the event loop still
attempted to accept connections on them.

This resulted in repeated "accept error: Bad file descriptor"
messages.

The fix ensures sockets are properly disconnected and the
accept loop ignores EBADF conditions that occur during reload
And i saw no bad error comming now. But due to linux environment i am not sharing screenshot.
closes: #767 