### PR TITLE
[#750] Guard pgagroal_io_stop in forked children; fix ev_io_uring_fork

### DIFF
--- a/src/include/ev.h
+++ b/src/include/ev.h
@@ -193,6 +193,7 @@ struct periodic_watcher
 struct event_loop
 {
    atomic_bool running;                 /**< Flag indicating if the event loop is running. */
+   atomic_bool forked;                  /**< Set to true in child processes after pgagroal_event_loop_fork(). */
    sigset_t sigset;                     /**< Signal set used for handling signals in the event loop. */
    event_watcher_t* events[MAX_EVENTS]; /**< List of events */
    int events_nr;                       /**< Size of list of events */

--- a/src/libpgagroal/ev.c
+++ b/src/libpgagroal/ev.c
@@ -260,6 +260,9 @@ pgagroal_event_loop_init(void)
       pgagroal_log_fatal("calloc error: %s", strerror(errno));
       return NULL;
    }
+
+   atomic_init(&loop->running, false);
+   atomic_init(&loop->forked, false);
    sigemptyset(&loop->sigset);
 
    if (!context_is_set)
@@ -345,6 +348,8 @@ pgagroal_event_loop_fork(void)
 
    /* no need to empty sigset */
    rc = loop_fork();
+
+   atomic_store(&loop->forked, true);
 
    return rc;
 }
@@ -469,6 +474,11 @@ pgagroal_io_stop(struct io_watcher* watcher)
    int i;
 
    assert(loop != NULL && watcher != NULL);
+
+   if (atomic_load(&loop->forked))
+   {
+      return PGAGROAL_EVENT_RC_OK;
+   }
 
    for (i = 0; i < loop->events_nr; i++)
    {
@@ -1035,7 +1045,7 @@ ev_io_uring_loop(void)
 static int
 ev_io_uring_fork(void)
 {
-   return 0;
+   return PGAGROAL_EVENT_RC_OK;
 }
 
 static int


### PR DESCRIPTION
Closes #750

## What this does

A problem remained after PR #765:

`pgagroal_io_stop()` could still be reached in forked children

Even after #765 removed `io_stop` calls from specific shutdown paths, a future
child cleanup path could still call `pgagroal_io_stop()` after
`pgagroal_event_loop_fork()`, touch `loop->events[]`, and generate noisy errors.

Fix:
- add `atomic_bool forked` to `struct event_loop`
- set it in `pgagroal_event_loop_fork()`
- return early in `pgagroal_io_stop()` when running in a forked child


## Changes

- `src/include/ev.h`
  - add `atomic_bool forked` to `struct event_loop`
- `src/libpgagroal/ev.c`
  - initialize loop atomics explicitly
  - set `forked` in `pgagroal_event_loop_fork()`
  - guard `pgagroal_io_stop()` in forked children
  - keep `ev_io_uring_fork()` as no-op