### PR TITLE
Improve documentation for pipeline behavior and defaults

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -64,13 +64,13 @@ The available keys and their accepted values are reported in the table below.
 | rotate_frontend_password_timeout | 0 | String | No | The amount of time after which the passwords of frontend users are updated periodically. If this value is specified without units, it is taken as seconds. It supports the following units as suffixes: 's' for seconds (default), 'm' for minutes, 'h' for hours, 'd' for days, and 'w' for weeks. (disable = 0) |
 | rotate_frontend_password_length | 8 | Int | No | The length of the randomized frontend password |
 | max_connection_age | 0 | String | No | The maximum amount of time that a connection will live. If this value is specified without units, it is taken as seconds. It supports the following units as suffixes: 's' for seconds (default), 'm' for minutes, 'h' for hours, 'd' for days, and 'w' for weeks. (disable = 0) |
-| validation | `off` | String | No | Should connection validation be performed. Valid options: `off`, `foreground` and `background` |
+| validation | `off` | String | No | Should connection validation be performed. Valid options: `off`, `foreground` and `background`. With the default `off`, connections are not actively checked before reuse and stale or broken connections can be handed to clients. Set to `background` to have a periodic scan validate idle connections, or to `foreground` to validate a connection before it is handed out. |
 | background_interval | 300s | String | No | The interval between background validation scans. If this value is specified without units, it is taken as seconds. It supports the following units as suffixes: 's' for seconds (default), 'm' for minutes, 'h' for hours, 'd' for days, and 'w' for weeks. |
 | max_retries | 5 | Int | No | The maximum number of iterations to obtain a connection |
 | max_connections | 100 | Int | No | The maximum number of connections to PostgreSQL (max 10000) |
-| allow_unknown_users | `true` | Bool | No | Allow unknown users to connect |
+| allow_unknown_users | `true` | Bool | No | Allow unknown users to connect. The default is `true`, which permits clients whose user is not listed in `pgagroal_users.conf` to reach the pooler and authenticate against PostgreSQL. Set to `false` to reject unknown users at the pooler. This setting is not supported by the transaction pipeline. |
 | authentication_timeout | 5s | String | No | The amount of time the process will wait for valid credentials. If this value is specified without units, it is taken as seconds. It supports the following units as suffixes: 's' for seconds (default), 'm' for minutes, 'h' for hours, 'd' for days, and 'w' for weeks. |
-| pipeline | `auto` | String | No | The pipeline type (`auto`, `performance`, `session`, `transaction`) |
+| pipeline | `auto` | String | No | The pipeline type (`auto`, `performance`, `session`, `transaction`). With `auto`, the performance pipeline is selected by default and pgagroal downgrades to the session pipeline when `tls`, `failover`, or `disconnect_client` is enabled. See [PIPELINES.md](./PIPELINES.md) for details on each pipeline. |
 | auth_query | `off` | Bool | No | Enable authentication query |
 | failover | `off` | Bool | No | Enable failover support |
 | failover_script | | String | No | The failover script to execute |

--- a/doc/PIPELINES.md
+++ b/doc/PIPELINES.md
@@ -15,6 +15,14 @@ pipeline = auto
 pgagroal will choose either the performance or the session pipeline
 based on the configuration settings by default.
 
+When `pipeline = auto` is used, the performance pipeline is selected by
+default. pgagroal downgrades to the session pipeline at startup when any
+of the following are configured:
+
+* `tls = on`
+* `failover = on`
+* `disconnect_client` is greater than 0
+
 # Performance
 
 The performance pipeline is fastest pipeline as it is a minimal implementation
@@ -94,16 +102,31 @@ __Performance considerations__
 Clients may need to wait for a connection between transactions leading to a higher
 latency.
 
-__Important__
+__Important behavioral differences__
 
-Make sure that the `blocking_timeout` settings to set to 0. Otherwise active clients
-may timeout during their workload. Likewise it is best to disable idle connection timeout 
-and max connection age by setting `idle_timeout` and `max_connection_age` to 0.
+The transaction pipeline has several behaviors that differ from the session
+and performance pipelines. Users should be aware of these before enabling
+it.
+
+* `max_connection_age` does not terminate transaction-mode connections on
+  return to the pool or from the periodic reaper. It is only applied to
+  transaction-mode connections indirectly via the validation path when
+  `validation = foreground` or `validation = background`.
+* `idle_timeout` does not terminate transaction-mode connections from the
+  periodic reaper. It is only applied via the validation path.
+* `blocking_timeout` applies to the transaction pipeline. If the pool is
+  exhausted, active clients may time out during their workload. Set
+  `blocking_timeout = 0` for the transaction pipeline.
+* `DISCARD ALL` is not issued when a connection is returned to the pool in
+  transaction mode. Session state such as `SET`, temporary tables and
+  cursors is not reset between clients sharing the same backend
+  connection.
+* The `disconnect_client` and `allow_unknown_users` settings are not
+  supported.
 
 It is highly recommended that you prefill all connections for each user.
-
-The transaction pipeline doesn't support the `disconnect_client` or
-`allow_unknown_users` settings.
+Because `idle_timeout` and `max_connection_age` have limited effect in
+transaction mode, it is best to set both to 0.
 
 Select the transaction pipeline by
 

--- a/doc/manual/en/04-configuration.md
+++ b/doc/manual/en/04-configuration.md
@@ -46,13 +46,13 @@ The available keys and their accepted values are reported in the table below.
 | rotate_frontend_password_timeout | 0 | String | No | The amount of time after which the passwords of frontend users are updated periodically. If this value is specified without units, it is taken as seconds. It supports the following units as suffixes: 'S' for seconds (default), 'M' for minutes, 'H' for hours, 'D' for days, and 'W' for weeks. (disable = 0) |
 | rotate_frontend_password_length | 8 | Int | No | The length of the randomized frontend password |
 | max_connection_age | 0 | String | No | The maximum amount of time that a connection will live. If this value is specified without units, it is taken as seconds. It supports the following units as suffixes: 'S' for seconds (default), 'M' for minutes, 'H' for hours, 'D' for days, and 'W' for weeks. (disable = 0) |
-| validation | `off` | String | No | Should connection validation be performed. Valid options: `off`, `foreground` and `background` |
+| validation | `off` | String | No | Should connection validation be performed. Valid options: `off`, `foreground` and `background`. With the default `off`, connections are not actively checked before reuse and stale or broken connections can be handed to clients. Set to `background` to have a periodic scan validate idle connections, or to `foreground` to validate a connection before it is handed out. |
 | background_interval | 300 | String | No | The interval between background validation scans. If this value is specified without units, it is taken as seconds. It supports the following units as suffixes: 'S' for seconds (default), 'M' for minutes, 'H' for hours, 'D' for days, and 'W' for weeks. |
 | max_retries | 5 | Int | No | The maximum number of iterations to obtain a connection |
 | max_connections | 100 | Int | No | The maximum number of connections to PostgreSQL (max 10000) |
-| allow_unknown_users | `true` | Bool | No | Allow unknown users to connect |
+| allow_unknown_users | `true` | Bool | No | Allow unknown users to connect. The default is `true`, which permits clients whose user is not listed in `pgagroal_users.conf` to reach the pooler and authenticate against PostgreSQL. Set to `false` to reject unknown users at the pooler. This setting is not supported by the transaction pipeline. |
 | authentication_timeout | 5 | String | No | The amount of time the process will wait for valid credentials. If this value is specified without units, it is taken as seconds. It supports the following units as suffixes: 'S' for seconds (default), 'M' for minutes, 'H' for hours, 'D' for days, and 'W' for weeks. |
-| pipeline | `auto` | String | No | The pipeline type (`auto`, `performance`, `session`, `transaction`) |
+| pipeline | `auto` | String | No | The pipeline type (`auto`, `performance`, `session`, `transaction`). With `auto`, the performance pipeline is selected by default and pgagroal downgrades to the session pipeline when `tls`, `failover`, or `disconnect_client` is enabled. See [Pipelines](./17-pipelines.md) for details on each pipeline. |
 | auth_query | `off` | Bool | No | Enable authentication query |
 | failover | `off` | Bool | No | Enable failover support |
 | failover_script | | String | No | The failover script to execute |

--- a/doc/manual/en/17-pipelines.md
+++ b/doc/manual/en/17-pipelines.md
@@ -10,8 +10,13 @@ The pipeline is defined in `pgagroal.conf` under the setting:
 pipeline = auto
 ```
 
-[**pgagroal**][pgagroal] will choose either the performance or the session pipeline
-based on the configuration settings by default.
+When `pipeline = auto` is used, the performance pipeline is selected by
+default. [**pgagroal**][pgagroal] downgrades to the session pipeline at
+startup when any of the following are configured:
+
+* `tls = on`
+* `failover = on`
+* `disconnect_client` is greater than 0
 
 ## Performance Pipeline
 


### PR DESCRIPTION
## Summary

- Document behavioral differences of the transaction pipeline: `max_size`, `max_connection_age`, `idle_timeout`, `blocking_timeout`, and the absence of `DISCARD ALL` on return.
- Document the `pipeline = auto` selection rules (fallback to session when `tls`, `failover`, or `disconnect_client` is set).
- Clarify the defaults and effect of `validation` and `allow_unknown_users` in `CONFIGURATION.md`.

## Test plan

- [ ] Render `doc/PIPELINES.md` and `doc/CONFIGURATION.md` and verify the new content is readable.
- [ ] Confirm there are no broken links.