### PR TITLE
Add .dockerignore for container builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Reduce Docker build context for container image builds.
+# The Dockerfiles in contrib/docker/ use COPY . . in the builder stage,
+# so only files needed by cmake and the runtime COPY are required.
+
+# Version control
+.git
+.gitignore
+
+# CI/CD
+.github
+
+# Tests (cmake skips test/ if absent)
+test
+
+# Monitoring and observability tooling
+contrib/grafana
+contrib/prometheus_scrape
+contrib/shell_comp
+contrib/valgrind
+contrib/docker/rpm
+
+# Developer tools
+.clang-format
+clang-format.sh
+
+# Package specs
+pgagroal.spec
+
+# Documentation at root level
+README.md
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+AUTHORS
+
+# Build artifacts (if present locally)
+build
+CMakeCache.txt
+CMakeFiles
+
+# OS and editor artifacts
+.DS_Store
+*.log


### PR DESCRIPTION
The Dockerfiles in contrib/docker/ are built with the repository root as
context (e.g. docker build -f ./contrib/docker/Dockerfile.alpine .). Without
a .dockerignore, the full repository is sent to the build context, including
files not required for the cmake build or runtime image.

Add a .dockerignore to exclude version control, CI configuration, tests,
monitoring tooling, developer utilities, packaging files, and build artifacts.

All required paths remain included:

- src/, cmake/, CMakeLists.txt (cmake build)
- doc/ (man page generation)
- contrib/docker/pgagroal.conf, pgagroal_hba.conf (runtime configuration)

Excluding test/ is safe, as cmake already guards for its presence.

No change in build output or runtime behavior. Compatible with Docker and Podman.