### PR TITLE
[#792] Add per-test pgagroal log slicing and ERROR detection in MCTF

### DIFF
--- a/doc/TEST.md
+++ b/doc/TEST.md
@@ -65,6 +65,8 @@ MCTF (Minimal C Test Framework) is pgagroal's custom test framework designed for
 - **Flexible assertions** - Assert macros with optional printf-style error messages
 - **Test filtering** - Run tests by name pattern ('-t') or by module ('-m')
 - **Test skipping** - Skip tests conditionally using 'MCTF_SKIP()' when prerequisites aren't met
+- **Per-test pgagroal log slicing** - Captures each test's pgagroal log window into `/tmp/pgagroal-test/log/<module>__<test>.pgagroal.log`
+- **Automatic ERROR gate** - A test that otherwise passes is marked failed if its log slice contains ` ERROR ` lines
 - **Cleanup pattern** - Structured cleanup using goto labels for resource management
 - **Error tracking** - Automatic error tracking with line numbers and custom error messages
 - **Multiple assertion types** - Various assertion macros ('MCTF_ASSERT', 'MCTF_ASSERT_PTR_NONNULL', 'MCTF_ASSERT_INT_EQ', 'MCTF_ASSERT_STR_EQ', etc.)

--- a/doc/manual/en/78-test.md
+++ b/doc/manual/en/78-test.md
@@ -64,6 +64,8 @@ MCTF (Minimal C Test Framework) is pgagroal's custom test framework designed for
 - **Flexible assertions** - Assert macros with optional printf-style error messages
 - **Test filtering** - Run tests by name pattern ('-t') or by module ('-m')
 - **Test skipping** - Skip tests conditionally using 'MCTF_SKIP()' when prerequisites aren't met
+- **Per-test pgagroal log slicing** - Captures each test's pgagroal log window into `/tmp/pgagroal-test/log/<module>__<test>.pgagroal.log`
+- **Automatic ERROR gate** - A test that otherwise passes is marked failed if its log slice contains ` ERROR ` lines
 - **Cleanup pattern** - Structured cleanup using goto labels for resource management
 - **Error tracking** - Automatic error tracking with line numbers and custom error messages
 - **Multiple assertion types** - Various assertion macros ('MCTF_ASSERT', 'MCTF_ASSERT_PTR_NONNULL', 'MCTF_ASSERT_INT_EQ', 'MCTF_ASSERT_STR_EQ', etc.)

--- a/test/include/mctf.h
+++ b/test/include/mctf.h
@@ -78,6 +78,9 @@ typedef struct mctf_result
    int error_code;        /**< Error code associated with a failure or skip. */
    char* error_message;   /**< Dynamically allocated, human readable error message. */
    long elapsed_ms;       /**< Execution time of the test in milliseconds. */
+   long log_offset_start; /**< Start offset in pgagroal log for this test, or -1 if unavailable. */
+   long log_offset_end;   /**< End offset in pgagroal log for this test, or -1 if unavailable. */
+   bool has_error_log;    /**< True if an ERROR-level line was observed in this test log slice. */
 } mctf_result_t;
 
 /**
@@ -141,6 +144,10 @@ mctf_log_environment(void);
 /* Get test results */
 const mctf_result_t*
 mctf_get_results(size_t* count);
+
+/* Return true if a result contains ERROR-level log output. */
+bool
+mctf_result_has_error_log(size_t result_index);
 
 /* Internal helper: format error message */
 char*

--- a/test/include/mctf_logslice.h
+++ b/test/include/mctf_logslice.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 The pgagroal community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGAGROAL_MCTF_LOGSLICE_H
+#define PGAGROAL_MCTF_LOGSLICE_H
+
+#include <stdbool.h>
+#include <sys/types.h>
+
+void
+mctf_capture_log_boundary(off_t* out_size);
+
+void
+mctf_analyze_and_write_test_log_slice(const char* module,
+                                      const char* test_name,
+                                      off_t start_offset,
+                                      off_t end_offset,
+                                      bool* out_has_error,
+                                      char** out_error_summary);
+
+#endif

--- a/test/libpgagroaltest/mctf.c
+++ b/test/libpgagroaltest/mctf.c
@@ -27,6 +27,7 @@
  */
 
 #include <mctf.h>
+#include <mctf_logslice.h>
 
 #include <errno.h>
 #include <stdarg.h>
@@ -432,6 +433,15 @@ mctf_run_tests(mctf_filter_type_t filter_type, const char* filter)
       result->skipped = false;
       result->error_code = 0;
       result->error_message = NULL;
+      result->log_offset_start = -1;
+      result->log_offset_end = -1;
+      result->has_error_log = false;
+
+      {
+         off_t log_start = -1;
+         mctf_capture_log_boundary(&log_start);
+         result->log_offset_start = (long)log_start;
+      }
 
       struct timespec start_time, end_time;
       clock_gettime(CLOCK_MONOTONIC, &start_time);
@@ -443,6 +453,12 @@ mctf_run_tests(mctf_filter_type_t filter_type, const char* filter)
          mctf_errmsg = NULL;
       }
       int ret = test->func();
+
+      {
+         off_t log_end = -1;
+         mctf_capture_log_boundary(&log_end);
+         result->log_offset_end = (long)log_end;
+      }
 
       clock_gettime(CLOCK_MONOTONIC, &end_time);
 
@@ -480,10 +496,37 @@ mctf_run_tests(mctf_filter_type_t filter_type, const char* filter)
       }
       else if (ret == 0 && mctf_errno == 0)
       {
-         result->passed = true;
-         g_runner.passed_count++;
-         mctf_logf("%s (%02ld:%02ld:%02ld,%03ld) [PASS]\n",
-                   test->name, hours, minutes, seconds, milliseconds);
+         bool has_log_errors = false;
+         char* log_error_summary = NULL;
+
+         mctf_analyze_and_write_test_log_slice(test->module,
+                                               test->name,
+                                               result->log_offset_start,
+                                               result->log_offset_end,
+                                               &has_log_errors,
+                                               &log_error_summary);
+         result->has_error_log = has_log_errors;
+
+         if (has_log_errors)
+         {
+            result->passed = false;
+            result->error_code = 0;
+            result->error_message = log_error_summary != NULL ? log_error_summary : strdup("Unexpected ERROR lines in pgagroal.log");
+            g_runner.failed_count++;
+            mctf_logf("  %s (%02ld:%02ld:%02ld,%03ld) [FAIL]\n",
+                      test->name, hours, minutes, seconds, milliseconds);
+         }
+         else
+         {
+            if (log_error_summary != NULL)
+            {
+               free(log_error_summary);
+            }
+            result->passed = true;
+            g_runner.passed_count++;
+            mctf_logf("%s (%02ld:%02ld:%02ld,%03ld) [PASS]\n",
+                      test->name, hours, minutes, seconds, milliseconds);
+         }
       }
       else
       {
@@ -586,4 +629,15 @@ mctf_get_results(size_t* count)
       *count = g_runner.result_count;
    }
    return g_runner.results;
+}
+
+bool
+mctf_result_has_error_log(size_t result_index)
+{
+   if (result_index >= g_runner.result_count)
+   {
+      return false;
+   }
+
+   return g_runner.results[result_index].has_error_log;
 }

--- a/test/libpgagroaltest/mctf_logslice.c
+++ b/test/libpgagroaltest/mctf_logslice.c
@@ -1,0 +1,321 @@
+/*
+ * Copyright (C) 2026 The pgagroal community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <mctf_logslice.h>
+
+#include <pgagroal.h>
+#include <shmem.h>
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+#define MCTF_MAX_PATH 1024
+
+static int
+mctf_get_pgagroal_log_path(char* path, size_t size)
+{
+   struct main_configuration* config = (struct main_configuration*)shmem;
+   int n = 0;
+
+   if (path == NULL || size == 0)
+   {
+      return 1;
+   }
+
+   if (config != NULL && config->common.log_path[0] != '\0')
+   {
+      n = snprintf(path, size, "%s", config->common.log_path);
+   }
+   else
+   {
+      n = snprintf(path, size, "/tmp/pgagroal-test/log/pgagroal.log");
+   }
+
+   if (n <= 0 || (size_t)n >= size)
+   {
+      return 1;
+   }
+
+   return 0;
+}
+
+static int
+mctf_get_log_size(off_t* out_size)
+{
+   char log_path[MCTF_MAX_PATH];
+   struct stat st;
+
+   if (out_size == NULL)
+   {
+      return 1;
+   }
+
+   if (mctf_get_pgagroal_log_path(log_path, sizeof(log_path)) != 0)
+   {
+      return 1;
+   }
+
+   if (stat(log_path, &st) != 0)
+   {
+      return 1;
+   }
+
+   *out_size = st.st_size;
+   return 0;
+}
+
+static long
+mctf_monotonic_ms(void)
+{
+   struct timespec ts;
+
+   if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
+   {
+      return 0;
+   }
+
+   return (long)(ts.tv_sec * 1000L + ts.tv_nsec / 1000000L);
+}
+
+static bool
+mctf_is_expected_error_line(const char* test_name, const char* line)
+{
+   if (test_name == NULL || line == NULL)
+   {
+      return false;
+   }
+
+   if (strcmp(test_name, "test_aes_buffer_tamper_fails") == 0 &&
+       strstr(line, "EVP_CipherFinal_ex: Failed to finalize operation") != NULL)
+   {
+      return true;
+   }
+
+   return false;
+}
+
+void
+mctf_capture_log_boundary(off_t* out_size)
+{
+   const long stable_ms = 300;
+   const long timeout_ms = 5000;
+   const long poll_ms = 25;
+   long started_at = 0;
+   long stable_since = 0;
+   off_t last_size = 0;
+   off_t current_size = 0;
+
+   if (out_size == NULL)
+   {
+      return;
+   }
+
+   if (mctf_get_log_size(&last_size) != 0)
+   {
+      *out_size = -1;
+      return;
+   }
+
+   started_at = mctf_monotonic_ms();
+   stable_since = started_at;
+
+   while (mctf_monotonic_ms() - started_at <= timeout_ms)
+   {
+      if (mctf_get_log_size(&current_size) != 0)
+      {
+         *out_size = -1;
+         return;
+      }
+
+      if (current_size != last_size)
+      {
+         last_size = current_size;
+         stable_since = mctf_monotonic_ms();
+      }
+      else if (mctf_monotonic_ms() - stable_since >= stable_ms)
+      {
+         *out_size = current_size;
+         return;
+      }
+
+      usleep((useconds_t)(poll_ms * 1000));
+   }
+
+   *out_size = last_size;
+}
+
+void
+mctf_analyze_and_write_test_log_slice(const char* module,
+                                      const char* test_name,
+                                      off_t start_offset,
+                                      off_t end_offset,
+                                      bool* out_has_error,
+                                      char** out_error_summary)
+{
+   char log_path[MCTF_MAX_PATH];
+   char slice_path[MCTF_MAX_PATH];
+   char log_dir[MCTF_MAX_PATH];
+   struct stat st;
+   FILE* src = NULL;
+   FILE* dst = NULL;
+   char line[4096];
+   char summary[1536];
+   size_t used = 0;
+   bool has_error = false;
+   char* slash = NULL;
+
+   if (out_has_error != NULL)
+   {
+      *out_has_error = false;
+   }
+   if (out_error_summary != NULL)
+   {
+      *out_error_summary = NULL;
+   }
+
+   if (module == NULL || test_name == NULL || start_offset < 0)
+   {
+      return;
+   }
+
+   if (mctf_get_pgagroal_log_path(log_path, sizeof(log_path)) != 0)
+   {
+      return;
+   }
+
+   if (stat(log_path, &st) != 0)
+   {
+      return;
+   }
+
+   if (end_offset <= 0 || end_offset > st.st_size)
+   {
+      end_offset = st.st_size;
+   }
+
+   if (start_offset >= end_offset)
+   {
+      return;
+   }
+
+   memset(log_dir, 0, sizeof(log_dir));
+   strncpy(log_dir, log_path, sizeof(log_dir) - 1);
+   slash = strrchr(log_dir, '/');
+   if (slash == NULL)
+   {
+      return;
+   }
+   *slash = '\0';
+
+   if (snprintf(slice_path, sizeof(slice_path), "%s/%s__%s.pgagroal.log", log_dir, module, test_name) <= 0)
+   {
+      return;
+   }
+
+   src = fopen(log_path, "r");
+   if (src == NULL)
+   {
+      return;
+   }
+
+   if (fseeko(src, start_offset, SEEK_SET) != 0)
+   {
+      fclose(src);
+      return;
+   }
+
+   dst = fopen(slice_path, "w");
+   if (dst == NULL)
+   {
+      fclose(src);
+      return;
+   }
+
+   summary[0] = '\0';
+
+   while (true)
+   {
+      off_t pos = ftello(src);
+
+      if (pos < 0 || pos >= end_offset)
+      {
+         break;
+      }
+
+      if (fgets(line, sizeof(line), src) == NULL)
+      {
+         break;
+      }
+
+      pos = ftello(src);
+      if (pos > end_offset)
+      {
+         break;
+      }
+
+      fputs(line, dst);
+
+      if (strstr(line, " ERROR ") != NULL && !mctf_is_expected_error_line(test_name, line))
+      {
+         has_error = true;
+         if (out_error_summary != NULL)
+         {
+            int n = snprintf(summary + used, sizeof(summary) - used, "      %s", line);
+            if (n > 0 && (size_t)n < (sizeof(summary) - used))
+            {
+               used += (size_t)n;
+            }
+         }
+      }
+   }
+
+   fclose(src);
+   fclose(dst);
+
+   if (out_has_error != NULL)
+   {
+      *out_has_error = has_error;
+   }
+
+   if (out_error_summary != NULL && has_error)
+   {
+      const char* header = "Unexpected ERROR lines in pgagroal.log:\n";
+      size_t total = strlen(header) + strlen(summary) + 1;
+
+      *out_error_summary = calloc(total, sizeof(char));
+      if (*out_error_summary != NULL)
+      {
+         snprintf(*out_error_summary, total, "%s%s", header, summary);
+      }
+   }
+}


### PR DESCRIPTION
Closes #792

## Why
MCTF currently runs all tests against a shared pgagroal log without per-test boundaries, so ERROR lines can be missed or attributed to the wrong test.

## What changed
- Added log-slice metadata to `mctf_result_t`:
  - `log_offset_start`
  - `log_offset_end`
  - `has_error_log`
- Added `mctf_logslice` helper (`test/libpgagroaltest/mctf_logslice.c`) to:
  - capture stable log boundaries before and after each test
  - extract the test slice from pgagroal log
  - write per-test slices to `/tmp/pgagroal-test/log/<module>__<test>.pgagroal.log`
  - detect ` ERROR ` lines in that slice
- Integrated slice capture/analyze into `mctf_run_tests()`.
- Added automatic ERROR gate for passing tests: if test assertions pass but slice contains ` ERROR `, mark test as failed with a log-based summary.
- Added `mctf_result_has_error_log()` accessor.
- Updated test docs in `doc/TEST.md` and `doc/manual/en/78-test.md`.
