### PR TITLE
[#793] Add shared-memory isolation reset in MCTF test runs

### DIFF
--- a/test/include/tsclient.h
+++ b/test/include/tsclient.h
@@ -64,6 +64,19 @@ int
 pgagroal_tsclient_destroy();
 
 /**
+ * Reset shared memory to the initial configuration state.
+ *
+ * Calls pgagroal_init_configuration() followed by
+ * pgagroal_read_configuration() to re-apply the test configuration file.
+ * This provides per-test isolation: call it before or after each test that
+ * modifies configuration values so subsequent tests start from a known state.
+ *
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgagroal_tsclient_reset_shmem(void);
+
+/**
  * A wrapper around pgbench specific to our usecase [benchmark options supported: '-c', '-j', '-t']
  * Execute a pgbench command for a set of instructions, assuming we are connecting to the 1st server
  * @param database name of the database

--- a/test/libpgagroaltest/mctf.c
+++ b/test/libpgagroaltest/mctf.c
@@ -27,6 +27,7 @@
  */
 
 #include <mctf.h>
+#include <tsclient.h>
 
 #include <errno.h>
 #include <stdarg.h>
@@ -442,7 +443,29 @@ mctf_run_tests(mctf_filter_type_t filter_type, const char* filter)
          free(mctf_errmsg);
          mctf_errmsg = NULL;
       }
-      int ret = test->func();
+      int ret = 0;
+
+      if (pgagroal_tsclient_reset_shmem())
+      {
+         mctf_errno = __LINE__;
+         mctf_errmsg = strdup("Failed to reset shared memory before test");
+         ret = 1;
+      }
+      else
+      {
+         ret = test->func();
+      }
+
+      if (pgagroal_tsclient_reset_shmem())
+      {
+         if (mctf_errmsg)
+         {
+            free(mctf_errmsg);
+         }
+         mctf_errno = __LINE__;
+         mctf_errmsg = strdup("Failed to reset shared memory after test");
+         ret = 1;
+      }
 
       clock_gettime(CLOCK_MONOTONIC, &end_time);
 

--- a/test/libpgagroaltest/tsclient.c
+++ b/test/libpgagroaltest/tsclient.c
@@ -102,6 +102,30 @@ pgagroal_tsclient_destroy()
 }
 
 int
+pgagroal_tsclient_reset_shmem(void)
+{
+   int ret;
+   char* configuration_path = NULL;
+
+   if (shmem == NULL)
+   {
+      return 1;
+   }
+
+   pgagroal_init_configuration(shmem);
+
+   configuration_path = get_configuration_path();
+   if (configuration_path != NULL)
+   {
+      ret = pgagroal_read_configuration(shmem, configuration_path, false);
+      free(configuration_path);
+      return ret;
+   }
+
+   return 1;
+}
+
+int
 pgagroal_tsclient_execute_pgbench(char* user, char* database, bool select_only, int client_count, int thread_count, int transaction_count)
 {
    char* command = NULL;


### PR DESCRIPTION
Closes #793

## Scope

This PR is intentionally narrowed to **config isolation only**.
Per review feedback, the log-slicing work from #792 is removed and will be submitted separately.

## What changed

- Keep `pgagroal_tsclient_reset_shmem()` as the shared-memory reset primitive.
- Integrate reset into MCTF execution lifecycle in `mctf_run_tests()`:
  - reset once **before** each test
  - reset once **after** each test
- If reset fails, mark the test as failed with a clear message.

## Why

Tests share one process and one shared-memory configuration. Without reset between tests,
mutations leak across test cases and make results order-dependent/flaky.

## Files

- `test/libpgagroaltest/mctf.c`
- `test/include/mctf.h`
- `test/include/tsclient.h`
- `test/libpgagroaltest/tsclient.c`