### PR TITLE
[#804] Add tests for server-section parameter routing

### DIFF
--- a/test/testcases/test_configuration.c
+++ b/test/testcases/test_configuration.c
@@ -499,3 +499,37 @@ MCTF_TEST(test_configuration_reject_invalid_int)
 
    MCTF_FINISH();
 }
+
+MCTF_TEST(test_configuration_server_section_keys)
+{
+   struct main_configuration config;
+   struct server srv;
+   int ret;
+
+   // primary accepted in server section
+   memset(&config, 0, sizeof(struct main_configuration));
+   memset(&srv, 0, sizeof(struct server));
+   ret = pgagroal_apply_main_configuration(&config, &srv, "myserver", CONFIGURATION_ARGUMENT_PRIMARY, "on");
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "primary=on should be accepted in server section");
+
+   // port accepted in server section
+   memset(&config, 0, sizeof(struct main_configuration));
+   memset(&srv, 0, sizeof(struct server));
+   ret = pgagroal_apply_main_configuration(&config, &srv, "myserver", CONFIGURATION_ARGUMENT_PORT, "5432");
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "port=5432 should be accepted in server section");
+
+   // invalid port rejected in server section
+   memset(&config, 0, sizeof(struct main_configuration));
+   memset(&srv, 0, sizeof(struct server));
+   ret = pgagroal_apply_main_configuration(&config, &srv, "myserver", CONFIGURATION_ARGUMENT_PORT, "abc");
+   MCTF_ASSERT_INT_EQ(ret, 1, cleanup, "port=abc should be rejected in server section");
+
+   // invalid primary rejected in server section
+   memset(&config, 0, sizeof(struct main_configuration));
+   memset(&srv, 0, sizeof(struct server));
+   ret = pgagroal_apply_main_configuration(&config, &srv, "myserver", CONFIGURATION_ARGUMENT_PRIMARY, "maybe");
+   MCTF_ASSERT_INT_EQ(ret, 1, cleanup, "primary=maybe should be rejected in server section");
+
+cleanup:
+   MCTF_FINISH();
+}


### PR DESCRIPTION
## Summary

Adds tests for configuration parameter parsing in server sections,
extending existing coverage which only covered the main `[pgagroal]`
section.

## Covered cases

- `primary=on` accepted in a server section
- `port=5432` accepted in a server section
- `port=abc` rejected in a server section (invalid integer)
- `primary=maybe` rejected in a server section (invalid boolean)

These tests call `pgagroal_apply_main_configuration` directly with a
server section name and a `struct server`, verifying that server-specific
keys are routed and validated correctly.

## Test plan
- [x] Configuration module tests pass (28/28)
- [x] No production code modified

Closes #804