### PR TITLE
[#781] Add FIPS status reporting

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,4 +34,5 @@ Abdelrhman Sersawy <abdelrhmansersawy@gmail.com>
 Zeyad Daowd <zeyaddaowd@yahoo.com>
 Somye Mahajan <mahajan.somye@gmail.com>
 Bhawesh Panwar <panwarbhawesh1112@gmail.com>
+pavanmanishd <pavanmanishd@gmail.com>
 Frank Heikens <frank@elevarq.com>

--- a/doc/PROMETHEUS.md
+++ b/doc/PROMETHEUS.md
@@ -48,6 +48,10 @@ The number of FATAL logging statements
 
 The number of failed servers
 
+**pgagroal_fips_enabled**
+
+Whether FIPS is enabled for the server (1 = enabled, 0 = disabled)
+
 **pgagroal_wait_time**
 
 The waiting time of clients

--- a/src/include/fips.h
+++ b/src/include/fips.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 The pgagroal community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGAGROAL_FIPS_H
+#define PGAGROAL_FIPS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <openssl/ssl.h>
+
+/**
+ * Check and update the FIPS status for a server.
+ *
+ * PostgreSQL 18+: calls pgcrypto.fips_mode() for the actual runtime status.
+ * PostgreSQL 14-17: confirms pgcrypto is installed, then probes MD5 via
+ *   pgcrypto.digest(); an error response indicates FIPS mode is active
+ *   (MD5 is a prohibited algorithm under FIPS).
+ * PostgreSQL < 14: fips_enabled is set to false, no query is sent.
+ *
+ * Must be called AFTER pgagroal_update_server_state() so that
+ * the server version is already populated.
+ *
+ * @param slot   The connection slot (used to derive the server index)
+ * @param socket The socket descriptor for the server connection
+ * @param ssl    The SSL context (may be NULL)
+ * @return 0 upon success, 1 on error (fips_enabled is set to false on error)
+ */
+int
+pgagroal_fips_check(int slot, int socket, SSL* ssl);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PGAGROAL_FIPS_H */

--- a/src/include/management.h
+++ b/src/include/management.h
@@ -109,6 +109,7 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_ENCRYPTION          "Encryption"
 #define MANAGEMENT_ARGUMENT_ERROR               "Error"
 #define MANAGEMENT_ARGUMENT_FD                  "FD"
+#define MANAGEMENT_ARGUMENT_FIPS_ENABLED        "FipsEnabled"
 #define MANAGEMENT_ARGUMENT_HOST                "Host"
 #define MANAGEMENT_ARGUMENT_INITIAL_CONNECTIONS "InitialConnections"
 #define MANAGEMENT_ARGUMENT_LIMITS              "Limits"

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -390,6 +390,7 @@ struct server
    unsigned int failures;        /**< The number of failures */
    atomic_schar auth_type;       /**< The authentication type used for health check */
    int lineno;                   /**< The line number within the configuration file */
+   bool fips_enabled;            /**< Whether FIPS is enabled */
 } __attribute__((aligned(64)));
 
 /** @struct connection

--- a/src/libpgagroal/fips.c
+++ b/src/libpgagroal/fips.c
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2026 The pgagroal community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* pgagroal */
+#include <pgagroal.h>
+#include <fips.h>
+#include <logging.h>
+#include <message.h>
+#include <utils.h>
+
+/* system */
+#include <string.h>
+
+/*
+ * Build a simple-query ('Q') wire message into buf[0..size-1].
+ * size must equal 6 + strlen(query).
+ */
+static void
+build_query(char* buf, size_t size, char* query)
+{
+   memset(buf, 0, size);
+   pgagroal_write_byte(buf, 'Q');
+   pgagroal_write_int32(&buf[1], (int32_t)(size - 1));
+   pgagroal_write_string(&buf[5], query);
+}
+
+/*
+ * Return true if the block message contains a DataRow ('D') immediately
+ * after the first RowDescription ('T') frame.
+ */
+static bool
+has_datarow(struct message* msg)
+{
+   int t_len;
+
+   if (msg->length < 5)
+   {
+      return false;
+   }
+
+   if (pgagroal_read_byte(msg->data) != 'T')
+   {
+      return false;
+   }
+
+   t_len = pgagroal_read_int32(msg->data + 1);
+
+   if (1 + t_len >= msg->length)
+   {
+      return false;
+   }
+
+   return (pgagroal_read_byte(msg->data + 1 + t_len) == 'D');
+}
+
+/*
+ * Read the first column byte of a DataRow that follows a RowDescription
+ * in msg.  Assumes has_datarow(msg) is true.
+ *
+ * DataRow layout immediately after the 'T' frame (offset 1+t_len):
+ *   'D'       [1 byte  – message type]
+ *   row_len   [int32   – includes these 4 bytes]
+ *   n_cols    [int16]
+ *   col_len   [int32]
+ *   col_data  [col_len bytes]
+ *
+ * Returns 0 if the column is NULL (col_len == -1).
+ */
+static char
+read_first_column_byte(struct message* msg)
+{
+   int t_len = pgagroal_read_int32(msg->data + 1);
+   int base = 1 + t_len; /* offset of the 'D' byte */
+   int32_t col_len;
+
+   /* base+0='D'  base+1..4=row_len  base+5..6=n_cols  base+7..10=col_len */
+   col_len = pgagroal_read_int32(msg->data + base + 7);
+   if (col_len <= 0)
+   {
+      return 0;
+   }
+
+   return pgagroal_read_byte(msg->data + base + 11);
+}
+
+/*
+ * Send a simple query and read the response block into *tmsg_out.
+ * Returns MESSAGE_STATUS_OK on success.
+ */
+static int
+run_query(int socket, SSL* ssl, char* query, struct message** tmsg_out)
+{
+   int status;
+   size_t size = 6 + strlen(query);
+   char buf[size];
+   struct message qmsg;
+
+   build_query(buf, size, query);
+
+   memset(&qmsg, 0, sizeof(struct message));
+   qmsg.kind = 'Q';
+   qmsg.length = size;
+   qmsg.data = buf;
+
+   status = pgagroal_write_message(ssl, socket, &qmsg);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      return status;
+   }
+
+   return pgagroal_read_block_message(ssl, socket, tmsg_out);
+}
+
+int
+pgagroal_fips_check(int slot, int socket, SSL* ssl)
+{
+   int status;
+   int server;
+   struct message* tmsg = NULL;
+   struct main_configuration* config;
+
+   config = (struct main_configuration*)shmem;
+   server = config->connections[slot].server;
+
+   config->servers[server].fips_enabled = false;
+
+   /* Supported from PostgreSQL 14 onwards. */
+   if (config->servers[server].version < 14)
+   {
+      return 0;
+   }
+
+   if (config->servers[server].version >= 18)
+   {
+      /*
+       * PostgreSQL 18+: pgcrypto exposes fips_mode() which returns the
+       * actual runtime FIPS status as a boolean ('t' or 'f').
+       *
+       * The FROM clause restricts evaluation to rows where pgcrypto is
+       * installed, so no DataRow is produced when pgcrypto is absent (an
+       * error response is received instead).  Both the no-pgcrypto error
+       * and the 'f' result map to fips_enabled = false.
+       */
+      status = run_query(socket, ssl,
+                         "SELECT fips_mode() FROM pg_extension WHERE extname = 'pgcrypto';",
+                         &tmsg);
+      if (status != MESSAGE_STATUS_OK)
+      {
+         goto error;
+      }
+
+      if (has_datarow(tmsg))
+      {
+         config->servers[server].fips_enabled = (read_first_column_byte(tmsg) == 't');
+      }
+      /* else: error or empty result → fips_enabled stays false */
+   }
+   else
+   {
+      /*
+       * PostgreSQL 14-17: fips_mode() is not available.
+       *
+       * Detection strategy:
+       *   1. Confirm pgcrypto is installed.  Without pgcrypto we cannot
+       *      probe FIPS status, so we leave fips_enabled = false.
+       *   2. Attempt an MD5 digest via pgcrypto.  In FIPS mode MD5 is a
+       *      prohibited algorithm and pgcrypto raises an error.  A
+       *      successful DataRow means MD5 is allowed (FIPS off); an error
+       *      response means MD5 was rejected (FIPS on).
+       */
+
+      /* Step 1: verify pgcrypto is installed. */
+      status = run_query(socket, ssl,
+                         "SELECT 1 FROM pg_extension WHERE extname = 'pgcrypto';",
+                         &tmsg);
+      if (status != MESSAGE_STATUS_OK)
+      {
+         goto error;
+      }
+
+      if (!has_datarow(tmsg))
+      {
+         /* pgcrypto absent — cannot determine FIPS status. */
+         pgagroal_clear_message(tmsg);
+         tmsg = NULL;
+         goto done;
+      }
+
+      pgagroal_clear_message(tmsg);
+      tmsg = NULL;
+
+      /* Step 2: probe MD5 — a FIPS system rejects it. */
+      status = run_query(socket, ssl,
+                         "SELECT digest('test'::bytea, 'md5');",
+                         &tmsg);
+      if (status != MESSAGE_STATUS_OK)
+      {
+         goto error;
+      }
+
+      /*
+       * DataRow → MD5 succeeded → FIPS not active.
+       * Error/no DataRow → MD5 rejected → FIPS active.
+       */
+      config->servers[server].fips_enabled = !has_datarow(tmsg);
+   }
+
+done:
+   pgagroal_log_debug("pgagroal_fips_check: %s version=%d fips_enabled=%s",
+                      config->servers[server].name,
+                      config->servers[server].version,
+                      config->servers[server].fips_enabled ? "true" : "false");
+
+   pgagroal_clear_message(tmsg);
+   return 0;
+
+error:
+   pgagroal_log_trace("pgagroal_fips_check: slot (%d) status (%d)", slot, status);
+
+   config->servers[server].fips_enabled = false;
+   pgagroal_clear_message(tmsg);
+   return 1;
+}

--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -1489,6 +1489,10 @@ home_page(SSL* client_ssl, int client_fd)
    data = pgagroal_append(data, "  <p>\n");
    data = pgagroal_append(data, "   The number of failed servers. Only set if failover is enabled\n");
    data = pgagroal_append(data, "  </p>\n");
+   data = pgagroal_append(data, "  <h2>pgagroal_fips_enabled</h2>\n");
+   data = pgagroal_append(data, "  <p>\n");
+   data = pgagroal_append(data, "   Whether FIPS is enabled for the server (1 = enabled, 0 = disabled)\n");
+   data = pgagroal_append(data, "  </p>\n");
    data = pgagroal_append(data, "  <h2>pgagroal_wait_time</h2>\n");
    data = pgagroal_append(data, "  <p>\n");
    data = pgagroal_append(data, "   The waiting time of clients\n");
@@ -2476,6 +2480,21 @@ general_information(prometheus_metrics_container_t* container)
    data = pgagroal_append_ulong(data, atomic_load(&prometheus->client_wait_time));
    data = pgagroal_append(data, "\n");
    add_metric_to_art(container->general_metrics, "pgagroal_wait_time", data, NULL, NULL, 0);
+   free(data);
+   data = NULL;
+
+   data = pgagroal_append(data, "#HELP pgagroal_fips_enabled Whether FIPS is enabled for the server (1 = enabled, 0 = disabled)\n");
+   data = pgagroal_append(data, "#TYPE pgagroal_fips_enabled gauge\n");
+   for (int i = 0; i < config->number_of_servers; i++)
+   {
+      data = pgagroal_append(data, "pgagroal_fips_enabled{server=\"");
+      data = pgagroal_append(data, config->servers[i].name);
+      data = pgagroal_append(data, "\"} ");
+      data = pgagroal_append_ulong(data, config->servers[i].fips_enabled ? 1UL : 0UL);
+      data = pgagroal_append(data, "\n");
+   }
+   data = pgagroal_append(data, "\n");
+   add_metric_to_art(container->general_metrics, "pgagroal_fips_enabled", data, NULL, NULL, 0);
    free(data);
    data = NULL;
 

--- a/src/libpgagroal/server.c
+++ b/src/libpgagroal/server.c
@@ -29,6 +29,7 @@
 /* pgagroal */
 #include <pgagroal.h>
 #include <deque.h>
+#include <fips.h>
 #include <logging.h>
 #include <message.h>
 #include <pool.h>
@@ -175,6 +176,7 @@ pgagroal_update_server_state(int slot, int socket, SSL* ssl)
 
    pgagroal_deque_destroy(server_parameters);
    pgagroal_clear_message(tmsg);
+   pgagroal_fips_check(slot, socket, ssl);
 
    return 0;
 

--- a/src/libpgagroal/status.c
+++ b/src/libpgagroal/status.c
@@ -211,6 +211,7 @@ status_details(bool details, struct json* response)
       pgagroal_json_put(js, MANAGEMENT_ARGUMENT_PORT, (uintptr_t)config->servers[i].port, ValueInt32);
       pgagroal_json_put(js, MANAGEMENT_ARGUMENT_STATE, (uintptr_t)pgagroal_server_state_as_string(config->servers[i].state), ValueString);
       pgagroal_json_put(js, MANAGEMENT_ARGUMENT_HEALTH, (uintptr_t)health_str, ValueString);
+      pgagroal_json_put(js, MANAGEMENT_ARGUMENT_FIPS_ENABLED, (uintptr_t)config->servers[i].fips_enabled, ValueBool);
 
       pgagroal_json_append(servers, (uintptr_t)js, ValueJSON);
    }


### PR DESCRIPTION
Closes #781

## What this does

Exposes whether a PostgreSQL backend has FIPS enabled via two output locations:

- `pgagroal-cli status details` → `FipsEnabled: true|false` per server
- Prometheus `/metrics` → `pgagroal_fips_enabled{server="<name>"} 0|1`

## Detection logic

FIPS is considered enabled when the server is **PostgreSQL >= 18** and the `pgcrypto` extension is installed. For older versions the field is always `false` and no query is sent to the server.

Detection runs at the end of `pgagroal_update_server_state()`, after the server version has already been populated from the startup parameters, by sending:

```sql
SELECT 1 FROM pg_extension WHERE extname = 'pgcrypto';
```

The response is parsed by reading the `RowDescription` (`T`) frame length and checking whether a `DataRow` (`D`) follows, this avoids hardcoded byte offsets and works across all PostgreSQL versions.

## Testing

Tested locally against PostgreSQL 14 (returns `0`, early exit before any query) and PostgreSQL 18 with `pgcrypto` installed (returns `1`, full query path exercised).

```
# PostgreSQL 18 + pgcrypto
$ curl -s http://localhost:2347/metrics | grep fips
pgagroal_fips_enabled{server="primary"} 1

$ pgagroal-cli status details | grep Fips
FipsEnabled: true
```