### PR TITLE
[#809] Add tests for log rotation configuration parsing

### DIFF
--- a/test/testcases/test_configuration.c
+++ b/test/testcases/test_configuration.c
@@ -375,3 +375,34 @@ MCTF_TEST(test_configuration_reject_invalid_update_process_title)
 
    MCTF_FINISH();
 }
+
+MCTF_TEST(test_configuration_accept_log_rotation)
+{
+   // log_rotation_size (as_bytes path)
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_LOG_ROTATION_SIZE, "1M");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_LOG_ROTATION_SIZE, "512K");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_LOG_ROTATION_SIZE, "1G");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_LOG_ROTATION_SIZE, "1024");
+
+   // log_rotation_age (as_seconds path)
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_LOG_ROTATION_AGE, "1d");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_LOG_ROTATION_AGE, "12h");
+   pgagroal_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_LOG_ROTATION_AGE, "1w");
+
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_configuration_reject_invalid_log_rotation)
+{
+   // log_rotation_size
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_LOG_ROTATION_SIZE, "abc");
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_LOG_ROTATION_SIZE, "-1");
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_LOG_ROTATION_SIZE, "1MK");
+
+   // log_rotation_age
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_LOG_ROTATION_AGE, "abc");
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_LOG_ROTATION_AGE, "10x");
+   pgagroal_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_LOG_ROTATION_AGE, "-1s");
+
+   MCTF_FINISH();
+}


### PR DESCRIPTION
## Summary

Adds unit test coverage for log rotation configuration parameter parsing
in `test/testcases/test_configuration.c`.

Covered cases:
- `log_rotation_size`: accepted byte formats (`1M`, `512K`, `1G`, bare integer), rejected invalid input (`abc`, `-1`, conflicting suffix)
- `log_rotation_age`: accepted time formats (`1d`, `12h`, `1w`), rejected invalid input (`abc`, `10x`, `-1s`)

## Test plan
- [x] Configuration module tests pass (22/22)
- [x] All unit tests pass; pre-existing integration test failures unchanged
- [x] No production code modified

Ref #809