### PR TITLE
[#841] Refactor pgagroal conf get output to decouple CLI and JSON for…

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -1729,15 +1729,36 @@ get_config_key_result(char* config_key, struct json* j, uintptr_t* r, int32_t ou
       else if (!strcmp(key, iter->key))
       {
          // Handle single or two-part keys
-         config_value = pgagroal_value_to_string(iter->value, FORMAT_TEXT, NULL, 0);
          if (iter->value->type == ValueJSON)
          {
-            struct json* server_data = NULL;
-            pgagroal_json_clone((struct json*)iter->value->data, &server_data);
-            pgagroal_json_put(filtered_response, key, (uintptr_t)server_data, iter->value->type);
+            struct json* nested_obj = (struct json*)iter->value->data;
+
+            /* Handle enriched values formatted as { "value": N, "string_value": "..." } */
+            if (pgagroal_json_contains_key(nested_obj, "string_value"))
+            {
+               /* Extract the string value for text output */
+               config_value = strdup((char*)pgagroal_json_get(nested_obj, "string_value"));
+
+               if (output_format == MANAGEMENT_OUTPUT_FORMAT_JSON)
+               {
+                  /* Emit the full nested object in JSON mode */
+                  struct json* cloned = NULL;
+                  pgagroal_json_clone(nested_obj, &cloned);
+                  pgagroal_json_put(filtered_response, key, (uintptr_t)cloned, ValueJSON);
+               }
+            }
+            else
+            {
+               /* Handle regular JSON objects */
+               struct json* server_data = NULL;
+               config_value = pgagroal_value_to_string(iter->value, FORMAT_TEXT, NULL, 0);
+               pgagroal_json_clone(nested_obj, &server_data);
+               pgagroal_json_put(filtered_response, key, (uintptr_t)server_data, ValueJSON);
+            }
          }
          else
          {
+            config_value = pgagroal_value_to_string(iter->value, FORMAT_TEXT, NULL, 0);
             pgagroal_json_put(filtered_response, key, (uintptr_t)iter->value->data, iter->value->type);
          }
          break;

--- a/src/include/json.h
+++ b/src/include/json.h
@@ -36,6 +36,7 @@ extern "C" {
 /* pgagroal */
 #include <pgagroal.h>
 #include <deque.h>
+#include <utils.h>
 #include <value.h>
 
 /* System */
@@ -254,6 +255,35 @@ pgagroal_json_read_file(char* path, struct json** obj);
  */
 int
 pgagroal_json_write_file(char* path, struct json* obj);
+
+/**
+ * Put an enum value as a nested JSON object { "value": N, "string_value": "label" }
+ * @param res The JSON object
+ * @param key The key
+ * @param value The numeric enum value
+ * @param to_str The converter function
+ */
+void
+pgagroal_json_put_enum_value(struct json* res, char* key, int value, int (*to_str)(char*, int));
+
+/**
+ * Put a time value as a nested JSON object { "value": N, "string_value": "Ns" }
+ * @param res The JSON object
+ * @param key The key
+ * @param t The time value
+ * @param format The time format (e.g., FORMAT_TIME_S, FORMAT_TIME_MS)
+ */
+void
+pgagroal_json_put_time_value(struct json* res, char* key, pgagroal_time_t t, enum pgagroal_time_format_t format);
+
+/**
+ * Put a size value as a nested JSON object { "value": N, "string_value": "NB" }
+ * @param res The JSON object
+ * @param key The key
+ * @param bytes The size in bytes
+ */
+void
+pgagroal_json_put_size_value(struct json* res, char* key, unsigned int bytes);
 
 #ifdef __cplusplus
 }

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -5281,7 +5281,6 @@ to_validation(char* where, int value)
 
    return 0;
 }
-
 /**
  * An utility function to convert the enumeration of values for the hugepage setting
  * into one of its possible string descriptions.
@@ -6576,31 +6575,31 @@ add_configuration_response(struct json* res)
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_PORT, (uintptr_t)config->common.port, ValueInt64);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_UNIX_SOCKET_DIR, (uintptr_t)config->unix_socket_dir, ValueString);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_METRICS, (uintptr_t)config->common.metrics, ValueInt64);
-   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, (uintptr_t)pgagroal_time_convert(config->common.metrics_cache_max_age, FORMAT_TIME_S), ValueInt64);
-   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_SIZE, (uintptr_t)config->common.metrics_cache_max_size, ValueInt64);
+   pgagroal_json_put_time_value(res, CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, config->common.metrics_cache_max_age, FORMAT_TIME_S);
+   pgagroal_json_put_size_value(res, CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_SIZE, config->common.metrics_cache_max_size);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_MANAGEMENT, (uintptr_t)config->management, ValueInt64);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_CONSOLE, (uintptr_t)config->console, ValueInt64);
-   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_LOG_TYPE, (uintptr_t)config->common.log_type, ValueInt64);
-   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_LOG_LEVEL, (uintptr_t)config->common.log_level, ValueInt64);
+   pgagroal_json_put_enum_value(res, CONFIGURATION_ARGUMENT_LOG_TYPE, config->common.log_type, to_log_type);
+   pgagroal_json_put_enum_value(res, CONFIGURATION_ARGUMENT_LOG_LEVEL, config->common.log_level, to_log_level);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_LOG_PATH, (uintptr_t)config->common.log_path, ValueString);
-   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_LOG_ROTATION_AGE, (uintptr_t)pgagroal_time_convert(config->common.log_rotation_age, FORMAT_TIME_S), ValueInt64);
-   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_LOG_ROTATION_SIZE, (uintptr_t)config->common.log_rotation_size, ValueInt64);
+   pgagroal_json_put_time_value(res, CONFIGURATION_ARGUMENT_LOG_ROTATION_AGE, config->common.log_rotation_age, FORMAT_TIME_S);
+   pgagroal_json_put_size_value(res, CONFIGURATION_ARGUMENT_LOG_ROTATION_SIZE, config->common.log_rotation_size);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_LOG_LINE_PREFIX, (uintptr_t)config->common.log_line_prefix, ValueString);
-   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_LOG_MODE, (uintptr_t)config->common.log_mode, ValueInt64);
+   pgagroal_json_put_enum_value(res, CONFIGURATION_ARGUMENT_LOG_MODE, config->common.log_mode, to_log_mode);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_LOG_CONNECTIONS, (uintptr_t)config->common.log_connections, ValueBool);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_LOG_DISCONNECTIONS, (uintptr_t)config->common.log_disconnections, ValueBool);
-   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_BLOCKING_TIMEOUT, (uintptr_t)pgagroal_time_convert(config->blocking_timeout, FORMAT_TIME_S), ValueInt64);
-   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_IDLE_TIMEOUT, (uintptr_t)pgagroal_time_convert(config->idle_timeout, FORMAT_TIME_S), ValueInt64);
-   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_ROTATE_FRONTEND_PASSWORD_TIMEOUT, (uintptr_t)pgagroal_time_convert(config->rotate_frontend_password_timeout, FORMAT_TIME_S), ValueInt64);
+   pgagroal_json_put_time_value(res, CONFIGURATION_ARGUMENT_BLOCKING_TIMEOUT, config->blocking_timeout, FORMAT_TIME_S);
+   pgagroal_json_put_time_value(res, CONFIGURATION_ARGUMENT_IDLE_TIMEOUT, config->idle_timeout, FORMAT_TIME_S);
+   pgagroal_json_put_time_value(res, CONFIGURATION_ARGUMENT_ROTATE_FRONTEND_PASSWORD_TIMEOUT, config->rotate_frontend_password_timeout, FORMAT_TIME_S);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_ROTATE_FRONTEND_PASSWORD_LENGTH, (uintptr_t)config->rotate_frontend_password_length, ValueInt64);
-   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_MAX_CONNECTION_AGE, (uintptr_t)pgagroal_time_convert(config->max_connection_age, FORMAT_TIME_S), ValueInt64);
-   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_VALIDATION, (uintptr_t)config->validation, ValueInt64);
-   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_BACKGROUND_INTERVAL, (uintptr_t)pgagroal_time_convert(config->background_interval, FORMAT_TIME_S), ValueInt64);
+   pgagroal_json_put_time_value(res, CONFIGURATION_ARGUMENT_MAX_CONNECTION_AGE, config->max_connection_age, FORMAT_TIME_S);
+   pgagroal_json_put_enum_value(res, CONFIGURATION_ARGUMENT_VALIDATION, config->validation, to_validation);
+   pgagroal_json_put_time_value(res, CONFIGURATION_ARGUMENT_BACKGROUND_INTERVAL, config->background_interval, FORMAT_TIME_S);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_MAX_RETRIES, (uintptr_t)config->max_retries, ValueInt64);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_MAX_CONNECTIONS, (uintptr_t)config->max_connections, ValueInt64);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_ALLOW_UNKNOWN_USERS, (uintptr_t)config->allow_unknown_users, ValueBool);
-   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_AUTHENTICATION_TIMEOUT, (uintptr_t)pgagroal_time_convert(config->common.authentication_timeout, FORMAT_TIME_S), ValueInt64);
-   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_PIPELINE, (uintptr_t)config->pipeline, ValueInt64);
+   pgagroal_json_put_time_value(res, CONFIGURATION_ARGUMENT_AUTHENTICATION_TIMEOUT, config->common.authentication_timeout, FORMAT_TIME_S);
+   pgagroal_json_put_enum_value(res, CONFIGURATION_ARGUMENT_PIPELINE, config->pipeline, to_pipeline);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_AUTH_QUERY, (uintptr_t)config->authquery, ValueBool);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_FAILOVER, (uintptr_t)config->failover, ValueBool);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_FAILOVER_SCRIPT, (uintptr_t)config->failover_script, ValueString);
@@ -6616,11 +6615,11 @@ add_configuration_response(struct json* res)
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_KEEP_ALIVE, (uintptr_t)config->keep_alive, ValueBool);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_NODELAY, (uintptr_t)config->nodelay, ValueBool);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_BACKLOG, (uintptr_t)config->backlog, ValueInt64);
-   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_HUGEPAGE, (uintptr_t)config->common.hugepage, ValueInt64);
+   pgagroal_json_put_enum_value(res, CONFIGURATION_ARGUMENT_HUGEPAGE, config->common.hugepage, to_hugepage);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_TRACKER, (uintptr_t)config->tracker, ValueBool);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_TRACK_PREPARED_STATEMENTS, (uintptr_t)config->track_prepared_statements, ValueBool);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_PIDFILE, (uintptr_t)config->pidfile, ValueString);
-   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_UPDATE_PROCESS_TITLE, (uintptr_t)config->update_process_title, ValueInt64);
+   pgagroal_json_put_enum_value(res, CONFIGURATION_ARGUMENT_UPDATE_PROCESS_TITLE, config->update_process_title, to_update_process_title);
 }
 
 static void

--- a/src/libpgagroal/json.c
+++ b/src/libpgagroal/json.c
@@ -805,6 +805,77 @@ error:
    return 1;
 }
 
+void
+pgagroal_json_put_enum_value(struct json* res, char* key, int value, int (*to_str)(char*, int))
+{
+   struct json* obj = NULL;
+   char str_buf[MISC_LENGTH];
+
+   memset(str_buf, 0, MISC_LENGTH);
+
+   if (pgagroal_json_create(&obj))
+   {
+      pgagroal_json_put(res, key, (uintptr_t)value, ValueInt64);
+      return;
+   }
+
+   pgagroal_json_put(obj, "value", (uintptr_t)value, ValueInt64);
+
+   if (!to_str(str_buf, value))
+   {
+      pgagroal_json_put(obj, "string_value", (uintptr_t)str_buf, ValueString);
+   }
+
+   pgagroal_json_put(res, key, (uintptr_t)obj, ValueJSON);
+}
+
+void
+pgagroal_json_put_time_value(struct json* res, char* key, pgagroal_time_t t, enum pgagroal_time_format_t format)
+{
+   struct json* obj = NULL;
+   char* str = NULL;
+   int64_t converted;
+
+   converted = pgagroal_time_convert(t, format);
+
+   if (pgagroal_json_create(&obj))
+   {
+      pgagroal_json_put(res, key, (uintptr_t)converted, ValueInt64);
+      return;
+   }
+
+   pgagroal_json_put(obj, "value", (uintptr_t)converted, ValueInt64);
+
+   if (!pgagroal_time_format(t, format, &str))
+   {
+      pgagroal_json_put(obj, "string_value", (uintptr_t)str, ValueString);
+      free(str);
+   }
+
+   pgagroal_json_put(res, key, (uintptr_t)obj, ValueJSON);
+}
+
+void
+pgagroal_json_put_size_value(struct json* res, char* key, unsigned int bytes)
+{
+   struct json* obj = NULL;
+   char str_buf[MISC_LENGTH];
+
+   memset(str_buf, 0, MISC_LENGTH);
+
+   if (pgagroal_json_create(&obj))
+   {
+      pgagroal_json_put(res, key, (uintptr_t)bytes, ValueInt64);
+      return;
+   }
+
+   pgagroal_json_put(obj, "value", (uintptr_t)bytes, ValueInt64);
+   snprintf(str_buf, MISC_LENGTH, "%uB", bytes);
+   pgagroal_json_put(obj, "string_value", (uintptr_t)str_buf, ValueString);
+
+   pgagroal_json_put(res, key, (uintptr_t)obj, ValueJSON);
+}
+
 static bool
 type_allowed(enum value_type type)
 {

--- a/test/testcases/test_configuration.c
+++ b/test/testcases/test_configuration.c
@@ -28,6 +28,7 @@
  */
 #include <pgagroal.h>
 #include <configuration.h>
+#include <json.h>
 #include <tscommon.h>
 #include <mctf.h>
 #include <utils.h>
@@ -531,5 +532,109 @@ MCTF_TEST(test_configuration_server_section_keys)
    MCTF_ASSERT_INT_EQ(ret, 1, cleanup, "primary=maybe should be rejected in server section");
 
 cleanup:
+   MCTF_FINISH();
+}
+
+static int
+test_enum_to_str(char* where, int value)
+{
+   if (!where)
+   {
+      return 1;
+   }
+
+   switch (value)
+   {
+      case 0:
+         snprintf(where, MISC_LENGTH, "%s", "off");
+         break;
+      case 1:
+         snprintf(where, MISC_LENGTH, "%s", "foreground");
+         break;
+      case 2:
+         snprintf(where, MISC_LENGTH, "%s", "background");
+         break;
+      default:
+         return 1;
+   }
+
+   return 0;
+}
+
+MCTF_TEST(test_configuration_json_put_enum_value)
+{
+   struct json* res = NULL;
+   struct json* nested = NULL;
+
+   pgagroal_json_create(&res);
+
+   pgagroal_json_put_enum_value(res, "validation", 1, test_enum_to_str);
+
+   nested = (struct json*)pgagroal_json_get(res, "validation");
+   MCTF_ASSERT_PTR_NONNULL(nested, cleanup, "nested object should exist");
+   MCTF_ASSERT(pgagroal_json_contains_key(nested, "value"), cleanup, "should contain 'value' key");
+   MCTF_ASSERT(pgagroal_json_contains_key(nested, "string_value"), cleanup, "should contain 'string_value' key");
+   MCTF_ASSERT_INT_EQ((int)pgagroal_json_get(nested, "value"), 1, cleanup, "value should be 1");
+   MCTF_ASSERT_STR_EQ((char*)pgagroal_json_get(nested, "string_value"), "foreground", cleanup, "string_value should be 'foreground'");
+
+cleanup:
+   pgagroal_json_destroy(res);
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_configuration_json_put_time_value)
+{
+   struct json* res = NULL;
+   struct json* nested = NULL;
+
+   pgagroal_json_create(&res);
+
+   // Seconds
+   pgagroal_json_put_time_value(res, "idle_timeout", PGAGROAL_TIME_SEC(30), FORMAT_TIME_S);
+
+   nested = (struct json*)pgagroal_json_get(res, "idle_timeout");
+   MCTF_ASSERT_PTR_NONNULL(nested, cleanup, "seconds: nested object should exist");
+
+   MCTF_ASSERT(pgagroal_json_contains_key(nested, "value"), cleanup, "seconds: should contain 'value' key");
+   MCTF_ASSERT(pgagroal_json_contains_key(nested, "string_value"), cleanup, "seconds: should contain 'string_value' key");
+
+   MCTF_ASSERT_INT_EQ((int)pgagroal_json_get(nested, "value"), 30, cleanup, "seconds: value should be 30");
+   MCTF_ASSERT_STR_EQ((char*)pgagroal_json_get(nested, "string_value"), "30s", cleanup, "seconds: string_value should be '30s'");
+
+   // Minutes
+   pgagroal_json_put_time_value(res, "blocking_timeout", PGAGROAL_TIME_MIN(5), FORMAT_TIME_MIN);
+
+   nested = (struct json*)pgagroal_json_get(res, "blocking_timeout");
+   MCTF_ASSERT_PTR_NONNULL(nested, cleanup, "minutes: nested object should exist");
+
+   MCTF_ASSERT(pgagroal_json_contains_key(nested, "value"), cleanup, "minutes: should contain 'value' key");
+   MCTF_ASSERT(pgagroal_json_contains_key(nested, "string_value"), cleanup, "minutes: should contain 'string_value' key");
+
+   MCTF_ASSERT_INT_EQ((int)pgagroal_json_get(nested, "value"), 5, cleanup, "minutes: value should be 5");
+   MCTF_ASSERT_STR_EQ((char*)pgagroal_json_get(nested, "string_value"), "5m", cleanup, "minutes: string_value should be '5m'");
+
+cleanup:
+   pgagroal_json_destroy(res);
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_configuration_json_put_size_value)
+{
+   struct json* res = NULL;
+   struct json* nested = NULL;
+
+   pgagroal_json_create(&res);
+
+   pgagroal_json_put_size_value(res, "buffer_size", 4096);
+
+   nested = (struct json*)pgagroal_json_get(res, "buffer_size");
+   MCTF_ASSERT_PTR_NONNULL(nested, cleanup, "nested object should exist");
+   MCTF_ASSERT(pgagroal_json_contains_key(nested, "value"), cleanup, "should contain 'value' key");
+   MCTF_ASSERT(pgagroal_json_contains_key(nested, "string_value"), cleanup, "should contain 'string_value' key");
+   MCTF_ASSERT_INT_EQ((int)pgagroal_json_get(nested, "value"), 4096, cleanup, "value should be 4096");
+   MCTF_ASSERT_STR_EQ((char*)pgagroal_json_get(nested, "string_value"), "4096B", cleanup, "string_value should be '4096B'");
+
+cleanup:
+   pgagroal_json_destroy(res);
    MCTF_FINISH();
 }


### PR DESCRIPTION
resolved #841

## Changes
1. Add `pgagroal_json_put_enum_value()`, `pgagroal_json_put_time_value()`, and `pgagroal_json_put_size_value()` to format Enum, Time, and Size parameters as structured objects (`{"value": N, "string_value": "..."}`)
2. Update the configuration response to emit these enriched structured objects instead of raw numeric values
3. Modify the CLI parser to extract the human-readable string for standard text output, while preserving the full structured objects for the management JSON output

## Test
```
% pgagroal-cli conf get validation
off

% pgagroal-cli conf get idle_timeout
600s

% pgagroal-cli json conf get hugepage
{
  "Header": {
    "ClientVersion": "2.1.0",
    "Command": 3,
    "Compression": 0,
    "Encryption": 0,
    "Output": 1,
    "Timestamp": "20260410092744"
  },
  "Outcome": {
    "Status": true,
    "Time": "00:00:00"
  },
  "Request": {},
  "Response": {
    "hugepage": {
      "string_value": "try",
      "value": 1
    }
  }
}
```