### PR TITLE
Remove development packages from container runtime images

### DIFF
--- a/contrib/docker/Dockerfile.alpine
+++ b/contrib/docker/Dockerfile.alpine
@@ -69,14 +69,11 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositori
     apk add --no-cache \
     bash \
     ca-certificates \
-    yaml \
     bzip2 \
-    bzip2-dev \
     libpq \
     libatomic \
-    liburing-dev\
+    liburing \
     zstd \
-    linux-headers \
     lz4-libs
 
 RUN adduser -D -s /bin/sh pgagroal

--- a/contrib/docker/Dockerfile.rocky9
+++ b/contrib/docker/Dockerfile.rocky9
@@ -76,24 +76,14 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.
     dnf install -y dnf-plugins-core && \
     dnf config-manager --set-enabled crb && \
     dnf makecache && \
-    dnf install -y \ 
+    dnf install -y \
         libpq \
-        libpq-devel \
         libatomic \
         zlib \
-        zlib-devel \
         zstd \
-        libzstd-devel \
         lz4 \
-        lz4-devel \
         bzip2 \
-        bzip2-devel \
-        libatomic \
-        libyaml-devel \
-        systemd-devel \
-        liburing-devel \
-        libasan \ 
-        libubsan && \
+        liburing && \
     dnf clean all
 
 RUN useradd --create-home --shell /bin/bash pgagroal


### PR DESCRIPTION
The runtime stages in both container Dockerfiles install packages that are only
needed at compile time. The pgagroal binaries are already compiled in the builder
stage and copied to the runtime image, so development headers, sanitizer
libraries, and unused dependencies serve no purpose at runtime.

Rocky 9: remove libpq-devel, zlib-devel, libzstd-devel, lz4-devel, bzip2-devel,
libyaml-devel, systemd-devel, libasan, libubsan, and a duplicate libatomic entry.
Replace liburing-devel with liburing (runtime library only).

Alpine: remove yaml, bzip2-dev, linux-headers. Replace liburing-dev with liburing.

All runtime library dependencies remain satisfied:
- libpq, zlib, zstd, lz4, bzip2, liburing, libatomic (explicit)
- openssl-libs, systemd-libs, glibc/musl, pthread (base image)

Builder stages are unchanged. No change to runtime behavior.