### PR TITLE
Log pipeline=auto fallback to session pipeline

### DIFF
--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -717,6 +717,9 @@ pgagroal_validate_configuration(void* shm, bool has_unix_socket, bool has_main_s
 
       if (config->failover || tls || config->disconnect_client > 0)
       {
+         const char* reason = config->failover ? "failover is enabled" : tls ? "TLS is enabled"
+                                                                             : "disconnect_client is enabled";
+         pgagroal_log_info("pgagroal: pipeline=auto selected session pipeline because %s", reason);
          config->pipeline = PIPELINE_SESSION;
       }
       else


### PR DESCRIPTION
## Summary

When `pipeline = auto` resolves to the session pipeline because `failover`, `tls`, or `disconnect_client` is enabled, pgagroal currently performs this fallback silently. This PR adds a single `log_info` at startup identifying the trigger.

Behavior is unchanged — only visibility is improved. The log line is emitted once at configuration validation, not per connection.

Example output:

```
pgagroal: pipeline=auto selected session pipeline because failover is enabled
pgagroal: pipeline=auto selected session pipeline because TLS is enabled
pgagroal: pipeline=auto selected session pipeline because disconnect_client is enabled
```

Only one line is emitted — the first matching reason in the order `failover` → `TLS` → `disconnect_client`.

`INFO` was chosen over `WARN` because the fallback may be deliberate when any of these features is enabled; operators should simply be able to see which pipeline is actually in use and why.

## Test plan

- [ ] Start pgagroal with `pipeline = auto` and `failover = on`; confirm the new log line is emitted.
- [ ] Start pgagroal with `pipeline = auto` and `tls = on` with cert/key configured; confirm the new log line is emitted.
- [ ] Start pgagroal with `pipeline = auto` and `disconnect_client > 0`; confirm the new log line is emitted.
- [ ] Start pgagroal with `pipeline = auto` and none of the above; confirm no line is emitted and performance pipeline is selected.