### PR TITLE
Extend coverage for time configuration parsing

### DIFF
--- a/test/testcases/test_configuration.c
+++ b/test/testcases/test_configuration.c
@@ -375,3 +375,42 @@ MCTF_TEST(test_configuration_reject_invalid_update_process_title)
 
    MCTF_FINISH();
 }
+
+MCTF_TEST(test_configuration_accept_time_params)
+{
+   // blocking_timeout
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_BLOCKING_TIMEOUT, "30s");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_BLOCKING_TIMEOUT, "2m");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_BLOCKING_TIMEOUT, "1h");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_BLOCKING_TIMEOUT, "1d");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_BLOCKING_TIMEOUT, "2w");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_BLOCKING_TIMEOUT, "60");
+
+   // idle_timeout
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_IDLE_TIMEOUT, "30s");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_IDLE_TIMEOUT, "5m");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_IDLE_TIMEOUT, "1w");
+
+   // authentication_timeout
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_AUTHENTICATION_TIMEOUT, "5s");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_AUTHENTICATION_TIMEOUT, "10");
+
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_configuration_reject_invalid_time_params)
+{
+   // Non-numeric
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_BLOCKING_TIMEOUT, "abc");
+
+   // Invalid suffix
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_BLOCKING_TIMEOUT, "10x");
+
+   // Negative value
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_IDLE_TIMEOUT, "-5s");
+
+   // Mixed units
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_AUTHENTICATION_TIMEOUT, "1h5s");
+
+   MCTF_FINISH();
+}


### PR DESCRIPTION
Add unit test coverage for time-configuration parameter parsing across multiple parameters, exercising the as_seconds() path via pgagroal_apply_main_configuration.

Covered cases:
- accepted values: 30s, 2m, 1h, 1d, 2w, bare integers like 60
- rejected values: abc, 10x, -5s, 1h5s
- parameters tested: blocking_timeout, idle_timeout, authentication_timeout

This extends the existing time tests (which only cover metrics_cache_max_age) to additional parameters and adds coverage for the week suffix.