### PR TITLE
[#798] Reject invalid enum configuration values instead of silently using defaults

### DIFF
--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -65,14 +65,14 @@ static int extract_key_value(char* str, char** key, char** value);
 static int extract_syskey_value(char* str, char** key, char** value);
 static int as_int(char* str, int* i);
 static int as_bool(char* str, bool* b);
-static int as_logging_type(char* str);
+static int as_logging_type(char* str, int* type);
 static int as_logging_level(char* str);
-static int as_logging_mode(char* str);
+static int as_logging_mode(char* str, int* mode);
 
 static int as_logging_rotation_size(char* str, unsigned int* size);
-static int as_validation(char* str);
-static int as_pipeline(char* str);
-static int as_hugepage(char* str);
+static int as_validation(char* str, int* val);
+static int as_pipeline(char* str, int* pipeline);
+static int as_hugepage(char* str, unsigned char* hp);
 static unsigned int as_update_process_title(char* str, unsigned int* policy, unsigned int default_policy);
 static int extract_value(char* str, int offset, char** value);
 static void extract_hba(char* str, char** type, char** database, char** user, char** address, char** method);
@@ -2783,24 +2783,27 @@ as_bool(char* str, bool* b)
 }
 
 static int
-as_logging_type(char* str)
+as_logging_type(char* str, int* type)
 {
    if (!strcasecmp(str, "console"))
    {
-      return PGAGROAL_LOGGING_TYPE_CONSOLE;
+      *type = PGAGROAL_LOGGING_TYPE_CONSOLE;
+      return 0;
    }
 
    if (!strcasecmp(str, "file"))
    {
-      return PGAGROAL_LOGGING_TYPE_FILE;
+      *type = PGAGROAL_LOGGING_TYPE_FILE;
+      return 0;
    }
 
    if (!strcasecmp(str, "syslog"))
    {
-      return PGAGROAL_LOGGING_TYPE_SYSLOG;
+      *type = PGAGROAL_LOGGING_TYPE_SYSLOG;
+      return 0;
    }
 
-   return PGAGROAL_LOGGING_TYPE_CONSOLE;
+   return 1;
 }
 
 static int
@@ -2887,87 +2890,99 @@ as_logging_level(char* str)
 }
 
 static int
-as_logging_mode(char* str)
+as_logging_mode(char* str, int* mode)
 {
    if (!strcasecmp(str, "a") || !strcasecmp(str, "append"))
    {
-      return PGAGROAL_LOGGING_MODE_APPEND;
+      *mode = PGAGROAL_LOGGING_MODE_APPEND;
+      return 0;
    }
 
    if (!strcasecmp(str, "c") || !strcasecmp(str, "create"))
    {
-      return PGAGROAL_LOGGING_MODE_CREATE;
+      *mode = PGAGROAL_LOGGING_MODE_CREATE;
+      return 0;
    }
 
-   return PGAGROAL_LOGGING_MODE_APPEND;
+   return 1;
 }
 
 static int
-as_validation(char* str)
+as_validation(char* str, int* val)
 {
    if (!strcasecmp(str, "off"))
    {
-      return VALIDATION_OFF;
+      *val = VALIDATION_OFF;
+      return 0;
    }
 
    if (!strcasecmp(str, "foreground"))
    {
-      return VALIDATION_FOREGROUND;
+      *val = VALIDATION_FOREGROUND;
+      return 0;
    }
 
    if (!strcasecmp(str, "background"))
    {
-      return VALIDATION_BACKGROUND;
+      *val = VALIDATION_BACKGROUND;
+      return 0;
    }
 
-   return VALIDATION_OFF;
+   return 1;
 }
 
 static int
-as_pipeline(char* str)
+as_pipeline(char* str, int* pipeline)
 {
    if (!strcasecmp(str, "auto"))
    {
-      return PIPELINE_AUTO;
+      *pipeline = PIPELINE_AUTO;
+      return 0;
    }
 
    if (!strcasecmp(str, "performance"))
    {
-      return PIPELINE_PERFORMANCE;
+      *pipeline = PIPELINE_PERFORMANCE;
+      return 0;
    }
 
    if (!strcasecmp(str, "session"))
    {
-      return PIPELINE_SESSION;
+      *pipeline = PIPELINE_SESSION;
+      return 0;
    }
 
    if (!strcasecmp(str, "transaction"))
    {
-      return PIPELINE_TRANSACTION;
+      *pipeline = PIPELINE_TRANSACTION;
+      return 0;
    }
 
-   return PIPELINE_AUTO;
+   return 1;
 }
 
 static int
-as_hugepage(char* str)
+as_hugepage(char* str, unsigned char* hp)
 {
    if (!strcasecmp(str, "off"))
    {
-      return HUGEPAGE_OFF;
+      *hp = HUGEPAGE_OFF;
+      return 0;
    }
 
    if (!strcasecmp(str, "try"))
    {
-      return HUGEPAGE_TRY;
+      *hp = HUGEPAGE_TRY;
+      return 0;
    }
 
    if (!strcasecmp(str, "on"))
    {
-      return HUGEPAGE_ON;
+      *hp = HUGEPAGE_ON;
+      return 0;
    }
 
-   return HUGEPAGE_OFF;
+   return 1;
 }
 
 static void
@@ -5601,7 +5616,10 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("pipeline", section, key, true, &unknown))
    {
-      config->pipeline = as_pipeline(value);
+      if (as_pipeline(value, &config->pipeline))
+      {
+         unknown = true;
+      }
    }
    else if (key_in_section("failover", section, key, true, &unknown))
    {
@@ -5743,7 +5761,10 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("validation", section, key, true, &unknown))
    {
-      config->validation = as_validation(value);
+      if (as_validation(value, &config->validation))
+      {
+         unknown = true;
+      }
    }
    else if (key_in_section("background_interval", section, key, true, &unknown))
    {
@@ -5829,7 +5850,10 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("log_type", section, key, true, &unknown))
    {
-      config->common.log_type = as_logging_type(value);
+      if (as_logging_type(value, &config->common.log_type))
+      {
+         unknown = true;
+      }
    }
    else if (key_in_section("log_level", section, key, true, &unknown))
    {
@@ -5884,7 +5908,10 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("log_mode", section, key, true, &unknown))
    {
-      config->common.log_mode = as_logging_mode(value);
+      if (as_logging_mode(value, &config->common.log_mode))
+      {
+         unknown = true;
+      }
    }
    else if (key_in_section("max_connections", section, key, true, &unknown))
    {
@@ -5929,7 +5956,10 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("hugepage", section, key, true, &unknown))
    {
-      config->common.hugepage = as_hugepage(value);
+      if (as_hugepage(value, &config->common.hugepage))
+      {
+         unknown = true;
+      }
    }
    else if (key_in_section("tracker", section, key, true, &unknown))
    {
@@ -5949,7 +5979,7 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    {
       if (as_update_process_title(value, &config->update_process_title, UPDATE_PROCESS_TITLE_VERBOSE))
       {
-         unknown = false;
+         unknown = true;
       }
    }
    else
@@ -6137,7 +6167,10 @@ pgagroal_apply_vault_configuration(struct vault_configuration* config,
    }
    else if (key_in_section("log_type", section, key, true, &unknown))
    {
-      config->common.log_type = as_logging_type(value);
+      if (as_logging_type(value, &config->common.log_type))
+      {
+         unknown = true;
+      }
    }
    else if (key_in_section("log_level", section, key, true, &unknown))
    {
@@ -6192,11 +6225,17 @@ pgagroal_apply_vault_configuration(struct vault_configuration* config,
    }
    else if (key_in_section("log_mode", section, key, true, &unknown))
    {
-      config->common.log_mode = as_logging_mode(value);
+      if (as_logging_mode(value, &config->common.log_mode))
+      {
+         unknown = true;
+      }
    }
    else if (key_in_section("hugepage", section, key, true, &unknown))
    {
-      config->common.hugepage = as_hugepage(value);
+      if (as_hugepage(value, &config->common.hugepage))
+      {
+         unknown = true;
+      }
    }
    return 0;
 }

--- a/test/testcases/test_configuration.c
+++ b/test/testcases/test_configuration.c
@@ -172,3 +172,121 @@ cleanup:
    free(str);
    MCTF_FINISH();
 }
+
+MCTF_TEST(test_configuration_accept_pipeline)
+{
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_PIPELINE, "auto");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_PIPELINE, "performance");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_PIPELINE, "session");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_PIPELINE, "transaction");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_PIPELINE, "AUTO");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_PIPELINE, "Session");
+
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_configuration_reject_invalid_pipeline)
+{
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_PIPELINE, "fast");
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_PIPELINE, "none");
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_PIPELINE, "");
+
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_configuration_accept_validation)
+{
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_VALIDATION, "off");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_VALIDATION, "foreground");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_VALIDATION, "background");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_VALIDATION, "OFF");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_VALIDATION, "Foreground");
+
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_configuration_reject_invalid_validation)
+{
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_VALIDATION, "on");
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_VALIDATION, "true");
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_VALIDATION, "");
+
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_configuration_accept_hugepage)
+{
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_HUGEPAGE, "off");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_HUGEPAGE, "try");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_HUGEPAGE, "on");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_HUGEPAGE, "OFF");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_HUGEPAGE, "Try");
+
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_configuration_reject_invalid_hugepage)
+{
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_HUGEPAGE, "yes");
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_HUGEPAGE, "true");
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_HUGEPAGE, "");
+
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_configuration_accept_log_type)
+{
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_LOG_TYPE, "console");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_LOG_TYPE, "file");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_LOG_TYPE, "syslog");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_LOG_TYPE, "Console");
+
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_configuration_reject_invalid_log_type)
+{
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_LOG_TYPE, "stdout");
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_LOG_TYPE, "");
+
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_configuration_accept_log_mode)
+{
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_LOG_MODE, "a");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_LOG_MODE, "append");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_LOG_MODE, "c");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_LOG_MODE, "create");
+
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_configuration_reject_invalid_log_mode)
+{
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_LOG_MODE, "overwrite");
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_LOG_MODE, "");
+
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_configuration_accept_update_process_title)
+{
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_UPDATE_PROCESS_TITLE, "never");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_UPDATE_PROCESS_TITLE, "off");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_UPDATE_PROCESS_TITLE, "strict");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_UPDATE_PROCESS_TITLE, "minimal");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_UPDATE_PROCESS_TITLE, "verbose");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_UPDATE_PROCESS_TITLE, "full");
+
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_configuration_reject_invalid_update_process_title)
+{
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_UPDATE_PROCESS_TITLE, "invalid");
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_UPDATE_PROCESS_TITLE, "yes");
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_UPDATE_PROCESS_TITLE, "");
+
+   MCTF_FINISH();
+}


### PR DESCRIPTION
## Summary

Several enum configuration parsers silently fell back to default values
when given unrecognized input. For example, `pipeline = perforance`
(typo) was silently treated as `pipeline = auto` with no feedback to
the operator.

This changes the affected parsers to signal an error on invalid input,
consistent with how `as_bool()` and `as_int()` already behave. The
existing configuration loading framework reports the invalid key/value
with file and line number context.

## Affected parameters

| Parameter | Valid values | Previous behavior on invalid input | New behavior |
|---|---|---|---|
| `pipeline` | auto, performance, session, transaction | Silent fallback to `auto` | Configuration error |
| `validation` | off, foreground, background | Silent fallback to `off` | Configuration error |
| `hugepage` | off, try, on | Silent fallback to `off` | Configuration error |
| `log_type` | console, file, syslog | Silent fallback to `console` | Configuration error |
| `log_mode` | a, append, c, create | Silent fallback to `append` | Configuration error |
| `update_process_title` | never, off, strict, minimal, verbose, full | Error returned but swallowed | Configuration error |

Omitted parameters and valid values (including case-insensitive
variants) behave exactly as before.

`as_logging_level()` is not changed as it has its own fallback logic
with explicit warnings for out-of-range debug levels.

## Tests

Adds 12 test functions covering acceptance and rejection for each
affected parameter.

## Test plan
- [x] All 16 configuration module tests pass
- [x] Full unit test suite passes (47/47)
- [x] No change to omitted-parameter defaults

Closes #798