### PR TITLE
Fix incorrect documentation entries

### DIFF
--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -189,7 +189,7 @@ pgagroal-cli -c pgagroal.conf flush idle
 To stop pgagroal you would use
 
 ```
-pgagroal-cli -c pgagroal.conf stop
+pgagroal-cli -c pgagroal.conf shutdown
 ```
 
 Check the outcome of the operations by verifying the exit code, like

--- a/doc/man/pgagroal.conf.5.rst
+++ b/doc/man/pgagroal.conf.5.rst
@@ -128,7 +128,7 @@ max_retries
   The maximum number of iterations to obtain a connection. Default is 5
 
 max_connections
-  The maximum number of connections (max 1000). Default is 1000
+  The maximum number of connections (max 10000). Default is 100
 
 allow_unknown_users
   Allow unknown users to connect. Default is true

--- a/doc/manual/en/04-configuration.md
+++ b/doc/manual/en/04-configuration.md
@@ -63,7 +63,7 @@ The available keys and their accepted values are reported in the table below.
 | metrics_cert_file | | String | No | Certificate file for TLS for Prometheus metrics. This file must be owned by either the user running pgagroal or root. |
 | metrics_key_file | | String | No | Private key file for TLS for Prometheus metrics. This file must be owned by either the user running pgagroal or root. Additionally permissions must be at least `0640` when owned by root or `0600` otherwise. |
 | metrics_ca_file | | String | No | Certificate Authority (CA) file for TLS for Prometheus metrics. This file must be owned by either the user running pgagroal or root.  |
-| libev | `auto` | String | No | Select the [libev](http://software.schmorp.de/pkg/libev.html) backend to use. Valid options: `auto`, `select`, `poll`, `epoll`, `iouring`, `devpoll` and `port` |
+| ev_backend | `auto` | String | No | Select the event backend to use. Valid options: `auto`, `io_uring`, `epoll` and `kqueue` |
 | keep_alive | on | Bool | No | Have `SO_KEEPALIVE` on sockets |
 | nodelay | on | Bool | No | Have `TCP_NODELAY` on sockets |
 | backlog | `max_connections` / 4 | Int | No | The backlog for `listen()`. Minimum `16` |

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -41,6 +41,7 @@ Abdelrhman Sersawy <abdelrhmansersawy@gmail.com>
 Zeyad Daowd <zeyaddaowd@yahoo.com>
 Somye Mahajan <mahajan.somye@gmail.com>
 Bhawesh Panwar <panwarbhawesh1112@gmail.com>
+Frank Heikens <frank@elevarq.com>
 ```
 
 ## Committers


### PR DESCRIPTION
This fixes three factual documentation issues:

- correct `max_connections` default and max value in the man page
- replace non-existent `stop` CLI command with `shutdown` in getting started docs
- replace obsolete `libev` parameter with `ev_backend` in the manual

All changes were verified against the current codebase.