### PR TITLE
Add tests for integer configuration parsing

### DIFF
--- a/test/testcases/test_configuration.c
+++ b/test/testcases/test_configuration.c
@@ -459,3 +459,43 @@ MCTF_TEST(test_configuration_reject_invalid_log_rotation)
 
    MCTF_FINISH();
 }
+
+MCTF_TEST(test_configuration_accept_int)
+{
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_PORT, "5432");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_PORT, "0");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_PORT, "65535");
+
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_MAX_CONNECTIONS, "100");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_MAX_CONNECTIONS, "1");
+
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_MAX_RETRIES, "5");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_MAX_RETRIES, "0");
+
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_BACKLOG, "128");
+
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_configuration_reject_invalid_int)
+{
+   // Non-numeric
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_PORT, "abc");
+
+   // Decimal
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_PORT, "12.5");
+
+   // Empty string
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_PORT, "");
+
+   // Trailing characters
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_PORT, "100abc");
+
+   // Embedded space
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_PORT, "12 34");
+
+   // Whitespace only
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_PORT, " ");
+
+   MCTF_FINISH();
+}


### PR DESCRIPTION
## Summary

Adds unit test coverage for integer configuration parameter parsing in
`test/testcases/test_configuration.c`.

Covered cases:
- accepted integer values such as `100`, `0`, `65535`
- rejected invalid values such as `abc`, `12.5`, empty string, `100abc`, `12 34`

## Motivation

Integer configuration parameters control important runtime behavior and were not
explicitly covered by tests.

This change ensures that valid integer values remain accepted and malformed
values are consistently rejected.

## Test plan

- [x] Configuration module tests pass
- [x] Full unit test suite passes
- [x] No production code modified