### PR TITLE
Add HEALTHCHECK to container Dockerfiles

### DIFF
--- a/contrib/docker/Dockerfile.alpine
+++ b/contrib/docker/Dockerfile.alpine
@@ -95,4 +95,7 @@ EXPOSE 2345 2346
 
 USER pgagroal
 
+HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=3 \
+    CMD pgagroal-cli -c /etc/pgagroal/pgagroal.conf ping || exit 1
+
 CMD ["/usr/local/bin/pgagroal", "-c", "/etc/pgagroal/pgagroal.conf", "-a", "/etc/pgagroal/pgagroal_hba.conf"]

--- a/contrib/docker/Dockerfile.rocky9
+++ b/contrib/docker/Dockerfile.rocky9
@@ -113,5 +113,7 @@ EXPOSE 2345 2346
 
 USER pgagroal
 
+HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=3 \
+    CMD pgagroal-cli -c /etc/pgagroal/pgagroal.conf ping || exit 1
 
 CMD ["/usr/local/bin/pgagroal", "-c", "/etc/pgagroal/pgagroal.conf", "-a", "/etc/pgagroal/pgagroal_hba.conf"]


### PR DESCRIPTION
The container Dockerfiles in contrib/docker/ have no HEALTHCHECK instruction.
This means Docker and Podman cannot report whether the pgagroal daemon inside
the container is actually running.

Add a HEALTHCHECK using pgagroal-cli ping, which checks daemon liveness via
the Unix socket. The check runs as the pgagroal user with the container's own
configuration file.

Parameters: interval 10s, timeout 5s, start-period 5s, retries 3.

pgagroal-cli ping checks the daemon process only, not backend connectivity.
This is intentional: the container is healthy when its daemon is running,
regardless of backend state.

No change to runtime behavior. Both Alpine and Rocky 9 variants are updated
identically.