### PR TITLE
[#772] Recognize [prometheus] as a global configuration section

### DIFF
--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -282,7 +282,7 @@ pgagroal_read_configuration(void* shm, char* filename, bool emit_warnings)
 
             idx_sections++;
 
-            if (strcmp(section, PGAGROAL_MAIN_INI_SECTION) && strcmp(section, "health_check"))
+            if (strcmp(section, PGAGROAL_MAIN_INI_SECTION) && strcmp(section, "health_check") && strcmp(section, "prometheus"))
             {
                if (idx_server > 0 && idx_server <= NUMBER_OF_SERVERS)
                {
@@ -4227,7 +4227,8 @@ key_in_section(char* wanted, char* section, char* key, bool global, bool* unknow
    // appropriate
    if (global && (!strncmp(section, PGAGROAL_MAIN_INI_SECTION, MISC_LENGTH) ||
                   !strncmp(section, PGAGROAL_VAULT_INI_SECTION, MISC_LENGTH) ||
-                  !strncmp(section, "health_check", MISC_LENGTH)))
+                  !strncmp(section, "health_check", MISC_LENGTH) ||
+                  !strncmp(section, "prometheus", MISC_LENGTH)))
    {
       return true;
    }

--- a/test/include/tscommon.h
+++ b/test/include/tscommon.h
@@ -44,6 +44,15 @@ void
 pgagroal_test_assert_conf_set_ok(char* key, char* value);
 
 /**
+ * Assert that conf set succeeds for a given section
+ * @param section The configuration section
+ * @param key The configuration key
+ * @param value The value to set
+ */
+void
+pgagroal_test_assert_conf_section_set_ok(char* section, char* key, char* value);
+
+/**
  * Assert that conf set fails for the given key/value
  * @param key The configuration key
  * @param value The value to set

--- a/test/libpgagroaltest/tscommon.c
+++ b/test/libpgagroaltest/tscommon.c
@@ -47,6 +47,20 @@ pgagroal_test_assert_conf_set_fail(char* key, char* value)
 }
 
 void
+pgagroal_test_assert_conf_section_set_ok(char* section, char* key, char* value)
+{
+   struct main_configuration config;
+   memset(&config, 0, sizeof(struct main_configuration));
+   int ret = pgagroal_apply_main_configuration(&config, NULL, section, key, value);
+   if (ret != 0)
+   {
+      mctf_errno = 1;
+      mctf_errmsg = mctf_format_error("Expected conf set to succeed for section='%s' key='%s' value='%s', but it failed with %d",
+                                       section, key, value, ret);
+   }
+}
+
+void
 pgagroal_test_assert_conf_set_ok(char* key, char* value)
 {
    struct main_configuration config;

--- a/test/testcases/test_configuration.c
+++ b/test/testcases/test_configuration.c
@@ -375,3 +375,17 @@ MCTF_TEST(test_configuration_reject_invalid_update_process_title)
 
    MCTF_FINISH();
 }
+
+MCTF_TEST(test_configuration_prometheus_section_keys)
+{
+   // Metrics keys should be accepted in a [prometheus] section
+   pgagroal_test_assert_conf_section_set_ok("prometheus", CONFIGURATION_ARGUMENT_METRICS, "9187");
+   pgagroal_test_assert_conf_section_set_ok("prometheus", CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, "10s");
+   pgagroal_test_assert_conf_section_set_ok("prometheus", CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_SIZE, "256K");
+
+   // Same keys should still work in the main [pgagroal] section
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_METRICS, "9187");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, "10s");
+
+   MCTF_FINISH();
+}


### PR DESCRIPTION
## Summary

The configuration parser treated `[prometheus]` as a server section,
causing "Unknown key" warnings for valid prometheus keys during startup
and reload.

## Root cause

Two hardcoded lists of known global sections (in `pgagroal_read_configuration`
and `key_in_section`) included `pgagroal`, `pgagroal-vault`, and
`health_check` but not `prometheus`. A `[prometheus]` section was
therefore parsed as a server definition, and its keys failed the
server-key lookup.

## Fix

Add `"prometheus"` to both global section checks, matching the existing
pattern for `"health_check"`. The fix covers both startup and reload
paths since both use `pgagroal_read_configuration`.

## Tests

Adds a regression test verifying that `metrics`, `metrics_cache_max_age`,
and `metrics_cache_max_size` are accepted in a `[prometheus]` section.
Also verifies the same keys still work in the main `[pgagroal]` section.

## Test plan
- [x] Configuration module tests pass (5/5)
- [x] All unit tests pass; pre-existing integration test failures unchanged
- [x] Regression test fails before fix, passes after

Closes #772