### PR TITLE
[#710] Detect duplicated and inconsistent servers

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -93,7 +93,8 @@ The available keys and their accepted values are reported in the table below.
 | health_check | `off` | Bool | No | Enables or disables periodic health checks. If enabled, pgagroal will periodically check the health of the servers. |
 | health_check_period | 30 | Int | No | The interval in seconds between health check scans. |
 | health_check_timeout | 5 | String | No | The amount of time the process will wait for a response during a health check. If this value is specified without units, it is taken as seconds. It supports the following units as suffixes: 'S' for seconds (default), 'M' for minutes, 'H' for hours, 'D' for days, and 'W' for weeks. |
-| health_check_user | | String | Yes (if health_check=on) | The user used for connecting to the health check. This user will also be used as the database name. |
+| health_check_user | | String | Yes (if health_check=on) | The user used for connecting to the health check. This user will also be used as the database name. This credential is also used at startup for the `startup_validation` check. It is best practice to configure `health_check_user` on all servers, even if `health_check` is disabled, so that startup validation can verify server identifiers. |
+| startup_validation | `try` | String | No | Controls startup validation of server system identifiers. `on`: fail startup if identifiers cannot be fetched or if duplicates are detected (requires `health_check_user`). `try`: attempt the check if `health_check_user` is set, otherwise log an INFO message and continue. `off`: skip identifier checks entirely. |
 
 
 __Danger zone__

--- a/doc/manual/en/04-configuration.md
+++ b/doc/manual/en/04-configuration.md
@@ -75,7 +75,8 @@ The available keys and their accepted values are reported in the table below.
 | health_check | `off` | Bool | No | Enables or disables periodic health checks. If enabled, pgagroal will periodically check the health of the servers. |
 | health_check_period | 30 | Int | No | The interval in seconds between health check scans. |
 | health_check_timeout | 5 | String | No | The amount of time the process will wait for a response during a health check. If this value is specified without units, it is taken as seconds. It supports the following units as suffixes: 'S' for seconds (default), 'M' for minutes, 'H' for hours, 'D' for days, and 'W' for weeks. |
-| health_check_user | | String | Yes (if health_check=on) | The user used for connecting to the health check. This user will also be used as the database name. Typically a superuser. See [Health Check](./19-health_check.md) for setup details and security considerations. |
+| health_check_user | | String | Yes (if health_check=on) | The user used for connecting to the health check. This user will also be used as the database name. This credential is also used at startup for the `startup_validation` check. It is best practice to configure `health_check_user` on all servers, even if `health_check` is disabled, so that startup validation can verify server identifiers. See [Health Check](./19-health_check.md) for setup details and security considerations. |
+| startup_validation | `try` | String | No | Controls startup validation of server system identifiers. `on`: fail startup if identifiers cannot be fetched or if duplicates are detected (requires `health_check_user`). `try`: attempt the check if `health_check_user` is set, otherwise log an INFO message and continue. `off`: skip identifier checks entirely. |
 
 
 __Danger zone__

--- a/doc/manual/en/19-health_check.md
+++ b/doc/manual/en/19-health_check.md
@@ -72,6 +72,25 @@ To set up a dedicated health check user:
    ```
    *Note: Ensure the backend [PostgreSQL][postgresql] `pg_hba.conf` also allows this connection.*
 
+## Best Practices
+
+* **Always configure `health_check_user`**: It is best practice to set `health_check_user` on all configured servers, even when `health_check` is disabled. This allows pgagroal to verify server system identifiers at startup and detect misconfigured duplicate servers before they cause problems.
+
+* **Use `startup_validation`**: The `startup_validation` parameter controls how strictly pgagroal validates server identifiers at startup:
+
+  | Value | Behavior |
+  |-------|----------|
+  | `on`  | Fail startup if `health_check_user` is not configured, if any server identifier cannot be fetched, or if duplicate identifiers are detected. Recommended for production. |
+  | `try` | (Default) Attempt the check if `health_check_user` is set. If not set, log an INFO message and continue. If a query fails, log a warning but continue. Duplicates still cause a fatal error. |
+  | `off` | Skip identifier checks entirely. |
+
+  Example configuration for strict startup validation:
+  ```ini
+  [pgagroal]
+  health_check_user = pgagroal_health
+  startup_validation = on
+  ```
+
 ## Monitoring
 
 The health status of each server is exposed via the Prometheus metrics endpoint (`pgagroal_server_health`).

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -99,6 +99,7 @@ extern "C" {
 #define CONFIGURATION_ARGUMENT_ROTATE_FRONTEND_PASSWORD_LENGTH  "rotate_frontend_password_length"
 #define CONFIGURATION_ARGUMENT_MAX_CONNECTION_AGE               "max_connection_age"
 #define CONFIGURATION_ARGUMENT_VALIDATION                       "validation"
+#define CONFIGURATION_ARGUMENT_STARTUP_VALIDATION               "startup_validation"
 #define CONFIGURATION_ARGUMENT_BACKGROUND_INTERVAL              "background_interval"
 #define CONFIGURATION_ARGUMENT_MAX_RETRIES                      "max_retries"
 #define CONFIGURATION_ARGUMENT_MAX_CONNECTIONS                  "max_connections"

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -169,6 +169,10 @@ extern "C" {
 #define HUGEPAGE_TRY                   1
 #define HUGEPAGE_ON                    2
 
+#define STARTUP_VALIDATION_OFF         0
+#define STARTUP_VALIDATION_TRY         1
+#define STARTUP_VALIDATION_ON          2
+
 #define TLS_CERT_AUTH_MODE_VERIFY_CA   0
 #define TLS_CERT_AUTH_MODE_VERIFY_FULL 1
 
@@ -712,6 +716,7 @@ struct main_configuration
    pgagroal_time_t health_check_timeout;             /**< The duration of health check timeout (Default seconds) */
    char health_check_user[MAX_USERNAME_LENGTH];      /**< The health check user */
    pid_t health_check_pid;                           /**< The health check PID */
+   int startup_validation;                           /**< Startup server identifier validation mode */
    int disconnect_client;                            /**< Disconnect client if idle for more than the specified seconds */
    bool disconnect_client_force;                     /**< Force a disconnect client if active for more than the specified seconds */
    char pidfile[MAX_PATH];                           /**< File containing the PID */

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -95,6 +95,26 @@ pgagroal_server_clear(char* server);
 int
 pgagroal_server_switch(char* server);
 
+/**
+ * Check server system identifiers for duplicates
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgagroal_check_server_identifiers(void);
+
+/**
+ * Connect to a server, authenticate, and execute a simple query
+ * @param server_idx The server index
+ * @param user The username for the connection
+ * @param database The database name for the connection
+ * @param query The SQL query string
+ * @param auth_type The authentication type used, can be NULL
+ * @param fd_out The resulting file descriptor for reading the response
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgagroal_server_query_execute(int server_idx, char* user, char* database, char* query, int* auth_type, int* fd_out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -51,6 +51,8 @@
 #include <string.h>
 #include <strings.h>
 #include <unistd.h>
+#include <netdb.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <err.h>
@@ -73,6 +75,7 @@ static int as_logging_rotation_size(char* str, unsigned int* size);
 static int as_validation(char* str, int* val);
 static int as_pipeline(char* str, int* pipeline);
 static int as_hugepage(char* str, unsigned char* hp);
+static int as_startup_validation(char* str, int* sv);
 static unsigned int as_update_process_title(char* str, unsigned int* policy, unsigned int default_policy);
 static int extract_value(char* str, int offset, char** value);
 static void extract_hba(char* str, char** type, char** database, char** user, char** address, char** method);
@@ -116,6 +119,7 @@ static int to_bool(char* where, bool value);
 static int to_int(char* where, int value);
 static int to_update_process_title(char* where, int value);
 static int to_validation(char* where, int value);
+static int to_startup_validation(char* where, int value);
 static int to_hugepage(char* where, int value);
 static int to_pipeline(char* where, int value);
 static int to_log_mode(char* where, int value);
@@ -171,6 +175,7 @@ pgagroal_init_configuration(void* shm)
    config->health_check_timeout = PGAGROAL_TIME_SEC(DEFAULT_HEALTH_CHECK_TIMEOUT);
    pgagroal_snprintf(config->health_check_user, MAX_USERNAME_LENGTH, "");
    config->health_check_pid = 0;
+   config->startup_validation = STARTUP_VALIDATION_TRY;
    config->common.authentication_timeout = PGAGROAL_TIME_SEC(DEFAULT_AUTHENTICATION_TIMEOUT);
    config->disconnect_client = 0;
    config->disconnect_client_force = false;
@@ -681,6 +686,25 @@ pgagroal_validate_configuration(void* shm, bool has_unix_socket, bool has_main_s
                                config->servers[j].lineno);
             return 1;
          }
+      }
+   }
+
+   // check for multiple primary servers
+   {
+      int primary_count = 0;
+      for (int i = 0; i < config->number_of_servers; i++)
+      {
+         if (atomic_load(&config->servers[i].state) == SERVER_NOTINIT_PRIMARY)
+         {
+            primary_count++;
+         }
+      }
+
+      if (primary_count > 1)
+      {
+         pgagroal_log_fatal("pgagroal: Multiple primary servers defined (%d). Only one primary is allowed",
+                            primary_count);
+         return 1;
       }
    }
 
@@ -2986,6 +3010,30 @@ as_hugepage(char* str, unsigned char* hp)
    return 1;
 }
 
+static int
+as_startup_validation(char* str, int* sv)
+{
+   if (!strcasecmp(str, "off"))
+   {
+      *sv = STARTUP_VALIDATION_OFF;
+      return 0;
+   }
+
+   if (!strcasecmp(str, "try"))
+   {
+      *sv = STARTUP_VALIDATION_TRY;
+      return 0;
+   }
+
+   if (!strcasecmp(str, "on"))
+   {
+      *sv = STARTUP_VALIDATION_ON;
+      return 0;
+   }
+
+   return 1;
+}
+
 static void
 extract_hba(char* str, char** type, char** database, char** user, char** address, char** method)
 {
@@ -3675,6 +3723,8 @@ transfer_configuration(struct main_configuration* config, struct main_configurat
 
    memcpy(config->health_check_user, reload->health_check_user, MAX_USERNAME_LENGTH);
 
+   config->startup_validation = reload->startup_validation;
+
    /* pidfile */
    if (restart_string("pidfile", config->pidfile, reload->pidfile, true))
    {
@@ -3812,26 +3862,74 @@ transfer_configuration(struct main_configuration* config, struct main_configurat
 }
 
 /**
- * Checks if the configuration of the first server
- * is the same as the configuration of the second server.
- * So far it tests for the same connection string, meaning
- * that the hostname and the port must be the same (i.e.,
- * pointing to the same endpoint).
- * It does not resolve the hostname, therefore 'localhost' and '127.0.0.1'
- * are considered as different hosts.
- * @return true if the server configurations look the same
+ * Checks if two servers point to the same endpoint.
+ * Resolves hostnames via getaddrinfo() to detect duplicates
+ * like 'localhost' vs '127.0.0.1' pointing to the same server
+ * @return true if the server configurations are same
  */
 static bool
 is_same_server(struct server* s1, struct server* s2)
 {
-   if (!strncmp(s1->host, s2->host, MISC_LENGTH) && s1->port == s2->port)
-   {
-      return true;
-   }
-   else
+   struct addrinfo hints;
+   struct addrinfo* res1 = NULL;
+   struct addrinfo* res2 = NULL;
+   struct addrinfo* p1;
+   struct addrinfo* p2;
+   char port1[6];
+   char port2[6];
+   bool same = false;
+
+   if (s1->port != s2->port)
    {
       return false;
    }
+
+   /* Quick string check first */
+   if (!strncmp(s1->host, s2->host, MISC_LENGTH))
+   {
+      return true;
+   }
+
+   /* Resolve via getaddrinfo */
+   memset(&hints, 0, sizeof(hints));
+   hints.ai_family = AF_UNSPEC;
+   hints.ai_socktype = SOCK_STREAM;
+
+   snprintf(port1, sizeof(port1), "%d", s1->port);
+   snprintf(port2, sizeof(port2), "%d", s2->port);
+
+   if (getaddrinfo(s1->host, port1, &hints, &res1) != 0 ||
+       getaddrinfo(s2->host, port2, &hints, &res2) != 0)
+   {
+      goto cleanup;
+   }
+
+   /* Compare all resolved addresses */
+   for (p1 = res1; p1 != NULL && !same; p1 = p1->ai_next)
+   {
+      for (p2 = res2; p2 != NULL && !same; p2 = p2->ai_next)
+      {
+         if (p1->ai_addrlen == p2->ai_addrlen &&
+             memcmp(p1->ai_addr, p2->ai_addr, p1->ai_addrlen) == 0)
+         {
+            same = true;
+         }
+      }
+   }
+
+cleanup:
+
+   if (res1 != NULL)
+   {
+      freeaddrinfo(res1);
+   }
+
+   if (res2 != NULL)
+   {
+      freeaddrinfo(res2);
+   }
+
+   return same;
 }
 
 /**
@@ -4798,6 +4896,10 @@ pgagroal_write_config_value(char* buffer, char* config_key, size_t buffer_size)
       {
          return to_validation(buffer, config->validation);
       }
+      else if (!strncmp(key, "startup_validation", MISC_LENGTH))
+      {
+         return to_startup_validation(buffer, config->startup_validation);
+      }
       else if (!strncmp(key, "update_process_title", MISC_LENGTH))
       {
          return to_update_process_title(buffer, config->update_process_title);
@@ -5281,6 +5383,39 @@ to_validation(char* where, int value)
 
    return 0;
 }
+
+/**
+ * An utility function to convert the enumeration of values for the startup_validation setting
+ * into one of its possible string descriptions.
+ *
+ * @param where the buffer used to store the stringy thing
+ * @param value the config->startup_validation setting
+ * @return 0 on success, 1 otherwise
+ */
+static int
+to_startup_validation(char* where, int value)
+{
+   if (!where || value < 0)
+   {
+      return 1;
+   }
+
+   switch (value)
+   {
+      case STARTUP_VALIDATION_OFF:
+         snprintf(where, MISC_LENGTH, "%s", "off");
+         break;
+      case STARTUP_VALIDATION_TRY:
+         snprintf(where, MISC_LENGTH, "%s", "try");
+         break;
+      case STARTUP_VALIDATION_ON:
+         snprintf(where, MISC_LENGTH, "%s", "on");
+         break;
+   }
+
+   return 0;
+}
+
 /**
  * An utility function to convert the enumeration of values for the hugepage setting
  * into one of its possible string descriptions.
@@ -5843,6 +5978,13 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
       }
       memset(config->health_check_user, 0, MAX_USERNAME_LENGTH);
       memcpy(config->health_check_user, value, max);
+   }
+   else if (key_in_section("startup_validation", section, key, true, &unknown))
+   {
+      if (as_startup_validation(value, &config->startup_validation))
+      {
+         unknown = true;
+      }
    }
    else if (key_in_section("authentication_timeout", section, key, true, &unknown))
    {
@@ -6592,9 +6734,10 @@ add_configuration_response(struct json* res)
    pgagroal_json_put_time_value(res, CONFIGURATION_ARGUMENT_IDLE_TIMEOUT, config->idle_timeout, FORMAT_TIME_S);
    pgagroal_json_put_time_value(res, CONFIGURATION_ARGUMENT_ROTATE_FRONTEND_PASSWORD_TIMEOUT, config->rotate_frontend_password_timeout, FORMAT_TIME_S);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_ROTATE_FRONTEND_PASSWORD_LENGTH, (uintptr_t)config->rotate_frontend_password_length, ValueInt64);
-   pgagroal_json_put_time_value(res, CONFIGURATION_ARGUMENT_MAX_CONNECTION_AGE, config->max_connection_age, FORMAT_TIME_S);
-   pgagroal_json_put_enum_value(res, CONFIGURATION_ARGUMENT_VALIDATION, config->validation, to_validation);
-   pgagroal_json_put_time_value(res, CONFIGURATION_ARGUMENT_BACKGROUND_INTERVAL, config->background_interval, FORMAT_TIME_S);
+   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_MAX_CONNECTION_AGE, (uintptr_t)pgagroal_time_convert(config->max_connection_age, FORMAT_TIME_S), ValueInt64);
+   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_VALIDATION, (uintptr_t)config->validation, ValueInt64);
+   pgagroal_json_put_enum_value(res, CONFIGURATION_ARGUMENT_STARTUP_VALIDATION, config->startup_validation, to_startup_validation);
+   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_BACKGROUND_INTERVAL, (uintptr_t)pgagroal_time_convert(config->background_interval, FORMAT_TIME_S), ValueInt64);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_MAX_RETRIES, (uintptr_t)config->max_retries, ValueInt64);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_MAX_CONNECTIONS, (uintptr_t)config->max_connections, ValueInt64);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_ALLOW_UNKNOWN_USERS, (uintptr_t)config->allow_unknown_users, ValueBool);

--- a/src/libpgagroal/health.c
+++ b/src/libpgagroal/health.c
@@ -31,19 +31,16 @@
 #include <health.h>
 #include <logging.h>
 #include <network.h>
+#include <server.h>
 #include <shmem.h>
 #include <utils.h>
 #include <message.h>
-#include <security.h>
 
 /* system */
 #include <stdlib.h>
 #include <unistd.h>
 #include <signal.h>
 #include <stdatomic.h>
-#include <arpa/inet.h>
-#include <string.h>
-#include <errno.h>
 #include <sys/wait.h>
 
 static void health_check_loop(void);
@@ -208,188 +205,33 @@ health_check_loop(void)
    pgagroal_log_info("Health check stopped");
 }
 
-/**
- * Probes a single server
- */
 static int
 server_probe(int server_idx, bool* up, int* auth_type)
 {
    struct main_configuration* config;
-   struct server* server;
    int fd = -1;
-   char buffer[1024];
-   int offset = 0;
    struct message* msg = NULL;
    int status;
-   size_t start_packet_size;
-   char* password = NULL;
-   char* query_string = "SELECT 1";
-   int query_len;
-   int msg_size;
    bool query_success = false;
-   int auth_type_msg;
-   bool ready = false;
-   int offset_p;
-   char kind;
-   int len;
    bool query_ready = false;
    int offset_q;
    char type_q;
    int len_q;
+   char buffer[8];
 
    config = (struct main_configuration*)shmem;
-   server = &config->servers[server_idx];
 
    *up = false;
    *auth_type = HEALTH_CHECK_AUTH_UNKNOWN;
 
-   pgagroal_log_debug("Health: Probing server %d (%s:%d) as user %s", server_idx, server->host, server->port, config->health_check_user);
+   pgagroal_log_debug("Health: Probing server %d (%s:%d) as user %s",
+                      server_idx, config->servers[server_idx].host,
+                      config->servers[server_idx].port, config->health_check_user);
 
-   if (pgagroal_connect(server->host, server->port, &fd, true, false) != 0)
+   if (pgagroal_server_query_execute(server_idx, config->health_check_user, config->health_check_user, "SELECT 1", auth_type, &fd) != 0)
    {
       pgagroal_log_debug("Health: Failed to connect to server %d", server_idx);
       return 1;
-   }
-
-   /* Construct Startup Packet */
-   start_packet_size = 4 + 4 + 5 + strlen(config->health_check_user) + 1 + 9 + strlen(config->health_check_user) + 1 + 1;
-
-   memset(buffer, 0, sizeof(buffer));
-   pgagroal_write_int32(buffer, start_packet_size);
-   pgagroal_write_int32(buffer + 4, 196608); /* Protocol 3.0 */
-
-   offset = 8;
-   pgagroal_snprintf(buffer + offset, sizeof(buffer) - offset, "user");
-   offset += 5;
-   pgagroal_snprintf(buffer + offset, sizeof(buffer) - offset, "%s", config->health_check_user);
-   offset += strlen(config->health_check_user) + 1;
-
-   pgagroal_snprintf(buffer + offset, sizeof(buffer) - offset, "database");
-   offset += 9;
-   pgagroal_snprintf(buffer + offset, sizeof(buffer) - offset, "%s", config->health_check_user);
-   offset += strlen(config->health_check_user) + 1;
-
-   buffer[offset++] = 0;
-
-   if (pgagroal_write_socket(NULL, fd, buffer, offset) != offset)
-   {
-      pgagroal_log_debug("Health: Failed to write startup packet");
-      goto error;
-   }
-
-   /* Authentication Phase */
-   status = pgagroal_read_timeout_message(NULL, fd, 5, &msg);
-   if (status != MESSAGE_STATUS_OK || msg->kind != 'R')
-   {
-      pgagroal_log_debug("Health: Expected 'R' but got %c (status %d)", msg ? msg->kind : '?', status);
-      goto error;
-   }
-
-   auth_type_msg = ntohl(*(int*)(msg->data + 5));
-   if (auth_type_msg == 0) /* Trust / AuthenticationOk */
-   {
-      pgagroal_log_debug("Health: AuthenticationOk (Trust)");
-      *auth_type = HEALTH_CHECK_AUTH_TRUST;
-   }
-   else if (auth_type_msg == 5) /* MD5 */
-   {
-      pgagroal_log_debug("Health: Server %d requires MD5 authentication", server_idx);
-      *auth_type = HEALTH_CHECK_AUTH_MD5;
-      password = pgagroal_get_user_password(config->health_check_user);
-      if (password == NULL)
-      {
-         pgagroal_log_warn("Health: Password for %s not found", config->health_check_user);
-         goto error;
-      }
-      if (pgagroal_md5_client_auth(msg, config->health_check_user, password, fd, NULL, &msg) != 0)
-      {
-         pgagroal_log_debug("Health: MD5 authentication failed for server %d", server_idx);
-         goto error;
-      }
-   }
-   else if (auth_type_msg == 10) /* SASL */
-   {
-      pgagroal_log_debug("Health: Server %d requires SCRAM-SHA-256 authentication", server_idx);
-      *auth_type = HEALTH_CHECK_AUTH_SCRAM;
-      password = pgagroal_get_user_password(config->health_check_user);
-      if (password == NULL)
-      {
-         pgagroal_log_warn("Health: Password for %s not found", config->health_check_user);
-         goto error;
-      }
-      if (pgagroal_scram_client_auth(config->health_check_user, password, fd, NULL, &msg) != 0)
-      {
-         pgagroal_log_debug("Health: SCRAM-SHA-256 authentication failed for server %d", server_idx);
-         goto error;
-      }
-   }
-   else
-   {
-      pgagroal_log_warn("Health: Unsupported authentication type %d for server %d", auth_type_msg, server_idx);
-      goto error;
-   }
-
-   /* Wait for ReadyForQuery */
-   while (true)
-   {
-      if (msg == NULL)
-      {
-         status = pgagroal_read_timeout_message(NULL, fd, 5, &msg);
-         if (status != MESSAGE_STATUS_OK || msg == NULL)
-         {
-            pgagroal_log_debug("Health: Failed to read from server (status %d)", status);
-            goto error;
-         }
-      }
-
-      offset_p = 0;
-      while (offset_p < msg->length)
-      {
-         kind = pgagroal_read_byte(msg->data + offset_p);
-         len = pgagroal_read_int32(msg->data + offset_p + 1);
-
-         pgagroal_log_debug("Health Trace: loop msg kind=%c len=%d offset=%d total=%zd", kind, len, offset_p, msg->length);
-
-         if (kind == 'Z')
-         {
-            ready = true;
-            break;
-         }
-         else if (kind == 'E')
-         {
-            pgagroal_log_debug("Health: Received ErrorResponse during session initialization");
-            goto error;
-         }
-
-         offset_p += 1 + len;
-         if (offset_p >= msg->length)
-         {
-            break;
-         }
-      }
-
-      pgagroal_clear_message(msg);
-      msg = NULL;
-
-      if (ready)
-      {
-         break;
-      }
-   }
-
-   /* Send SELECT 1 */
-   query_len = strlen(query_string);
-   memset(buffer, 0, sizeof(buffer));
-   buffer[0] = 'Q';
-   pgagroal_write_int32(buffer + 1, 4 + query_len + 1);
-   memcpy(buffer + 5, query_string, query_len);
-   buffer[5 + query_len] = 0;
-   msg_size = 1 + 4 + query_len + 1;
-
-   if (pgagroal_write_socket(NULL, fd, buffer, msg_size) != msg_size)
-   {
-      pgagroal_log_debug("Health: Failed to write query");
-      goto error;
    }
 
    /* Wait for query response */

--- a/src/libpgagroal/server.c
+++ b/src/libpgagroal/server.c
@@ -34,6 +34,8 @@
 #include <pool.h>
 #include <security.h>
 #include <server.h>
+#include <message.h>
+#include <network.h>
 #include <utils.h>
 #include <value.h>
 
@@ -45,9 +47,400 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <arpa/inet.h>
 
 static int failover(int old_primary);
 static int process_server_parameters(int server, struct deque* server_parameters);
+static int query_system_identifier(int server_idx, char* identifier, size_t id_size);
+
+/**
+ * Check server system identifiers for duplicates.
+ *
+ * Behavior is controlled by the startup_validation config parameter:
+ *   off: skip entirely
+ *   try: run check if health_check_user is set, otherwise log INFO and continue
+ *   on:  require health_check_user and fail on any query error or duplicate
+ */
+int
+pgagroal_check_server_identifiers(void)
+{
+   struct main_configuration* config;
+   char identifiers[NUMBER_OF_SERVERS][64];
+   int num_servers;
+
+   config = (struct main_configuration*)shmem;
+   num_servers = config->number_of_servers;
+
+   if (config->startup_validation == STARTUP_VALIDATION_OFF)
+   {
+      pgagroal_log_debug("Startup validation: off, skipping identifier check");
+      return 0;
+   }
+
+   if (num_servers < 2)
+   {
+      return 0;
+   }
+
+   if (strlen(config->health_check_user) == 0)
+   {
+      if (config->startup_validation == STARTUP_VALIDATION_ON)
+      {
+         pgagroal_log_fatal("startup_validation is set to 'on' but health_check_user is not configured");
+         return 1;
+      }
+
+      /* try mode: no health_check_user, just inform and continue */
+      pgagroal_log_info("Startup validation: health_check_user not set, skipping server identifier check");
+      return 0;
+   }
+
+   pgagroal_log_info("Checking server system identifiers");
+
+   for (int i = 0; i < num_servers; i++)
+   {
+      memset(identifiers[i], 0, sizeof(identifiers[i]));
+
+      if (query_system_identifier(i, identifiers[i], sizeof(identifiers[i])))
+      {
+         if (config->startup_validation == STARTUP_VALIDATION_ON)
+         {
+            pgagroal_log_fatal("Could not query system_identifier for server [%s] (%s:%d)",
+                               config->servers[i].name, config->servers[i].host, config->servers[i].port);
+            return 1;
+         }
+
+         pgagroal_log_warn("Could not query system_identifier for server [%s] (%s:%d)",
+                           config->servers[i].name, config->servers[i].host, config->servers[i].port);
+      }
+   }
+
+   for (int i = 0; i < num_servers; i++)
+   {
+      if (!strlen(identifiers[i]))
+      {
+         continue;
+      }
+
+      for (int j = i + 1; j < num_servers; j++)
+      {
+         if (!strlen(identifiers[j]))
+         {
+            continue;
+         }
+
+         if (!strcmp(identifiers[i], identifiers[j]))
+         {
+            pgagroal_log_fatal("Servers [%s] (%s:%d) and [%s] (%s:%d) have the same system_identifier (%s) "
+                               "- they point to the same PostgreSQL cluster",
+                               config->servers[i].name, config->servers[i].host, config->servers[i].port,
+                               config->servers[j].name, config->servers[j].host, config->servers[j].port,
+                               identifiers[i]);
+            return 1;
+         }
+      }
+   }
+
+   return 0;
+}
+
+int
+pgagroal_server_query_execute(int server_idx, char* user, char* database, char* query, int* auth_type, int* fd_out)
+{
+   struct main_configuration* config;
+   struct server* srv;
+   int fd = -1;
+   char buffer[1024];
+   struct message* msg = NULL;
+   struct message* startup_msg = NULL;
+   int status;
+   char* password = NULL;
+   int query_len;
+   int msg_size;
+   int auth_type_msg;
+   bool ready = false;
+   int offset_p;
+   char kind;
+   int len;
+
+   config = (struct main_configuration*)shmem;
+   srv = &config->servers[server_idx];
+
+   if (pgagroal_connect(srv->host, srv->port, &fd, true, false) != 0)
+   {
+      pgagroal_log_debug("server_query: Failed to connect to server %d (%s:%d)",
+                         server_idx, srv->host, srv->port);
+      return 1;
+   }
+
+   /* Construct and send Startup Packet */
+   if (pgagroal_create_startup_message(user, database, &(startup_msg)) != MESSAGE_STATUS_OK)
+   {
+      pgagroal_log_debug("server_query: Failed to create startup message");
+      goto error;
+   }
+
+   if (pgagroal_write_message(NULL, fd, startup_msg) != MESSAGE_STATUS_OK)
+   {
+      pgagroal_log_debug("server_query: Failed to write startup packet");
+      pgagroal_free_message(startup_msg);
+      startup_msg = NULL;
+      goto error;
+   }
+
+   pgagroal_free_message(startup_msg);
+   startup_msg = NULL;
+
+   /* Authentication Phase */
+   status = pgagroal_read_timeout_message(NULL, fd, 5, &msg);
+   if (status != MESSAGE_STATUS_OK || msg == NULL || msg->kind != 'R')
+   {
+      pgagroal_log_debug("server_query: Expected 'R' but got %c (status %d)",
+                         msg ? msg->kind : '?', status);
+      goto error;
+   }
+
+   auth_type_msg = ntohl(*(int*)(msg->data + 5));
+   if (auth_type_msg == 0) /* Trust */
+   {
+      if (auth_type != NULL)
+      {
+         *auth_type = HEALTH_CHECK_AUTH_TRUST;
+      }
+   }
+   else if (auth_type_msg == 5) /* MD5 */
+   {
+      if (auth_type != NULL)
+      {
+         *auth_type = HEALTH_CHECK_AUTH_MD5;
+      }
+      password = pgagroal_get_user_password(user);
+      if (password == NULL)
+      {
+         pgagroal_log_debug("server_query: Password for %s not found", user);
+         goto error;
+      }
+      if (pgagroal_md5_client_auth(msg, user, password, fd, NULL, &msg) != 0)
+      {
+         pgagroal_log_debug("server_query: MD5 auth failed for server %d", server_idx);
+         goto error;
+      }
+   }
+   else if (auth_type_msg == 10) /* SASL */
+   {
+      if (auth_type != NULL)
+      {
+         *auth_type = HEALTH_CHECK_AUTH_SCRAM;
+      }
+      password = pgagroal_get_user_password(user);
+      if (password == NULL)
+      {
+         pgagroal_log_debug("server_query: Password for %s not found", user);
+         goto error;
+      }
+      if (pgagroal_scram_client_auth(user, password, fd, NULL, &msg) != 0)
+      {
+         pgagroal_log_debug("server_query: SCRAM auth failed for server %d", server_idx);
+         goto error;
+      }
+   }
+   else
+   {
+      pgagroal_log_debug("server_query: Unsupported auth type %d for server %d", auth_type_msg, server_idx);
+      goto error;
+   }
+
+   /* Wait for ReadyForQuery */
+   while (true)
+   {
+      if (msg == NULL)
+      {
+         status = pgagroal_read_timeout_message(NULL, fd, 5, &msg);
+         if (status != MESSAGE_STATUS_OK || msg == NULL)
+         {
+            pgagroal_log_debug("server_query: Failed to read from server (status %d)", status);
+            goto error;
+         }
+      }
+
+      offset_p = 0;
+      while (offset_p < msg->length)
+      {
+         kind = pgagroal_read_byte(msg->data + offset_p);
+         len = pgagroal_read_int32(msg->data + offset_p + 1);
+
+         if (kind == 'Z')
+         {
+            ready = true;
+            break;
+         }
+         else if (kind == 'E')
+         {
+            pgagroal_log_debug("server_query: Received ErrorResponse during session initialization");
+            goto error;
+         }
+
+         offset_p += 1 + len;
+         if (offset_p >= msg->length)
+         {
+            break;
+         }
+      }
+
+      pgagroal_clear_message(msg);
+      msg = NULL;
+
+      if (ready)
+      {
+         break;
+      }
+   }
+
+   /* Send query */
+   query_len = strlen(query);
+   msg_size = 1 + 4 + query_len + 1;
+
+   if ((size_t)msg_size > sizeof(buffer))
+   {
+      pgagroal_log_debug("server_query: Query too large (%d bytes)", query_len);
+      goto error;
+   }
+
+   memset(buffer, 0, sizeof(buffer));
+   buffer[0] = 'Q';
+   pgagroal_write_int32(buffer + 1, 4 + query_len + 1);
+   memcpy(buffer + 5, query, query_len);
+   buffer[5 + query_len] = 0;
+
+   if (pgagroal_write_socket(NULL, fd, buffer, msg_size) != msg_size)
+   {
+      pgagroal_log_debug("server_query: Failed to write query");
+      goto error;
+   }
+
+   *fd_out = fd;
+   return 0;
+
+error:
+   if (msg != NULL)
+   {
+      pgagroal_clear_message(msg);
+   }
+   if (fd != -1)
+   {
+      pgagroal_disconnect(fd);
+   }
+   return 1;
+}
+
+static int
+query_system_identifier(int server_idx, char* identifier, size_t id_size)
+{
+   struct main_configuration* config;
+   struct server* srv;
+   int fd = -1;
+   struct message* msg = NULL;
+   int status;
+   bool query_ready = false;
+   int offset_q;
+   char buffer[8];
+
+   config = (struct main_configuration*)shmem;
+   srv = &config->servers[server_idx];
+
+   if (pgagroal_server_query_execute(server_idx,
+                                     config->health_check_user,
+                                     config->health_check_user,
+                                     "SELECT system_identifier FROM pg_control_system()",
+                                     NULL, &fd) != 0)
+   {
+      return 1;
+   }
+
+   /* Parse query response and extract system_identifier from DataRow */
+   while (true)
+   {
+      status = pgagroal_read_timeout_message(NULL, fd, 5, &msg);
+      if (status != MESSAGE_STATUS_OK || msg == NULL)
+      {
+         goto error;
+      }
+
+      offset_q = 0;
+      while (offset_q < msg->length)
+      {
+         char type_q = pgagroal_read_byte(msg->data + offset_q);
+         int len_q = pgagroal_read_int32(msg->data + offset_q + 1);
+
+         if (type_q == 'D')
+         {
+            /* DataRow: 'D' | int32 len | int16 num_cols | int32 col_len | data */
+            int dr_offset = offset_q + 5; /* skip 'D' + len */
+            int num_cols = pgagroal_read_int16(msg->data + dr_offset);
+            dr_offset += 2;
+
+            if (num_cols >= 1)
+            {
+               int col_len = pgagroal_read_int32(msg->data + dr_offset);
+               dr_offset += 4;
+
+               if (col_len > 0 && (size_t)col_len < id_size)
+               {
+                  memcpy(identifier, msg->data + dr_offset, col_len);
+                  identifier[col_len] = '\0';
+               }
+            }
+         }
+         else if (type_q == 'Z')
+         {
+            query_ready = true;
+            break;
+         }
+         else if (type_q == 'E')
+         {
+            pgagroal_log_error("cannot query pg_control_system() on server %d", server_idx);
+            goto error;
+         }
+
+         offset_q += 1 + len_q;
+         if (offset_q >= msg->length)
+         {
+            break;
+         }
+      }
+
+      pgagroal_clear_message(msg);
+      msg = NULL;
+
+      if (query_ready)
+      {
+         break;
+      }
+   }
+
+   /* Send Terminate */
+   buffer[0] = 'X';
+   pgagroal_write_int32(buffer + 1, 4);
+   pgagroal_write_socket(NULL, fd, buffer, 5);
+
+   pgagroal_disconnect(fd);
+
+   pgagroal_log_debug("system_identifier: Server [%s] (%s:%d) = %s",
+                      srv->name, srv->host, srv->port, identifier);
+
+   return strlen(identifier) > 0 ? 0 : 1;
+
+error:
+   if (msg != NULL)
+   {
+      pgagroal_clear_message(msg);
+   }
+   if (fd != -1)
+   {
+      pgagroal_disconnect(fd);
+   }
+   return 1;
+}
 
 int
 pgagroal_get_primary(int* server)

--- a/src/main.c
+++ b/src/main.c
@@ -1259,6 +1259,15 @@ read_superuser_path:
       pgagroal_health_check(argc, argv);
    }
 
+   if (pgagroal_check_server_identifiers())
+   {
+      pgagroal_log_fatal("pgagroal: Duplicate server system identifiers detected");
+#ifdef HAVE_SYSTEMD
+      sd_notify(0, "STATUS=Duplicate server system identifiers detected");
+#endif
+      goto error;
+   }
+
    if (pgagroal_time_is_valid(config->idle_timeout))
    {
       pgagroal_periodic_init(&idle_timeout, idle_timeout_cb,

--- a/test/conf/07/pgagroal.conf
+++ b/test/conf/07/pgagroal.conf
@@ -1,0 +1,12 @@
+[pgagroal]
+host = localhost
+port = 2345
+unix_socket_dir = /tmp/
+
+[rachel]
+host = 127.0.0.1
+port = 5432
+
+[ross]
+host = localhost
+port = 5432

--- a/test/conf/08/pgagroal.conf
+++ b/test/conf/08/pgagroal.conf
@@ -1,0 +1,12 @@
+[pgagroal]
+host = localhost
+port = 2345
+unix_socket_dir = /tmp/
+
+[test]
+host = 192.168.1.1
+port = 5432
+
+[test]
+host = 192.168.1.2
+port = 5433

--- a/test/conf/09/pgagroal.conf
+++ b/test/conf/09/pgagroal.conf
@@ -1,0 +1,14 @@
+[pgagroal]
+host = localhost
+port = 2345
+unix_socket_dir = /tmp/
+
+[server1]
+host = 192.168.1.1
+port = 5432
+primary = on
+
+[server2]
+host = 192.168.1.2
+port = 5433
+primary = on

--- a/test/conf/10/pgagroal.conf
+++ b/test/conf/10/pgagroal.conf
@@ -1,0 +1,13 @@
+[pgagroal]
+host = localhost
+port = 2345
+unix_socket_dir = /tmp/
+
+[primary_server]
+host = 192.168.1.1
+port = 5432
+primary = on
+
+[replica_server]
+host = 192.168.1.2
+port = 5433

--- a/test/conf/11/pgagroal.conf
+++ b/test/conf/11/pgagroal.conf
@@ -1,0 +1,14 @@
+[pgagroal]
+host = localhost
+port = 2345
+unix_socket_dir = /tmp/
+startup_validation = off
+health_check_user = postgres
+
+[rachel]
+host = 127.0.0.1
+port = 5432
+
+[ross]
+host = localhost
+port = 5432

--- a/test/conf/12/pgagroal.conf
+++ b/test/conf/12/pgagroal.conf
@@ -1,0 +1,13 @@
+[pgagroal]
+host = localhost
+port = 2345
+unix_socket_dir = /tmp/
+startup_validation = try
+
+[rachel]
+host = 127.0.0.1
+port = 5432
+
+[ross]
+host = localhost
+port = 5432

--- a/test/conf/13/pgagroal.conf
+++ b/test/conf/13/pgagroal.conf
@@ -1,0 +1,13 @@
+[pgagroal]
+host = localhost
+port = 2345
+unix_socket_dir = /tmp/
+startup_validation = on
+
+[rachel]
+host = 127.0.0.1
+port = 5432
+
+[ross]
+host = localhost
+port = 5432

--- a/test/testcases/test_startup_validation.c
+++ b/test/testcases/test_startup_validation.c
@@ -1,0 +1,286 @@
+/*
+ * Copyright (C) 2026 The pgagroal community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <pgagroal.h>
+#include <configuration.h>
+#include <server.h>
+#include <shmem.h>
+#include <tsclient.h>
+#include <mctf.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int
+build_test_conf_path(const char* subdir, char* path, size_t path_size)
+{
+   int n;
+
+   n = snprintf(path, path_size, "%s/test/conf/%s/pgagroal.conf",
+                project_directory, subdir);
+
+   if (n <= 0 || (size_t)n >= path_size)
+   {
+      return 1;
+   }
+
+   return 0;
+}
+
+// duplicate server detection via getaddrinfo (localhost vs 127.0.0.1)
+MCTF_TEST(test_server_validation_duplicate_server_getaddrinfo)
+{
+   struct main_configuration config;
+   char path[MAX_PATH];
+   int ret;
+
+   memset(&config, 0, sizeof(struct main_configuration));
+   pgagroal_init_configuration(&config);
+
+   MCTF_ASSERT(build_test_conf_path("07", path, sizeof(path)) == 0,
+               cleanup, "Failed to build config path");
+
+   ret = pgagroal_read_configuration(&config, path, false);
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "pgagroal_read_configuration should succeed");
+
+   ret = pgagroal_validate_configuration(&config, true, true);
+   MCTF_ASSERT(ret != 0, cleanup,
+               "validation should fail for duplicate servers (localhost vs 127.0.0.1)");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+// duplicate server name detection
+MCTF_TEST(test_server_validation_duplicate_server_name)
+{
+   struct main_configuration config;
+   char path[MAX_PATH];
+   int ret;
+
+   memset(&config, 0, sizeof(struct main_configuration));
+   pgagroal_init_configuration(&config);
+
+   MCTF_ASSERT(build_test_conf_path("08", path, sizeof(path)) == 0,
+               cleanup, "Failed to build config path");
+
+   ret = pgagroal_read_configuration(&config, path, false);
+   MCTF_ASSERT(ret != 0, cleanup,
+               "read_configuration should fail for duplicate server names");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+// multiple primary server detection
+MCTF_TEST(test_server_validation_multiple_primaries)
+{
+   struct main_configuration config;
+   char path[MAX_PATH];
+   int ret;
+
+   memset(&config, 0, sizeof(struct main_configuration));
+   pgagroal_init_configuration(&config);
+
+   MCTF_ASSERT(build_test_conf_path("09", path, sizeof(path)) == 0,
+               cleanup, "Failed to build config path");
+
+   ret = pgagroal_read_configuration(&config, path, false);
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "pgagroal_read_configuration should succeed");
+
+   ret = pgagroal_validate_configuration(&config, true, true);
+   MCTF_ASSERT(ret != 0, cleanup,
+               "validation should fail for multiple primary servers");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+// valid configuration should pass all checks
+MCTF_TEST(test_server_validation_valid_config)
+{
+   struct main_configuration config;
+   char path[MAX_PATH];
+   int ret;
+
+   memset(&config, 0, sizeof(struct main_configuration));
+   pgagroal_init_configuration(&config);
+
+   MCTF_ASSERT(build_test_conf_path("10", path, sizeof(path)) == 0,
+               cleanup, "Failed to build config path");
+
+   ret = pgagroal_read_configuration(&config, path, false);
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "pgagroal_read_configuration should succeed");
+
+   ret = pgagroal_validate_configuration(&config, true, true);
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup,
+                      "validation should pass for a valid configuration");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+// duplicate system_identifier detection (same cluster, different server names)
+MCTF_TEST(test_server_validation_duplicate_system_identifier)
+{
+   struct main_configuration* config;
+   int ret;
+   int orig_count;
+   struct server orig_servers[NUMBER_OF_SERVERS];
+   char orig_health_check_user[MAX_USERNAME_LENGTH];
+
+   config = (struct main_configuration*)shmem;
+
+   /* Save original state */
+   orig_count = config->number_of_servers;
+   memcpy(orig_servers, config->servers, sizeof(orig_servers));
+   memcpy(orig_health_check_user, config->health_check_user, MAX_USERNAME_LENGTH);
+
+   /* Set health_check_user to postgres */
+   snprintf(config->health_check_user, MAX_USERNAME_LENGTH, "postgres");
+
+   /* Set up two servers pointing to the same instance */
+   config->number_of_servers = 2;
+   memset(&config->servers[0], 0, sizeof(struct server));
+   memset(&config->servers[1], 0, sizeof(struct server));
+
+   snprintf(config->servers[0].name, MISC_LENGTH, "server_a");
+   snprintf(config->servers[0].host, MISC_LENGTH, "%s", orig_servers[0].host);
+   config->servers[0].port = orig_servers[0].port;
+
+   snprintf(config->servers[1].name, MISC_LENGTH, "server_b");
+   snprintf(config->servers[1].host, MISC_LENGTH, "%s", orig_servers[0].host);
+   config->servers[1].port = orig_servers[0].port;
+
+   ret = pgagroal_check_server_identifiers();
+
+   /* Restore original config */
+   config->number_of_servers = orig_count;
+   memcpy(config->servers, orig_servers, sizeof(orig_servers));
+   memcpy(config->health_check_user, orig_health_check_user, MAX_USERNAME_LENGTH);
+
+   MCTF_ASSERT(ret != 0, cleanup,
+               "check_server_identifiers should fail for two servers pointing to the same cluster");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+// startup_validation = off: identifier check should be skipped entirely
+MCTF_TEST(test_startup_validation_off)
+{
+   struct main_configuration* config;
+   struct main_configuration backup;
+   char path[MAX_PATH];
+   int ret;
+
+   config = (struct main_configuration*)shmem;
+
+   /* Save original state */
+   memcpy(&backup, config, sizeof(struct main_configuration));
+
+   MCTF_ASSERT(build_test_conf_path("11", path, sizeof(path)) == 0,
+               cleanup, "Failed to build config path");
+
+   pgagroal_init_configuration(config);
+   ret = pgagroal_read_configuration(config, path, false);
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "pgagroal_read_configuration should succeed");
+
+   ret = pgagroal_check_server_identifiers();
+
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup,
+                      "check_server_identifiers should return 0 when startup_validation is off");
+
+cleanup:
+   /* Restore original config */
+   memcpy(config, &backup, sizeof(struct main_configuration));
+   MCTF_FINISH();
+}
+
+// startup_validation = try with no health_check_user: should skip gracefully
+MCTF_TEST(test_startup_validation_try_no_user)
+{
+   struct main_configuration* config;
+   struct main_configuration backup;
+   char path[MAX_PATH];
+   int ret;
+
+   config = (struct main_configuration*)shmem;
+
+   /* Save original state */
+   memcpy(&backup, config, sizeof(struct main_configuration));
+
+   MCTF_ASSERT(build_test_conf_path("12", path, sizeof(path)) == 0,
+               cleanup, "Failed to build config path");
+
+   pgagroal_init_configuration(config);
+   ret = pgagroal_read_configuration(config, path, false);
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "pgagroal_read_configuration should succeed");
+
+   ret = pgagroal_check_server_identifiers();
+
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup,
+                      "check_server_identifiers should return 0 in try mode without health_check_user");
+
+cleanup:
+   /* Restore original config */
+   memcpy(config, &backup, sizeof(struct main_configuration));
+   MCTF_FINISH();
+}
+
+// startup_validation = on with no health_check_user: should fail
+MCTF_TEST(test_startup_validation_on_no_user)
+{
+   struct main_configuration* config;
+   struct main_configuration backup;
+   char path[MAX_PATH];
+   int ret;
+
+   config = (struct main_configuration*)shmem;
+
+   /* Save original state */
+   memcpy(&backup, config, sizeof(struct main_configuration));
+
+   MCTF_ASSERT(build_test_conf_path("13", path, sizeof(path)) == 0,
+               cleanup, "Failed to build config path");
+
+   pgagroal_init_configuration(config);
+   ret = pgagroal_read_configuration(config, path, false);
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "pgagroal_read_configuration should succeed");
+
+   ret = pgagroal_check_server_identifiers();
+
+   MCTF_ASSERT(ret != 0, cleanup,
+               "check_server_identifiers should fail in on mode without health_check_user");
+
+cleanup:
+   /* Restore original config */
+   memcpy(config, &backup, sizeof(struct main_configuration));
+   MCTF_FINISH();
+}


### PR DESCRIPTION
resolved #710 

## Changes

- Enhanced `is_same_server()` to resolve hostnames using `getaddrinfo()`, allowing detection of duplicates such as `localhost` vs `127.0.0.1`.
- Add `pgagroal_check_server_identifiers()` to detect servers pointing to the same PostgreSQL cluster by comparing `system_identifier` via `pg_control_system()` at startup.
- Refactored `server_probe()` in `health.c` to use the shared `pgagroal_server_query_execute()` in `server.c`, eliminating duplicated connect-and-query logic.
- Added test cases that test (Multiple primary servers, Duplicate server section names, System identifier checks, Valid configuration acceptance)
