### PR TITLE
[#710] Fix system_identifier fatal check for non-primary duplicates

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -121,6 +121,15 @@ There can be up to `64` host sections, each with an unique name and different co
 
 Note, that if `host` starts with a `/` it represents a path and [**pgagroal**](https://github.com/pgagroal/pgagroal) will connect using a Unix Domain Socket.
 
+### system_identifier duplicate behavior
+
+At startup, pgagroal validates each configured server's PostgreSQL `system_identifier` when `startup_validation` is enabled (subject to the configured `health_check_user` mode).
+
+- If two non-primary servers (`primary = off`) report the same `system_identifier`, startup validation fails.
+- If a duplicate pair includes a server configured with `primary = on`, startup validation does not fail for that pair.
+
+This behavior is consistent with PostgreSQL replication semantics: a standby created from a primary backup remains part of the same cluster and therefore shares the same `system_identifier` as its primary.
+
 # pgagroal_hba configuration
 
 The `pgagroal_hba` configuration controls access to [**pgagroal**](https://github.com/pgagroal/pgagroal) through host-based authentication.

--- a/doc/manual/en/04-configuration.md
+++ b/doc/manual/en/04-configuration.md
@@ -104,6 +104,15 @@ There can be up to `64` host sections, each with an unique name and different co
 
 Note, that if `host` starts with a `/` it represents a path and [**pgagroal**](https://github.com/pgagroal/pgagroal) will connect using a Unix Domain Socket.
 
+### system_identifier duplicate behavior
+
+At startup, pgagroal checks each configured server's PostgreSQL `system_identifier` when `startup_validation` is enabled (and `health_check_user` is configured according to the selected mode).
+
+- If two non-primary servers (`primary = off`) expose the same `system_identifier`, startup validation fails.
+- If a duplicate pair includes a server with `primary = on`, startup validation does not fail for that pair.
+
+This behavior is consistent with PostgreSQL replication semantics: a standby created from a primary backup remains part of the same cluster and therefore shares the same `system_identifier` as its primary.
+
 ## pgagroal_hba.conf
 
 The `pgagroal_hba` configuration controls access to [**pgagroal**](https://github.com/pgagroal/pgagroal) through host-based authentication.

--- a/src/libpgagroal/server.c
+++ b/src/libpgagroal/server.c
@@ -123,18 +123,24 @@ pgagroal_check_server_identifiers(void)
 
    for (int i = 0; i < num_servers; i++)
    {
-      if (!strlen(identifiers[i]))
+      signed char state_i = atomic_load(&config->servers[i].state);
+
+      if (!strlen(identifiers[i]) ||
+          state_i == SERVER_PRIMARY ||
+          state_i == SERVER_NOTINIT_PRIMARY)
       {
          continue;
       }
-
       for (int j = i + 1; j < num_servers; j++)
       {
-         if (!strlen(identifiers[j]))
+         signed char state_j = atomic_load(&config->servers[j].state);
+
+         if (!strlen(identifiers[j]) ||
+             state_j == SERVER_PRIMARY ||
+             state_j == SERVER_NOTINIT_PRIMARY)
          {
             continue;
          }
-
          if (!strcmp(identifiers[i], identifiers[j]))
          {
             pgagroal_log_fatal("Servers [%s] (%s:%d) and [%s] (%s:%d) have the same system_identifier (%s) "

--- a/test/conf/15/pgagroal.conf
+++ b/test/conf/15/pgagroal.conf
@@ -1,0 +1,15 @@
+[pgagroal]
+host = localhost
+port = 2345
+unix_socket_dir = /tmp/
+startup_validation = on
+health_check_user = postgres
+
+[rachel]
+host = 127.0.0.1
+port = 5432
+primary = on
+
+[ross]
+host = 127.0.0.1
+port = 5433

--- a/test/conf/16/pgagroal.conf
+++ b/test/conf/16/pgagroal.conf
@@ -1,0 +1,14 @@
+[pgagroal]
+host = localhost
+port = 2345
+unix_socket_dir = /tmp/
+startup_validation = on
+health_check_user = postgres
+
+[rachel]
+host = 127.0.0.1
+port = 5432
+
+[ross]
+host = 127.0.0.1
+port = 5433

--- a/test/testcases/test_startup_validation.c
+++ b/test/testcases/test_startup_validation.c
@@ -146,49 +146,77 @@ cleanup:
    MCTF_FINISH();
 }
 
-// duplicate system_identifier detection (same cluster, different server names)
-MCTF_TEST(test_server_validation_duplicate_system_identifier)
+// duplicate system_identifier with primary=on + primary=off: should pass
+MCTF_TEST(test_server_validation_duplicate_system_identifier_primary_on_off)
 {
    struct main_configuration* config;
+   struct main_configuration backup;
+   char path[MAX_PATH];
    int ret;
-   int orig_count;
-   struct server orig_servers[NUMBER_OF_SERVERS];
-   char orig_health_check_user[MAX_USERNAME_LENGTH];
 
    config = (struct main_configuration*)shmem;
 
    /* Save original state */
-   orig_count = config->number_of_servers;
-   memcpy(orig_servers, config->servers, sizeof(orig_servers));
-   memcpy(orig_health_check_user, config->health_check_user, MAX_USERNAME_LENGTH);
+   memcpy(&backup, config, sizeof(struct main_configuration));
 
-   /* Set health_check_user to postgres */
-   snprintf(config->health_check_user, MAX_USERNAME_LENGTH, "postgres");
+   MCTF_ASSERT(build_test_conf_path("15", path, sizeof(path)) == 0,
+               cleanup, "Failed to build config path");
 
-   /* Set up two servers pointing to the same instance */
-   config->number_of_servers = 2;
-   memset(&config->servers[0], 0, sizeof(struct server));
-   memset(&config->servers[1], 0, sizeof(struct server));
+   pgagroal_init_configuration(config);
+   ret = pgagroal_read_configuration(config, path, false);
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "pgagroal_read_configuration should succeed");
 
-   snprintf(config->servers[0].name, MISC_LENGTH, "server_a");
-   snprintf(config->servers[0].host, MISC_LENGTH, "%s", orig_servers[0].host);
-   config->servers[0].port = orig_servers[0].port;
-
-   snprintf(config->servers[1].name, MISC_LENGTH, "server_b");
-   snprintf(config->servers[1].host, MISC_LENGTH, "%s", orig_servers[0].host);
-   config->servers[1].port = orig_servers[0].port;
+   /* Point both servers to the same live instance to force equal system_identifier */
+   snprintf(config->servers[0].host, MISC_LENGTH, "%s", backup.servers[0].host);
+   config->servers[0].port = backup.servers[0].port;
+   snprintf(config->servers[1].host, MISC_LENGTH, "%s", backup.servers[0].host);
+   config->servers[1].port = backup.servers[0].port;
 
    ret = pgagroal_check_server_identifiers();
 
-   /* Restore original config */
-   config->number_of_servers = orig_count;
-   memcpy(config->servers, orig_servers, sizeof(orig_servers));
-   memcpy(config->health_check_user, orig_health_check_user, MAX_USERNAME_LENGTH);
-
-   MCTF_ASSERT(ret != 0, cleanup,
-               "check_server_identifiers should fail for two servers pointing to the same cluster");
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup,
+                      "check_server_identifiers should pass when only one duplicate is primary");
 
 cleanup:
+   /* Restore original config */
+   memcpy(config, &backup, sizeof(struct main_configuration));
+   MCTF_FINISH();
+}
+
+// duplicate system_identifier with primary=off + primary=off: should fail
+MCTF_TEST(test_server_validation_duplicate_system_identifier_primary_off_off)
+{
+   struct main_configuration* config;
+   struct main_configuration backup;
+   char path[MAX_PATH];
+   int ret;
+
+   config = (struct main_configuration*)shmem;
+
+   /* Save original state */
+   memcpy(&backup, config, sizeof(struct main_configuration));
+
+   MCTF_ASSERT(build_test_conf_path("16", path, sizeof(path)) == 0,
+               cleanup, "Failed to build config path");
+
+   pgagroal_init_configuration(config);
+   ret = pgagroal_read_configuration(config, path, false);
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "pgagroal_read_configuration should succeed");
+
+   /* Point both servers to the same live instance to force equal system_identifier */
+   snprintf(config->servers[0].host, MISC_LENGTH, "%s", backup.servers[0].host);
+   config->servers[0].port = backup.servers[0].port;
+   snprintf(config->servers[1].host, MISC_LENGTH, "%s", backup.servers[0].host);
+   config->servers[1].port = backup.servers[0].port;
+
+   ret = pgagroal_check_server_identifiers();
+
+   MCTF_ASSERT(ret != 0, cleanup,
+               "check_server_identifiers should fail when duplicate non-primary servers share identifier");
+
+cleanup:
+   /* Restore original config */
+   memcpy(config, &backup, sizeof(struct main_configuration));
    MCTF_FINISH();
 }
 


### PR DESCRIPTION
Make duplicate system_identifier fatal only for replica-replica conflicts (primary=off/off). Add coverage for on/off and off/off scenarios and update documentation for validation behavior.