### PR TITLE
[#813] Add pool saturation test configuration and test case

### DIFF
--- a/test/conf/07/pgagroal.conf
+++ b/test/conf/07/pgagroal.conf
@@ -1,0 +1,19 @@
+[pgagroal]
+host = localhost
+port = 2345
+
+log_type = file
+log_level = debug5
+log_path = test.log
+
+max_connections = 6
+blocking_timeout = 10
+idle_timeout = 600
+validation = off
+unix_socket_dir = /tmp/
+pipeline = session
+ev_backend = epoll
+
+[primary]
+host = localhost
+port = 5432

--- a/test/conf/07/pgagroal_databases.conf
+++ b/test/conf/07/pgagroal_databases.conf
@@ -1,0 +1,4 @@
+#
+# DATABASE=ALIAS1,ALIAS2 USER MAX_SIZE INITIAL_SIZE MIN_SIZE
+#
+mydb=pgalias1,pgalias2 myuser 6 6 1

--- a/test/conf/07/pgagroal_hba.conf
+++ b/test/conf/07/pgagroal_hba.conf
@@ -1,0 +1,4 @@
+#
+# TYPE  DATABASE USER  ADDRESS  METHOD
+#
+host    all all all trust

--- a/test/testcases/test_connection.c
+++ b/test/testcases/test_connection.c
@@ -26,6 +26,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <pgagroal.h>
 #include <tsclient.h>
 #include <mctf.h>
 
@@ -44,6 +45,23 @@ MCTF_TEST(test_pgagroal_connection_load)
 {
    int found = 0;
    found = !pgagroal_tsclient_execute_pgbench(user, database, true, 6, 0, 1000);
+   MCTF_ASSERT(found, cleanup, "success status not found");
+cleanup:
+   MCTF_FINISH();
+}
+
+// saturation
+MCTF_TEST(test_pgagroal_connection_saturation)
+{
+   int found = 0;
+   struct main_configuration* config = (struct main_configuration*)shmem;
+
+   if (config->max_connections >= 8)
+   {
+      MCTF_SKIP("pool has enough slots for all clients");
+   }
+
+   found = !pgagroal_tsclient_execute_pgbench(user, database, true, 8, 8, 100);
    MCTF_ASSERT(found, cleanup, "success status not found");
 cleanup:
    MCTF_FINISH();


### PR DESCRIPTION
## Summary

Adds the test configuration and test case for pool saturation that was
described in #815 but not included in the merged diff.

**Config files:**
- **test/conf/07/pgagroal.conf** — session pipeline with
  `max_connections = 6` and `blocking_timeout = 10`
- **test/conf/07/pgagroal_databases.conf** — limit overrides that
  reduce the total from 8 to 6, matching the lower `max_connections`
- **test/conf/07/pgagroal_hba.conf** — standard trust-all HBA

**Test:**
- `test_pgagroal_connection_saturation`: 8 pgbench clients (1 thread
  each, select-only, 100 transactions)

Against config 07, the first 6 clients connect immediately, the
remaining 2 enter the `blocking_timeout` retry loop and acquire
connections as earlier clients finish and disconnect.

### Skip condition

The test skips when `max_connections >= 8` (the client count).
Saturation only occurs when the pool is smaller than the number of
clients. Configs 01–06 have `max_connections` of 100–200 (capped to 8
in Debug builds), so the test only runs against config 07
(`max_connections = 6`).

### Databases config override

The CI base `pgagroal_databases.conf` defines limits totaling 8
connections (6 + 2). With `max_connections = 6`, pgagroal rejects this
as invalid (`total_connections > max_connections`). The override in
`test/conf/07/` reduces the limits to 4 + 2 = 6, matching
`max_connections`. The existing `run_multiple_config_tests`
infrastructure (merged in #815) already supports per-config
`pgagroal_databases.conf` overrides.

## What this does NOT change

- No production code modified
- No retry algorithm changes
- No new configuration parameters

This is a test-only baseline for #813.

## Test plan
- [x] Compiles cleanly
- [x] Config 07 limit totals (6) <= max_connections (6)
- [x] Existing tests unaffected — `test_pgagroal_connection_load`
      (6 clients) fits in max_connections = 6
- [x] Skips on configs 01–06 (max_connections >= 8)
- [x] No production source files modified
- [ ] CI validation (pending)

Ref #813