### PR TITLE
[#767] Refactored the configuration set and reload command remove the support for port reloads

### DIFF
--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -293,12 +293,9 @@ The pipeline is defined in [pipeline_transaction.c](../src/libpgagroal/pipeline_
 The main process of [**pgagroal**](https://github.com/pgagroal/pgagroal) supports the following signals `SIGTERM`, `SIGINT` and `SIGALRM`
 as a mechanism for shutting down. The `SIGTRAP` signal will put [**pgagroal**](https://github.com/pgagroal/pgagroal) into graceful shutdown, meaning that
 existing connections are allowed to finish their session. The `SIGABRT` is used to request a core dump (`abort()`).
-The `SIGHUP` signal will trigger a full reload of the configuration. When `SIGHUP` is received, [**pgagroal**](https://github.com/pgagroal/pgagroal) will re-read the configuration from the configuration files on disk and apply any changes that can be handled at runtime. This is the standard way to apply changes made to the configuration files.
+The `SIGHUP` signal will trigger a full reload of the configuration. When `SIGHUP` is received, [**pgagroal**](https://github.com/pgagroal/pgagroal) will re-read the configuration from the configuration files on disk and apply any changes that can be handled at runtime. If a structural configuration change (like a port change) is detected, it will be ignored and a restart will be required to apply it. The in-memory configuration will continue to reflect the running state for these parameters.
 
-In contrast, the `SIGUSR1` signal will trigger a service reload, but **does not** re-read the configuration files. Instead, `SIGUSR1` restarts sockets and listeners using the current in-memory configuration. This is useful for applying certain changes (such as re-opening sockets or refreshing listeners) without modifying or reloading the configuration from disk. Any changes made to the configuration files will **not** be picked up when using `SIGUSR1`; only the configuration already loaded in memory will be used.
-
-Use `SIGHUP` when you want to apply changes from updated configuration files.  
-Use `SIGUSR1` when you want to restart services without changing the current configuration.
+The `SIGUSR1` signal is used to refresh the system-level side effects of the configuration without reading from disk, such as performing log file rotation and managing worker or timer processes (for example health checks and periodic maintenance watchers). It applies changes made directly to shared memory (via `conf set`) to the running instance. Use this to ensure log files are correctly handled by external tools like `logrotate` or to trigger dynamic process management.
 
 The child processes support `SIGQUIT` as a mechanism to shutdown. This will not shutdown the pool itself.
 
@@ -313,11 +310,15 @@ However, some configuration settings requires a full restart of [**pgagroal**](h
 
 * `hugepage`
 * `ev_backend`
-* `log_path`
 * `log_type`
 * `max_connections`
 * `pipeline`
+* `host`
+* `port`
 * `unix_socket_dir`
+* `metrics`
+* `management`
+* `console`
 * `pidfile`
 * Limit rules defined by `pgagroal_databases.conf`
 * TLS rules defined by server section
@@ -373,5 +374,3 @@ A **database alias** in pgagroal allows clients to connect using an alternative 
 - Each database entry in the limits configuration (`pgagroal_databases.conf`) can specify up to eight aliases.
 - When a client connects using an alias, pgagroal transparently maps the alias to the real database name before establishing or reusing a backend connection.
 - Aliases are resolved during both pooled and unpooled connection handling, ensuring that connections are matched and authenticated against the correct backend database.
-
-

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -416,7 +416,7 @@ pgagroal-cli conf set max_connections 1000 --format json
     "message": "Configuration change requires restart. Current values preserved.",
     "requested_value": "1000",
     "restart_required": true,
-    "status": "success_restart_required"
+    "status": "restart_required"
   }
 }
 ```
@@ -426,17 +426,11 @@ pgagroal-cli conf set max_connections 1000 --format json
 ### **Important**
 
 > **Warning:**  
-> When changing critical parameters such as the **main port**, **metrics port**, **management port**, or **unix_socket_dir**, you must choose values carefully.
+> When changing critical structural parameters such as the **main port (host, port)**, **metrics**, **management**, **console**, or **unix_socket_dir**, the changes cannot be applied to the active pooling engine without a restart.
 >
-> If you set a port or socket to a value that is already in use or unavailable, the reload will fail. In this case, the CLI may still report "success" because the configuration was accepted, but the server will **not** be listening on the new port or socket.  
+> In these cases, the CLI will return a **Restart Required** (`status: restart_required`) response and will **not** modify the configuration (neither on disk nor in memory). This ensures that the configuration correctly reflects the actually running state of the daemon. To apply these changes, you must manually edit the configuration files and restart the `pgagroal` service.
 >
-> **How to recover:**  
-> If you accidentally set a port or socket to an unavailable value, simply use the `conf set` command again to set it to a valid, available value. The server process will remain running and can be reconfigured as needed.
->
-> **Recommendation:**  
-> - Avoid setting ports or sockets to values that are already in use by other services.
-> - Always verify the availability of the desired port or socket before applying changes.
-> - Review server logs for detailed error messages if a configuration change does not take effect as expected.
+> Note: The `conf set` command is **in-memory only**; it does not persist changes to the configuration files on disk.
 >
 > **Multiple Entries in `limit` or `hba`:**  
 > If your configuration contains multiple entries with the **same database name** in the `limit` section or the **same username** in the `hba` section,  

--- a/doc/manual/en/14-cli-tools.md
+++ b/doc/manual/en/14-cli-tools.md
@@ -322,12 +322,11 @@ Configuration change failed
 ```
 
 > **Warning:**  
-> When changing critical parameters such as the **main port**, **metrics port**, **management port**, or **unix_socket_dir**, you must choose values carefully.
+> When changing critical structural parameters such as the **main port (host, port)**, **metrics**, **management**, **console**, or **unix_socket_dir**, the changes cannot be applied to the active pooling engine without a restart.
 >
-> If you set a port or socket to a value that is already in use or unavailable, the reload will fail. In this case, the CLI may still report "success" because the configuration was accepted, but the server will **not** be listening on the new port or socket.
+> In these cases, the CLI will return a **Restart Required** (`status: restart_required`) response and will **not** modify the configuration (neither on disk nor in memory). This ensures that the configuration correctly reflects the actually running state of the daemon. To apply these changes, you must manually edit the configuration files and restart the `pgagroal` service.
 >
-> **How to recover:**  
-> If you accidentally set a port or socket to an unavailable value, simply use the `conf set` command again to set it to a valid, available value.
+> Note: The `conf set` command is **in-memory only**; it does not persist changes to the configuration files on disk.
 >
 > **Multiple Entries in `limit` or `hba`:**  
 > If your configuration contains multiple entries with the **same database name** in the `limit` section or the **same username** in the `hba` section, **the `conf set` command will apply the change to the first matching entry** (topmost in the configuration file).

--- a/doc/manual/en/72-architecture.md
+++ b/doc/manual/en/72-architecture.md
@@ -275,9 +275,9 @@ The pipeline is defined in [pipeline_transaction.c](../src/libpgagroal/pipeline_
 The main process of [**pgagroal**](https://github.com/pgagroal/pgagroal) supports the following signals `SIGTERM`, `SIGINT` and `SIGALRM`
 as a mechanism for shutting down. The `SIGTRAP` signal will put [**pgagroal**](https://github.com/pgagroal/pgagroal) into graceful shutdown, meaning that
 existing connections are allowed to finish their session. The `SIGABRT` is used to request a core dump (`abort()`).
-The `SIGHUP` signal will trigger a full reload of the configuration. When `SIGHUP` is received, [**pgagroal**](https://github.com/pgagroal/pgagroal) will re-read the configuration from the configuration files on disk and apply any changes that can be handled at runtime. This is the standard way to apply changes made to the configuration files.
+The `SIGHUP` signal will trigger a full reload of the configuration. When `SIGHUP` is received, [**pgagroal**](https://github.com/pgagroal/pgagroal) will re-read the configuration from the configuration files on disk and apply any changes that can be handled at runtime. If a structural configuration change (like a port change) is detected, it will be ignored and a restart will be required to apply it. The in-memory configuration will continue to reflect the running state for these parameters.
 
-In contrast, the `SIGUSR1` signal will trigger a service reload, but **does not** re-read the configuration files. Instead, `SIGUSR1` restarts sockets and listeners using the current in-memory configuration. This is useful for applying certain changes (such as re-opening sockets or refreshing listeners) without modifying or reloading the configuration from disk. Any changes made to the configuration files will **not** be picked up when using `SIGUSR1`; only the configuration already loaded in memory will be used.
+The `SIGUSR1` signal is used to refresh the system-level side effects of the configuration without reading from disk, such as performing log file rotation and managing worker or timer processes (for example health checks and periodic maintenance watchers). It applies changes made directly to shared memory (via `conf set`) to the running instance. Use this to ensure log files are correctly handled by external tools like `logrotate` or to trigger dynamic process management.
 
 The child processes support `SIGQUIT` as a mechanism to shutdown. This will not shutdown the pool itself.
 
@@ -291,11 +291,16 @@ The `SIGHUP` signal will trigger a reload of the configuration.
 However, some configuration settings requires a full restart of [**pgagroal**](https://github.com/pgagroal/pgagroal) in order to take effect. These are
 
 * `hugepage`
-* `log_path`
+* `ev_backend`
 * `log_type`
 * `max_connections`
 * `pipeline`
+* `host`
+* `port`
 * `unix_socket_dir`
+* `metrics`
+* `management`
+* `console`
 * `pidfile`
 * Limit rules defined by `pgagroal_databases.conf`
 * TLS rules defined by server section

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -177,7 +177,7 @@ extern "C" {
 #define CONFIGURATION_RESPONSE_NEW_VALUE        "new_value"
 #define CONFIGURATION_RESPONSE_RESTART_REQUIRED "restart_required"
 #define CONFIGURATION_STATUS_SUCCESS            "success"
-#define CONFIGURATION_STATUS_RESTART_REQUIRED   "success_restart_required"
+#define CONFIGURATION_STATUS_RESTART_REQUIRED   "restart_required"
 #define CONFIGURATION_MESSAGE_SUCCESS           "Configuration change applied successfully"
 #define CONFIGURATION_MESSAGE_RESTART_REQUIRED  "Configuration change requires restart. Current values preserved."
 
@@ -423,10 +423,11 @@ pgagroal_validate_superuser_configuration(void* shmem);
 /**
  * Reload the configuration
  * @param reload Should the server be reloaded
+ * @param health_check_changed Set to true if health check settings changed during reload
  * @return 0 upon success, otherwise 1
  */
 int
-pgagroal_reload_configuration(bool* reload);
+pgagroal_reload_configuration(bool* reload, bool* health_check_changed);
 
 /**
  * Automatically initialize the 'pidfile'

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -86,22 +86,22 @@ static int as_seconds(char* str, pgagroal_time_t* result, pgagroal_time_t defaul
 static unsigned int as_bytes(char* str, unsigned int* bytes, unsigned int default_bytes);
 static int extract_alias_with_space(char* str, int offset, char** db_part);
 
-static bool transfer_configuration(struct main_configuration* config, struct main_configuration* reload);
+static bool transfer_configuration(struct main_configuration* config, struct main_configuration* reload, bool* health_check_changed);
 static void copy_server(struct server* dst, struct server* src);
 static void copy_hba(struct hba* dst, struct hba* src);
 static void copy_user(struct user* dst, struct user* src);
 static int restart_int(char* name, int e, int n);
 static int __attribute__((unused)) restart_bool(char* name, bool e, bool n);
-static int restart_time(char* name, pgagroal_time_t e, pgagroal_time_t n, bool requires_restart);
 static int restart_string(char* name, char* e, char* n, bool skip_non_existing);
 static int restart_limit(char* name, struct main_configuration* config, struct main_configuration* reload);
 static int restart_server(struct server* src, struct server* dst);
+static bool health_check_settings_changed(struct main_configuration* config, struct main_configuration* reload);
+static void reset_health_check_state(struct main_configuration* config);
 
 static bool is_empty_string(char* s);
 static bool is_same_server(struct server* s1, struct server* s2);
 static bool is_same_tls(struct server* s1, struct server* s2);
 static bool is_valid_config_key(const char* config_key, struct config_key_info* key_info);
-static void reset_server_failures(void);
 
 static bool key_in_section(char* wanted, char* section, char* key, bool global, bool* unknown);
 static bool is_comment_line(char* line);
@@ -2378,7 +2378,7 @@ pgagroal_validate_superuser_configuration(void* shm __attribute__((unused)))
 }
 
 int
-pgagroal_reload_configuration(bool* r)
+pgagroal_reload_configuration(bool* r, bool* health_check_changed)
 {
    size_t reload_size;
    struct main_configuration* reload = NULL;
@@ -2387,6 +2387,10 @@ pgagroal_reload_configuration(bool* r)
    config = (struct main_configuration*)shmem;
 
    *r = false;
+   if (health_check_changed != NULL)
+   {
+      *health_check_changed = false;
+   }
 
    pgagroal_log_trace("Configuration: %s", config->common.configuration_path);
    pgagroal_log_trace("HBA: %s", config->hba_path);
@@ -2490,7 +2494,7 @@ pgagroal_reload_configuration(bool* r)
       goto error;
    }
 
-   *r = transfer_configuration(config, reload);
+   *r = transfer_configuration(config, reload, health_check_changed);
    // Update certificate metrics after successful reload
    if (config->common.metrics > 0)
    {
@@ -3558,14 +3562,125 @@ extract_alias_with_space(char* str, int offset, char** db_part)
  * @return True, if restart or false if not
  */
 static bool
-transfer_configuration(struct main_configuration* config, struct main_configuration* reload)
+check_restart_required(struct main_configuration* config, struct main_configuration* reload)
 {
-   bool changed = false;
+   bool restart = false;
+
+   if (restart_string("host", config->common.host, reload->common.host, false))
+   {
+      restart = true;
+   }
+   if (restart_int("port", config->common.port, reload->common.port))
+   {
+      restart = true;
+   }
+   if (restart_int("metrics", config->common.metrics, reload->common.metrics))
+   {
+      restart = true;
+   }
+   if (restart_int("metrics_cache_max_size", config->common.metrics_cache_max_size, reload->common.metrics_cache_max_size))
+   {
+      restart = true;
+   }
+   if (restart_int("management", config->management, reload->management))
+   {
+      restart = true;
+   }
+   if (restart_int("console", config->console, reload->console))
+   {
+      restart = true;
+   }
+   if (restart_int("pipeline", config->pipeline, reload->pipeline))
+   {
+      restart = true;
+   }
+   if (restart_int("log_type", config->common.log_type, reload->common.log_type))
+   {
+      restart = true;
+   }
+   if (restart_int("max_connections", config->max_connections, reload->max_connections))
+   {
+      restart = true;
+   }
+   if (restart_string("pidfile", config->pidfile, reload->pidfile, true))
+   {
+      restart = true;
+   }
+   if (restart_int("ev_backend", config->ev_backend, reload->ev_backend))
+   {
+      restart = true;
+   }
+   if (restart_int("hugepage", config->common.hugepage, reload->common.hugepage))
+   {
+      restart = true;
+   }
+   if (restart_string("unix_socket_dir", config->unix_socket_dir, reload->unix_socket_dir, false))
+   {
+      restart = true;
+   }
+   if (restart_bool("tls", config->common.tls, reload->common.tls))
+   {
+      restart = true;
+   }
+
+   if (config->number_of_servers > reload->number_of_servers)
+   {
+      if (restart_int("decreasing number of servers", config->number_of_servers, reload->number_of_servers))
+      {
+         restart = true;
+      }
+   }
+
+   for (int i = 0; i < reload->number_of_servers; i++)
+   {
+      if (i < config->number_of_servers)
+      {
+         if (restart_server(&reload->servers[i], &config->servers[i]))
+         {
+            restart = true;
+         }
+      }
+   }
+
+   if (restart_limit("limits", config, reload))
+   {
+      restart = true;
+   }
+
+   return restart;
+}
+
+static bool
+transfer_configuration(struct main_configuration* config, struct main_configuration* reload, bool* health_check_changed)
+{
+   bool reset_health = false;
 
 #ifdef HAVE_SYSTEMD
    sd_notify(0, "RELOADING=1");
 #endif
 
+   /* Check if any parameter requires a restart before applying any changes */
+   if (check_restart_required(config, reload))
+   {
+      pgagroal_log_warn("Configuration reload denied: restart required for one or more parameters. Running state preserved.");
+#ifdef HAVE_SYSTEMD
+      sd_notify(0, "READY=1");
+#endif
+      return true;
+   }
+
+   reset_health = health_check_settings_changed(config, reload);
+   if (health_check_changed != NULL)
+   {
+      *health_check_changed = reset_health;
+   }
+
+   /* No restart required: apply all changes to the shared memory.
+    * Structural parameters (host, port, metrics, management, console, etc.) are safe
+    * to copy here because check_restart_required() above verified they are unchanged.
+    */
+
+   /* Network resources */
    memcpy(config->common.host, reload->common.host, MISC_LENGTH);
    config->common.port = reload->common.port;
    config->common.metrics = reload->common.metrics;
@@ -3573,40 +3688,26 @@ transfer_configuration(struct main_configuration* config, struct main_configurat
    memcpy(config->common.metrics_key_file, reload->common.metrics_key_file, MAX_PATH);
    memcpy(config->common.metrics_ca_file, reload->common.metrics_ca_file, MAX_PATH);
    config->common.metrics_cache_max_age = reload->common.metrics_cache_max_age;
-   if (restart_int("metrics_cache_max_size", config->common.metrics_cache_max_size, reload->common.metrics_cache_max_size))
-   {
-      changed = true;
-   }
+   config->common.metrics_cache_max_size = reload->common.metrics_cache_max_size;
    config->management = reload->management;
    config->console = reload->console;
-
    config->update_process_title = reload->update_process_title;
 
-   /* gracefully */
-
-   /* disabled */
-
    /* pipeline */
-   if (restart_int("pipeline", config->pipeline, reload->pipeline))
-   {
-      changed = true;
-   }
-
+   config->pipeline = reload->pipeline;
    config->failover = reload->failover;
    memcpy(config->failover_script, reload->failover_script, MISC_LENGTH);
    memcpy(config->failover_notify_script, reload->failover_notify_script, MISC_LENGTH);
 
    /* log_type */
-   if (restart_int("log_type", config->common.log_type, reload->common.log_type))
-   {
-      changed = true;
-   }
+   config->common.log_type = reload->common.log_type;
    config->common.log_level = reload->common.log_level;
 
    /* log_path */
-   // if the log main parameters have changed, we need
-   // to restart the logging system
-   if (strncmp(config->common.log_path, reload->common.log_path, MISC_LENGTH) || config->common.log_rotation_size != reload->common.log_rotation_size || config->common.log_rotation_age.s != reload->common.log_rotation_age.s || config->common.log_mode != reload->common.log_mode)
+   if (strncmp(config->common.log_path, reload->common.log_path, MISC_LENGTH) ||
+       config->common.log_rotation_size != reload->common.log_rotation_size ||
+       config->common.log_rotation_age.s != reload->common.log_rotation_age.s ||
+       config->common.log_mode != reload->common.log_mode)
    {
       pgagroal_log_debug("Log restart triggered!");
       pgagroal_stop_logging();
@@ -3620,9 +3721,6 @@ transfer_configuration(struct main_configuration* config, struct main_configurat
 
    config->common.log_connections = reload->common.log_connections;
    config->common.log_disconnections = reload->common.log_disconnections;
-
-   /* log_lock */
-
    config->authquery = reload->authquery;
 
    config->common.tls = reload->common.tls;
@@ -3639,163 +3737,51 @@ transfer_configuration(struct main_configuration* config, struct main_configurat
       }
    }
 
-   /* active_connections */
-   /* max_connections */
-   if (restart_int("max_connections", config->max_connections, reload->max_connections))
-   {
-      changed = true;
-   }
+   config->max_connections = reload->max_connections;
    config->allow_unknown_users = reload->allow_unknown_users;
-
-   if (restart_time("blocking_timeout", config->blocking_timeout, reload->blocking_timeout, false))
-   {
-      changed = true;
-   }
-
    memcpy(&config->blocking_timeout, &reload->blocking_timeout, sizeof(config->blocking_timeout));
-
-   if (restart_time("idle_timeout", config->idle_timeout, reload->idle_timeout, false))
-   {
-      changed = true;
-   }
-
    memcpy(&config->idle_timeout, &reload->idle_timeout, sizeof(config->idle_timeout));
-
-   if (restart_time("rotate_frontend_password_timeout", config->rotate_frontend_password_timeout, reload->rotate_frontend_password_timeout, false))
-   {
-      changed = true;
-   }
-
    memcpy(&config->rotate_frontend_password_timeout, &reload->rotate_frontend_password_timeout, sizeof(config->rotate_frontend_password_timeout));
-
    config->rotate_frontend_password_length = reload->rotate_frontend_password_length;
-
-   if (restart_time("max_connection_age", config->max_connection_age, reload->max_connection_age, false))
-   {
-      changed = true;
-   }
-
    memcpy(&config->max_connection_age, &reload->max_connection_age, sizeof(config->max_connection_age));
-
    config->validation = reload->validation;
-
-   if (restart_time("background_interval", config->background_interval, reload->background_interval, false))
-   {
-      changed = true;
-   }
-
    memcpy(&config->background_interval, &reload->background_interval, sizeof(config->background_interval));
-
    config->max_retries = reload->max_retries;
-
-   if (restart_time("authentication_timeout", config->common.authentication_timeout, reload->common.authentication_timeout, false))
-   {
-      changed = true;
-   }
-
    memcpy(&config->common.authentication_timeout, &reload->common.authentication_timeout, sizeof(config->common.authentication_timeout));
-
    config->disconnect_client = reload->disconnect_client;
    config->disconnect_client_force = reload->disconnect_client_force;
 
    /* Health Check */
-   if (restart_bool("health_check", config->health_check, reload->health_check))
-   {
-      reset_server_failures();
-      changed = true;
-   }
-
-   if (restart_time("health_check_period", config->health_check_period, reload->health_check_period, true))
-   {
-      reset_server_failures();
-      changed = true;
-   }
-
-   if (restart_time("health_check_timeout", config->health_check_timeout, reload->health_check_timeout, true))
-   {
-      reset_server_failures();
-      changed = true;
-   }
-
    config->health_check = reload->health_check;
    memcpy(&config->health_check_period, &reload->health_check_period, sizeof(config->health_check_period));
    memcpy(&config->health_check_timeout, &reload->health_check_timeout, sizeof(config->health_check_timeout));
-
-   if (restart_string("health_check_user", config->health_check_user, reload->health_check_user, true))
-   {
-      reset_server_failures();
-      changed = true;
-   }
-
    memcpy(config->health_check_user, reload->health_check_user, MAX_USERNAME_LENGTH);
 
    config->startup_validation = reload->startup_validation;
-
-   /* pidfile */
-   if (restart_string("pidfile", config->pidfile, reload->pidfile, true))
-   {
-      changed = true;
-   }
-
-   /* event backend */
-   if (restart_int("ev_backend", config->ev_backend, reload->ev_backend))
-   {
-      changed = true;
-   }
-
+   memcpy(config->pidfile, reload->pidfile, MAX_PATH);
+   config->ev_backend = reload->ev_backend;
    config->keep_alive = reload->keep_alive;
    config->nodelay = reload->nodelay;
    config->backlog = reload->backlog;
-
-   /* hugepage */
-   if (restart_int("hugepage", config->common.hugepage, reload->common.hugepage))
-   {
-      changed = true;
-   }
+   config->common.hugepage = reload->common.hugepage;
    config->tracker = reload->tracker;
    config->track_prepared_statements = reload->track_prepared_statements;
+   memcpy(config->unix_socket_dir, reload->unix_socket_dir, MISC_LENGTH);
 
-   /* unix_socket_dir */
-
-   // does make sense to check for remote connections? Because in the case the Unix socket dir
-   // changes the pgagroal-cli probably will not be able to connect in any case!
-   if (restart_string("unix_socket_dir", config->unix_socket_dir, reload->unix_socket_dir, false))
-   {
-      changed = true;
-   }
-
-   /* su_connection */
-
-   /* states */
-
-   // decreasing the number of servers is probably a bad idea
-   if (config->number_of_servers > reload->number_of_servers)
-   {
-      if (restart_int("decreasing number of servers", config->number_of_servers, reload->number_of_servers))
-      {
-         changed = true;
-      }
-   }
-
+   /* Servers */
    for (int i = 0; i < reload->number_of_servers; i++)
    {
-      // check and emit restart warning only for not-added servers
-      if (i < config->number_of_servers)
-      {
-         if (restart_server(&reload->servers[i], &config->servers[i]))
-         {
-            changed = true;
-         }
-      }
-
       copy_server(&config->servers[i], &reload->servers[i]);
    }
    config->number_of_servers = reload->number_of_servers;
+   memset(&config->servers[config->number_of_servers], 0, sizeof(struct server) * (NUMBER_OF_SERVERS - config->number_of_servers));
 
-   // zero fill remaining memory that is unused
-   memset(&config->servers[config->number_of_servers], 0,
-          sizeof(struct server) * (NUMBER_OF_SERVERS - config->number_of_servers));
+   if (reset_health)
+   {
+      reset_health_check_state(config);
+   }
 
+   /* HBAs */
    memset(&config->hbas[0], 0, sizeof(struct hba) * NUMBER_OF_HBAS);
    for (int i = 0; i < reload->number_of_hbas; i++)
    {
@@ -3803,31 +3789,15 @@ transfer_configuration(struct main_configuration* config, struct main_configurat
    }
    config->number_of_hbas = reload->number_of_hbas;
 
-   /* number_of_limits */
-   /* limits */
-   if (restart_limit("limits", config, reload))
+   /* Limits */
+   memset(&config->limits[0], 0, sizeof(struct limit) * NUMBER_OF_LIMITS);
+   for (int i = 0; i < reload->number_of_limits; i++)
    {
-      changed = true;
+      copy_limit(&config->limits[i], &reload->limits[i]);
    }
-   else
-   {
-      // Successful reload - copy all limit configurations including aliases
-      for (int i = 0; i < reload->number_of_limits; i++)
-      {
-         copy_limit(&config->limits[i], &reload->limits[i]);
+   config->number_of_limits = reload->number_of_limits;
 
-         // Log alias changes for debugging
-         if (config->limits[i].aliases_count != reload->limits[i].aliases_count)
-         {
-            pgagroal_log_debug("Reloaded aliases for database '%s': count changed from %d to %d",
-                               config->limits[i].database,
-                               config->limits[i].aliases_count,
-                               reload->limits[i].aliases_count);
-         }
-      }
-      config->number_of_limits = reload->number_of_limits;
-   }
-
+   /* Users */
    memset(&config->users[0], 0, sizeof(struct user) * NUMBER_OF_USERS);
    for (int i = 0; i < reload->number_of_users; i++)
    {
@@ -3835,6 +3805,7 @@ transfer_configuration(struct main_configuration* config, struct main_configurat
    }
    config->number_of_users = reload->number_of_users;
 
+   /* Frontend Users */
    memset(&config->frontend_users[0], 0, sizeof(struct user) * NUMBER_OF_USERS);
    for (int i = 0; i < reload->number_of_frontend_users; i++)
    {
@@ -3842,6 +3813,7 @@ transfer_configuration(struct main_configuration* config, struct main_configurat
    }
    config->number_of_frontend_users = reload->number_of_frontend_users;
 
+   /* Admins */
    memset(&config->admins[0], 0, sizeof(struct user) * NUMBER_OF_ADMINS);
    for (int i = 0; i < reload->number_of_admins; i++)
    {
@@ -3849,25 +3821,15 @@ transfer_configuration(struct main_configuration* config, struct main_configurat
    }
    config->number_of_admins = reload->number_of_admins;
 
+   /* Superuser */
    memset(&config->superuser, 0, sizeof(struct user));
    copy_user(&config->superuser, &reload->superuser);
-
-   /* Runtime revalidation: check for duplicate system identifiers after reload */
-   pgagroal_check_server_identifiers(false);
-
-   /* prometheus */
-   /* connections[] */
 
 #ifdef HAVE_SYSTEMD
    sd_notify(0, "READY=1");
 #endif
 
-   if (changed)
-   {
-      pgagroal_log_warn("Settings cannot be applied");
-   }
-
-   return changed;
+   return false;
 }
 
 /**
@@ -4022,21 +3984,42 @@ static void
 copy_server(struct server* dst, struct server* src)
 {
    atomic_schar state;
+   atomic_schar health_state;
+   atomic_schar auth_type;
+   unsigned int failures;
+   int version;
+   int minor_version;
+   char system_identifier[sizeof(dst->system_identifier)];
 
    // check the server cloned "seems" the same
    if (is_same_server(dst, src))
    {
       state = atomic_load(&dst->state);
+      health_state = atomic_load(&dst->health_state);
+      auth_type = atomic_load(&dst->auth_type);
+      failures = dst->failures;
+      version = dst->version;
+      minor_version = dst->minor_version;
+      memcpy(system_identifier, dst->system_identifier, sizeof(system_identifier));
    }
    else
    {
       state = SERVER_NOTINIT;
+      health_state = SERVER_HEALTH_UNKNOWN;
+      auth_type = HEALTH_CHECK_AUTH_UNKNOWN;
+      failures = 0;
+      version = 0;
+      minor_version = 0;
+      memset(system_identifier, 0, sizeof(system_identifier));
    }
 
    memset(dst, 0, sizeof(struct server));
    memcpy(&dst->name[0], &src->name[0], MISC_LENGTH);
    memcpy(&dst->host[0], &src->host[0], MISC_LENGTH);
    dst->port = src->port;
+   dst->version = version;
+   dst->minor_version = minor_version;
+   memcpy(&dst->system_identifier[0], system_identifier, sizeof(dst->system_identifier));
    dst->tls = src->tls;
    memcpy(&dst->tls_cert_file[0], &src->tls_cert_file[0], MAX_PATH);
    memcpy(&dst->tls_key_file[0], &src->tls_key_file[0], MAX_PATH);
@@ -4045,6 +4028,10 @@ copy_server(struct server* dst, struct server* src)
    dst->valid = src->valid;
 
    atomic_init(&dst->state, state);
+   atomic_init(&dst->health_state, health_state);
+   dst->failures = failures;
+   atomic_init(&dst->auth_type, auth_type);
+   dst->lineno = src->lineno;
 }
 
 static void
@@ -4069,31 +4056,8 @@ restart_int(char* name, int e, int n)
 {
    if (e != n)
    {
-      pgagroal_log_info("Restart required for %s - Existing %d New %d", name, e, n);
+      pgagroal_log_warn("Restart required for %s - Existing %d New %d", name, e, n);
       return 1;
-   }
-
-   return 0;
-}
-
-static int
-restart_time(char* name, pgagroal_time_t e, pgagroal_time_t n, bool requires_restart)
-{
-   int64_t old_time = pgagroal_time_convert(e, FORMAT_TIME_S);
-   int64_t new_time = pgagroal_time_convert(n, FORMAT_TIME_S);
-
-   if (old_time != new_time)
-   {
-      if (requires_restart)
-      {
-         pgagroal_log_info("Restart required for %s - Existing %" PRId64 " New %" PRId64, name, old_time, new_time);
-         return 1;
-      }
-      else
-      {
-         pgagroal_log_debug("Reloaded %s - Existing %" PRId64 " New %" PRId64, name, old_time, new_time);
-         return 0;
-      }
    }
 
    return 0;
@@ -4108,7 +4072,7 @@ restart_bool(char* name, bool e, bool n)
 {
    if (e != n)
    {
-      pgagroal_log_info("Restart required for %s - Existing %s New %s", name, e ? "true" : "false", n ? "true" : "false");
+      pgagroal_log_warn("Restart required for %s - Existing %s New %s", name, e ? "true" : "false", n ? "true" : "false");
       return 1;
    }
 
@@ -4138,7 +4102,7 @@ restart_string(char* name, char* e, char* n, bool skip_non_existing)
 
    if (strcmp(e, n))
    {
-      pgagroal_log_info("Restart required for %s - Existing %s New %s", name, e, n);
+      pgagroal_log_warn("Restart required for %s - Existing %s New %s", name, e, n);
       return 1;
    }
 
@@ -4170,7 +4134,7 @@ restart_limit(char* name __attribute__((unused)), struct main_configuration* con
           e->initial_size != n->initial_size ||
           e->min_size != n->min_size)
       {
-         pgagroal_log_info("Restart required for limits");
+         pgagroal_log_warn("Restart required for limits");
          goto error;
       }
 
@@ -4226,6 +4190,51 @@ restart_server(struct server* src, struct server* dst)
    }
 
    return 0;
+}
+
+/**
+ * Checks if health check settings differ between two configurations.
+ * Used during transfer_configuration to decide whether to reset server
+ * health state (failures, health_state, auth_type) and to inform callers
+ * via the health_check_changed output parameter.
+ */
+static bool
+health_check_settings_changed(struct main_configuration* config, struct main_configuration* reload)
+{
+   if (config->health_check != reload->health_check)
+   {
+      return true;
+   }
+
+   if (pgagroal_time_convert(config->health_check_period, FORMAT_TIME_S) !=
+       pgagroal_time_convert(reload->health_check_period, FORMAT_TIME_S))
+   {
+      return true;
+   }
+
+   if (pgagroal_time_convert(config->health_check_timeout, FORMAT_TIME_S) !=
+       pgagroal_time_convert(reload->health_check_timeout, FORMAT_TIME_S))
+   {
+      return true;
+   }
+
+   if (strcmp(config->health_check_user, reload->health_check_user))
+   {
+      return true;
+   }
+
+   return false;
+}
+
+static void
+reset_health_check_state(struct main_configuration* config)
+{
+   for (int i = 0; i < config->number_of_servers; i++)
+   {
+      config->servers[i].failures = 0;
+      atomic_store(&config->servers[i].health_state, SERVER_HEALTH_UNKNOWN);
+      atomic_store(&config->servers[i].auth_type, HEALTH_CHECK_AUTH_UNKNOWN);
+   }
 }
 
 static bool
@@ -5693,6 +5702,7 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
 
    if (key_in_section("host", section, key, true, NULL))
    {
+      memset(config->common.host, 0, MISC_LENGTH);
       max = strlen(value);
       if (max > MISC_LENGTH - 1)
       {
@@ -5702,12 +5712,15 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("host", section, key, false, &unknown))
    {
+      memset(&srv->name, 0, MISC_LENGTH);
       max = strlen(section);
       if (max > MISC_LENGTH - 1)
       {
          max = MISC_LENGTH - 1;
       }
       memcpy(&srv->name, section, max);
+
+      memset(&srv->host, 0, MISC_LENGTH);
       max = strlen(value);
       if (max > MISC_LENGTH - 1)
       {
@@ -5725,6 +5738,7 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("port", section, key, false, &unknown))
    {
+      memset(&srv->name, 0, MISC_LENGTH);
       memcpy(&srv->name, section, strlen(section));
       if (as_int(value, &srv->port))
       {
@@ -5757,6 +5771,7 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("metrics_ca_file", section, key, true, NULL))
    {
+      memset(config->common.metrics_ca_file, 0, MAX_PATH);
       max = strlen(value);
       if (max > MAX_PATH - 1)
       {
@@ -5766,6 +5781,7 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("metrics_cert_file", section, key, true, NULL))
    {
+      memset(config->common.metrics_cert_file, 0, MAX_PATH);
       max = strlen(value);
       if (max > MAX_PATH - 1)
       {
@@ -5775,6 +5791,7 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("metrics_key_file", section, key, true, NULL))
    {
+      memset(config->common.metrics_key_file, 0, MAX_PATH);
       max = strlen(value);
       if (max > MAX_PATH - 1)
       {
@@ -5826,6 +5843,7 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("failover_script", section, key, true, &unknown))
    {
+      memset(config->failover_script, 0, MISC_LENGTH);
       max = strlen(value);
       if (max > MISC_LENGTH - 1)
       {
@@ -5835,6 +5853,7 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("failover_notify_script", section, key, true, &unknown))
    {
+      memset(config->failover_notify_script, 0, MISC_LENGTH);
       max = strlen(value);
       if (max > MISC_LENGTH - 1)
       {
@@ -5868,6 +5887,7 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("tls_ca_file", section, key, true, NULL))
    {
+      memset(config->common.tls_ca_file, 0, MAX_PATH);
       max = strlen(value);
       if (max > MAX_PATH - 1)
       {
@@ -5877,6 +5897,7 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("tls_ca_file", section, key, false, &unknown))
    {
+      memset(srv->tls_ca_file, 0, MAX_PATH);
       max = strlen(value);
       if (max > MAX_PATH - 1)
       {
@@ -5886,6 +5907,7 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("tls_cert_file", section, key, true, NULL))
    {
+      memset(config->common.tls_cert_file, 0, MAX_PATH);
       max = strlen(value);
       if (max > MAX_PATH - 1)
       {
@@ -5895,6 +5917,7 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("tls_cert_file", section, key, false, &unknown))
    {
+      memset(srv->tls_cert_file, 0, MAX_PATH);
       max = strlen(value);
       if (max > MAX_PATH - 1)
       {
@@ -5904,6 +5927,7 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("tls_key_file", section, key, true, NULL))
    {
+      memset(config->common.tls_key_file, 0, MAX_PATH);
       max = strlen(value);
       if (max > MAX_PATH - 1)
       {
@@ -5913,6 +5937,7 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("tls_key_file", section, key, false, &unknown))
    {
+      memset(srv->tls_key_file, 0, MAX_PATH);
       max = strlen(value);
       if (max > MAX_PATH - 1)
       {
@@ -6037,10 +6062,11 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("pidfile", section, key, true, &unknown))
    {
+      memset(config->pidfile, 0, MAX_PATH);
       max = strlen(value);
-      if (max > MISC_LENGTH - 1)
+      if (max > MAX_PATH - 1)
       {
-         max = MISC_LENGTH - 1;
+         max = MAX_PATH - 1;
       }
       memcpy(config->pidfile, value, max);
    }
@@ -6064,6 +6090,7 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("log_path", section, key, true, &unknown))
    {
+      memset(config->common.log_path, 0, MISC_LENGTH);
       max = strlen(value);
       if (max > MISC_LENGTH - 1)
       {
@@ -6087,6 +6114,7 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("log_line_prefix", section, key, true, &unknown))
    {
+      memset(config->common.log_line_prefix, 0, MISC_LENGTH);
       max = strlen(value);
       if (max > MISC_LENGTH - 1)
       {
@@ -6125,6 +6153,7 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("unix_socket_dir", section, key, true, &unknown))
    {
+      memset(config->unix_socket_dir, 0, MISC_LENGTH);
       max = strlen(value);
       if (max > MISC_LENGTH - 1)
       {
@@ -6214,6 +6243,7 @@ pgagroal_apply_vault_configuration(struct vault_configuration* config,
 
    if (key_in_section("host", section, key, true, NULL))
    {
+      memset(config->common.host, 0, MISC_LENGTH);
       max = strlen(value);
       if (max > MISC_LENGTH - 1)
       {
@@ -6223,12 +6253,15 @@ pgagroal_apply_vault_configuration(struct vault_configuration* config,
    }
    else if (key_in_section("host", section, key, false, &unknown))
    {
+      memset(&srv->server.name, 0, MISC_LENGTH);
       max = strlen(section);
       if (max > MISC_LENGTH - 1)
       {
          max = MISC_LENGTH - 1;
       }
       memcpy(&srv->server.name, section, max);
+
+      memset(&srv->server.host, 0, MISC_LENGTH);
       max = strlen(value);
       if (max > MISC_LENGTH - 1)
       {
@@ -6245,6 +6278,7 @@ pgagroal_apply_vault_configuration(struct vault_configuration* config,
    }
    else if (key_in_section("port", section, key, false, &unknown))
    {
+      memset(&srv->server.name, 0, MISC_LENGTH);
       memcpy(&srv->server.name, section, strlen(section));
       if (as_int(value, &srv->server.port))
       {
@@ -6257,6 +6291,7 @@ pgagroal_apply_vault_configuration(struct vault_configuration* config,
    }
    else if (key_in_section("user", section, key, false, &unknown))
    {
+      memset(&srv->user.username, 0, MISC_LENGTH);
       max = strlen(value);
       if (max > MISC_LENGTH - 1)
       {
@@ -6273,6 +6308,7 @@ pgagroal_apply_vault_configuration(struct vault_configuration* config,
    }
    else if (key_in_section("tls_ca_file", section, key, true, &unknown))
    {
+      memset(config->common.tls_ca_file, 0, MAX_PATH);
       max = strlen(value);
       if (max > MAX_PATH - 1)
       {
@@ -6282,6 +6318,7 @@ pgagroal_apply_vault_configuration(struct vault_configuration* config,
    }
    else if (key_in_section("tls_cert_file", section, key, true, &unknown))
    {
+      memset(config->common.tls_cert_file, 0, MAX_PATH);
       max = strlen(value);
       if (max > MAX_PATH - 1)
       {
@@ -6291,6 +6328,7 @@ pgagroal_apply_vault_configuration(struct vault_configuration* config,
    }
    else if (key_in_section("tls_key_file", section, key, true, &unknown))
    {
+      memset(config->common.tls_key_file, 0, MAX_PATH);
       max = strlen(value);
       if (max > MAX_PATH - 1)
       {
@@ -6322,6 +6360,7 @@ pgagroal_apply_vault_configuration(struct vault_configuration* config,
    }
    else if (key_in_section("metrics_ca_file", section, key, true, &unknown))
    {
+      memset(config->common.metrics_ca_file, 0, MAX_PATH);
       max = strlen(value);
       if (max > MAX_PATH - 1)
       {
@@ -6331,6 +6370,7 @@ pgagroal_apply_vault_configuration(struct vault_configuration* config,
    }
    else if (key_in_section("metrics_cert_file", section, key, true, &unknown))
    {
+      memset(config->common.metrics_cert_file, 0, MAX_PATH);
       max = strlen(value);
       if (max > MAX_PATH - 1)
       {
@@ -6340,6 +6380,7 @@ pgagroal_apply_vault_configuration(struct vault_configuration* config,
    }
    else if (key_in_section("metrics_key_file", section, key, true, &unknown))
    {
+      memset(config->common.metrics_key_file, 0, MAX_PATH);
       max = strlen(value);
       if (max > MAX_PATH - 1)
       {
@@ -6553,8 +6594,11 @@ pgagroal_apply_configuration(char* config_key, char* config_value,
       goto error;
    }
 
-   // Check if restart is required
-   *restart_required = transfer_configuration(current_config, temp_config);
+   /* transfer_configuration internally calls check_restart_required and
+    * returns true if a restart is needed (no changes applied in that case).
+    * When restart is not required, it applies all changes to the running config.
+    */
+   *restart_required = transfer_configuration(current_config, temp_config, NULL);
 
    if (*restart_required)
    {
@@ -6562,10 +6606,8 @@ pgagroal_apply_configuration(char* config_key, char* config_value,
    }
    else
    {
-      // Apply the changes for real
-      transfer_configuration(current_config, temp_config);
       pgagroal_log_info("Configuration change %s = %s applied successfully", config_key, config_value);
-      // Update certificate metrics after successful reload
+      /* Update certificate metrics after successful reload */
       if (current_config->common.metrics > 0)
       {
          if (pgagroal_update_main_certificate_metrics(current_config))
@@ -7059,7 +7101,7 @@ pgagroal_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t compr
    if (!is_valid_config_key(config_key, &key_info))
    {
       pgagroal_management_response_error(NULL, client_fd, NULL, MANAGEMENT_ERROR_CONF_SET_ERROR, compression, encryption, payload);
-      pgagroal_log_error("Conf Set: Invalid config key format: %s", config_key);
+      pgagroal_log_error("Conf Set: Invalid config key: %s", config_key);
       goto error;
    }
 
@@ -7136,10 +7178,6 @@ pgagroal_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t compr
    // Clean up memory
    free(elapsed);
 
-   pgagroal_disconnect(client_fd);
-   pgagroal_memory_destroy();
-   pgagroal_stop_logging();
-
    return;
 
 error:
@@ -7148,10 +7186,6 @@ error:
    {
       free(elapsed);
    }
-
-   pgagroal_disconnect(client_fd);
-   pgagroal_memory_destroy();
-   pgagroal_stop_logging();
 
    return;
 }
@@ -7310,7 +7344,7 @@ is_valid_config_key(const char* config_key, struct config_key_info* key_info)
          }
          if (!hba_found)
          {
-            pgagroal_log_debug("HBA user '%s' not found in configuration", key_info->context);
+            pgagroal_log_error("HBA user '%s' not found in configuration", key_info->context);
             return false;
          }
       }
@@ -7375,15 +7409,4 @@ pgagroal_is_binary_file(const char* path)
 
 error:
    return true;
-}
-
-static void
-reset_server_failures(void)
-{
-   struct main_configuration* config = (struct main_configuration*)shmem;
-
-   FOREACH_VALID_SERVER
-   {
-      config->servers[i].failures = 0;
-   }
 }

--- a/src/libpgagroal/health.c
+++ b/src/libpgagroal/health.c
@@ -105,13 +105,14 @@ pgagroal_health_check_stop(void)
    {
       kill(config->health_check_pid, SIGTERM);
 
-      for (int i = 0; i < 50; i++)
+      /* Wait up to 2s for exit - the worker checks its flags every 1s via sleep(1) */
+      for (int i = 0; i < 10; i++)
       {
          if (kill(config->health_check_pid, 0))
          {
             break;
          }
-         SLEEP(100000000L);
+         SLEEP(200000000L);
       }
 
       waitpid(config->health_check_pid, NULL, WNOHANG);
@@ -143,16 +144,17 @@ health_check_loop(void)
       previous_state[i] = -2; /* Initial value representing 'never checked' */
    }
 
-   while (config->keep_running)
+   while (config->keep_running && config->health_check)
    {
-      /* Sleep for the configured period, but check keep_running every second */
+      /* Sleep for the configured period, but check flags every second */
+      period = config->health_check_period;
       t = pgagroal_time_convert(period, FORMAT_TIME_S);
-      for (int32_t i = 0; i < t && config->keep_running; i++)
+      for (int32_t i = 0; i < t && config->keep_running && config->health_check; i++)
       {
          sleep(1);
       }
 
-      if (!config->keep_running)
+      if (!config->keep_running || !config->health_check)
       {
          break;
       }

--- a/src/main.c
+++ b/src/main.c
@@ -97,8 +97,10 @@ static void frontend_user_password_startup(struct main_configuration* config);
 static bool accept_fatal(int error);
 static void add_client(pid_t pid);
 static void remove_client(pid_t pid);
+static void refresh_periodic_watchers(void);
+static void start_periodic_watcher(struct periodic_watcher* watcher, bool* started, periodic_cb cb, int interval);
+static void stop_periodic_watcher(struct periodic_watcher* watcher, bool* started);
 static bool reload_configuration(bool* restart);
-static bool reload_services_only(void);
 static void reload_set_configuration(SSL* ssl, int client_fd, uint8_t compression, uint8_t encryption, struct json* payload);
 static void create_pidfile_or_exit(void);
 static void remove_pidfile(void);
@@ -129,6 +131,16 @@ static struct pipeline main_pipeline;
 static int known_fds[MAX_NUMBER_OF_CONNECTIONS];
 static struct client* clients = NULL;
 static struct accept_io io_transfer;
+static struct periodic_watcher idle_timeout_watcher;
+static struct periodic_watcher max_connection_age_watcher;
+static struct periodic_watcher validation_watcher;
+static struct periodic_watcher disconnect_client_watcher;
+static struct periodic_watcher rotate_frontend_password_watcher;
+static bool idle_timeout_started = false;
+static bool max_connection_age_started = false;
+static bool validation_started = false;
+static bool disconnect_client_started = false;
+static bool rotate_frontend_password_started = false;
 
 static void
 start_mgt(void)
@@ -387,11 +399,6 @@ main(int argc, char** argv)
    bool has_main_sockets = false;
    void* tmp_shmem = NULL;
    struct signal_info signal_watcher[SIGNALS_NUMBER];
-   struct periodic_watcher idle_timeout;
-   struct periodic_watcher max_connection_age;
-   struct periodic_watcher validation;
-   struct periodic_watcher disconnect_client;
-   struct periodic_watcher rotate_frontend_password;
    struct rlimit flimit;
    size_t shmem_size;
    size_t pipeline_shmem_size = 0;
@@ -1268,40 +1275,7 @@ read_superuser_path:
       goto error;
    }
 
-   if (pgagroal_time_is_valid(config->idle_timeout))
-   {
-      pgagroal_periodic_init(&idle_timeout, idle_timeout_cb,
-                             1000 * MAX(1. * pgagroal_time_convert(config->idle_timeout, FORMAT_TIME_S) / 2., 5.));
-      pgagroal_periodic_start(&idle_timeout);
-   }
-
-   if (pgagroal_time_is_valid(config->max_connection_age))
-   {
-      pgagroal_periodic_init(&max_connection_age, max_connection_age_cb,
-                             1000 * MAX(1. * pgagroal_time_convert(config->max_connection_age, FORMAT_TIME_S) / 2., 5.));
-      pgagroal_periodic_start(&max_connection_age);
-   }
-
-   if (config->validation == VALIDATION_BACKGROUND)
-   {
-      pgagroal_periodic_init(&validation, validation_cb,
-                             1000 * MAX(1. * pgagroal_time_convert(config->background_interval, FORMAT_TIME_S), 5.));
-      pgagroal_periodic_start(&validation);
-   }
-
-   if (config->disconnect_client > 0)
-   {
-      pgagroal_periodic_init(&disconnect_client, disconnect_client_cb,
-                             1000 * MIN(300., MAX(1. * config->disconnect_client / 2., 1.)));
-      pgagroal_periodic_start(&disconnect_client);
-   }
-
-   if (pgagroal_time_is_valid(config->rotate_frontend_password_timeout))
-   {
-      pgagroal_periodic_init(&rotate_frontend_password, rotate_frontend_password_cb,
-                             1000 * pgagroal_time_convert(config->rotate_frontend_password_timeout, FORMAT_TIME_S));
-      pgagroal_periodic_start(&rotate_frontend_password);
-   }
+   refresh_periodic_watchers();
 
    if (config->common.metrics > 0)
    {
@@ -2936,167 +2910,122 @@ remove_client(pid_t pid)
    }
 }
 
-static bool
-reload_configuration(bool* restart)
+static void
+start_periodic_watcher(struct periodic_watcher* watcher, bool* started, periodic_cb cb, int interval)
 {
-   char pgsql[MISC_LENGTH];
-   char old_host[MISC_LENGTH];
-   int old_port;
-   int old_metrics;
-   int old_management;
-   int old_console;
+   if (pgagroal_periodic_init(watcher, cb, interval) != PGAGROAL_EVENT_RC_OK)
+   {
+      memset(watcher, 0, sizeof(struct periodic_watcher));
+      *started = false;
+      return;
+   }
+
+   if (pgagroal_periodic_start(watcher) != PGAGROAL_EVENT_RC_OK)
+   {
+      memset(watcher, 0, sizeof(struct periodic_watcher));
+      *started = false;
+      return;
+   }
+
+   *started = true;
+}
+
+static void
+stop_periodic_watcher(struct periodic_watcher* watcher, bool* started)
+{
+   if (*started)
+   {
+      if (pgagroal_periodic_stop(watcher) != PGAGROAL_EVENT_RC_OK)
+      {
+         pgagroal_log_warn("Unable to stop periodic watcher");
+      }
+
+      memset(watcher, 0, sizeof(struct periodic_watcher));
+      *started = false;
+   }
+}
+
+static void
+refresh_periodic_watchers(void)
+{
    struct main_configuration* config;
 
    config = (struct main_configuration*)shmem;
 
-   pgagroal_health_check_stop();
+   stop_periodic_watcher(&idle_timeout_watcher, &idle_timeout_started);
+   stop_periodic_watcher(&max_connection_age_watcher, &max_connection_age_started);
+   stop_periodic_watcher(&validation_watcher, &validation_started);
+   stop_periodic_watcher(&disconnect_client_watcher, &disconnect_client_started);
+   stop_periodic_watcher(&rotate_frontend_password_watcher, &rotate_frontend_password_started);
 
-   /* Save old values before reload */
-   memset(&old_host, 0, sizeof(old_host));
-   memcpy(&old_host, config->common.host, sizeof(old_host));
-   old_port = config->common.port;
-   old_metrics = config->common.metrics;
-   old_management = config->management;
-   old_console = config->console;
+   if (pgagroal_time_is_valid(config->idle_timeout))
+   {
+      start_periodic_watcher(&idle_timeout_watcher, &idle_timeout_started, idle_timeout_cb,
+                             1000 * MAX(1. * pgagroal_time_convert(config->idle_timeout, FORMAT_TIME_S) / 2., 5.));
+   }
 
-   pgagroal_reload_configuration(restart);
+   if (pgagroal_time_is_valid(config->max_connection_age))
+   {
+      start_periodic_watcher(&max_connection_age_watcher, &max_connection_age_started, max_connection_age_cb,
+                             1000 * MAX(1. * pgagroal_time_convert(config->max_connection_age, FORMAT_TIME_S) / 2., 5.));
+   }
 
-   if (config->health_check)
+   if (config->validation == VALIDATION_BACKGROUND)
+   {
+      start_periodic_watcher(&validation_watcher, &validation_started, validation_cb,
+                             1000 * MAX(1. * pgagroal_time_convert(config->background_interval, FORMAT_TIME_S), 5.));
+   }
+
+   if (config->disconnect_client > 0)
+   {
+      start_periodic_watcher(&disconnect_client_watcher, &disconnect_client_started, disconnect_client_cb,
+                             1000 * MIN(300., MAX(1. * config->disconnect_client / 2., 1.)));
+   }
+
+   if (pgagroal_time_is_valid(config->rotate_frontend_password_timeout))
+   {
+      start_periodic_watcher(&rotate_frontend_password_watcher, &rotate_frontend_password_started, rotate_frontend_password_cb,
+                             1000 * pgagroal_time_convert(config->rotate_frontend_password_timeout, FORMAT_TIME_S));
+   }
+}
+
+static void
+manage_health_check_worker(void)
+{
+   struct main_configuration* config;
+
+   config = (struct main_configuration*)shmem;
+
+   // If health check was started and now disabled, signal it to exit
+   if (config->health_check_pid != 0 && !config->health_check)
+   {
+      pgagroal_health_check_stop();
+   }
+   // If it was stopped and now enabled, start it (if not already running)
+   else if (config->health_check && config->health_check_pid == 0)
    {
       pgagroal_health_check(main_argc, main_argv);
    }
+}
 
-   /* Only rebind main listening sockets if host or port changed */
-   if (strcmp(old_host, config->common.host) || old_port != config->common.port)
+static bool
+reload_configuration(bool* restart)
+{
+   bool health_check_changed = false;
+
+   pgagroal_reload_configuration(restart, &health_check_changed);
+
+   if (!*restart)
    {
-      shutdown_io();
-      pgagroal_io_stop(&io_uds.watcher);
-      shutdown_uds(true);
+      refresh_periodic_watchers();
 
-      memset(&pgsql, 0, sizeof(pgsql));
-      pgagroal_snprintf(&pgsql[0], sizeof(pgsql), PG_UDS);
-
-      if (pgagroal_bind_unix_socket(config->unix_socket_dir, &pgsql[0], &unix_pgsql_socket))
+      if (health_check_changed)
       {
-         pgagroal_log_fatal("pgagroal: Could not bind to %s/%s.%d", config->unix_socket_dir, &pgsql[0], config->common.port);
-         goto error;
-      }
-
-      free(main_fds);
-      main_fds = NULL;
-      main_fds_length = 0;
-
-      if (pgagroal_bind(config->common.host, config->common.port, &main_fds, &main_fds_length, config->nodelay, config->backlog))
-      {
-         pgagroal_log_fatal("pgagroal: Could not bind to %s:%d", config->common.host, config->common.port);
-         goto error;
-      }
-
-      if (main_fds_length > MAX_FDS)
-      {
-         pgagroal_log_fatal("pgagroal: Too many descriptors %d", main_fds_length);
-         goto error;
-      }
-
-      start_io();
-      start_uds();
-   }
-
-   /* Only rebind metrics if metrics port changed */
-   if (old_metrics != config->common.metrics)
-   {
-      for (int i = 0; i < metrics_fds_length; i++)
-      {
-         pgagroal_io_stop(&io_metrics[i].watcher);
-      }
-      shutdown_metrics();
-
-      free(metrics_fds);
-      metrics_fds = NULL;
-      metrics_fds_length = 0;
-
-      if (config->common.metrics > 0)
-      {
-         /* Bind metrics socket */
-         if (pgagroal_bind(config->common.host, config->common.metrics, &metrics_fds, &metrics_fds_length, config->nodelay, config->backlog))
-         {
-            pgagroal_log_fatal("pgagroal: Could not bind to %s:%d", config->common.host, config->common.metrics);
-            goto error;
-         }
-
-         if (metrics_fds_length > MAX_FDS)
-         {
-            pgagroal_log_fatal("pgagroal: Too many descriptors %d", metrics_fds_length);
-            goto error;
-         }
-
-         start_metrics();
+         pgagroal_health_check_stop();
       }
    }
 
-   /* Only rebind management if management port changed */
-   if (old_management != config->management)
-   {
-      for (int i = 0; i < management_fds_length; i++)
-      {
-         pgagroal_io_stop(&io_management[i].watcher);
-      }
-      shutdown_management(true);
-
-      free(management_fds);
-      management_fds = NULL;
-      management_fds_length = 0;
-
-      if (config->management > 0)
-      {
-         /* Bind management socket */
-         if (pgagroal_bind(config->common.host, config->management, &management_fds, &management_fds_length, config->nodelay, config->backlog))
-         {
-            pgagroal_log_fatal("pgagroal: Could not bind to %s:%d", config->common.host, config->management);
-            goto error;
-         }
-
-         if (management_fds_length > MAX_FDS)
-         {
-            pgagroal_log_fatal("pgagroal: Too many descriptors %d", management_fds_length);
-            goto error;
-         }
-
-         start_management();
-      }
-   }
-
-   /* Only rebind console if console port changed */
-   if (old_console != config->console)
-   {
-      for (int i = 0; i < console_fds_length; i++)
-      {
-         pgagroal_io_stop(&io_console[i].watcher);
-      }
-      shutdown_console();
-
-      free(console_fds);
-      console_fds = NULL;
-      console_fds_length = 0;
-
-      if (config->console > 0)
-      {
-         /* Bind console socket */
-         if (pgagroal_bind(config->common.host, config->console, &console_fds, &console_fds_length, config->nodelay, config->backlog))
-         {
-            pgagroal_log_fatal("pgagroal: Could not bind to %s:%d", config->common.host, config->console);
-            goto error;
-         }
-
-         if (console_fds_length > MAX_FDS)
-         {
-            pgagroal_log_fatal("pgagroal: Too many descriptors %d", console_fds_length);
-            goto error;
-         }
-
-         start_console();
-      }
-   }
+   manage_health_check_worker();
 
    for (int i = 0; i < main_fds_length; i++)
    {
@@ -3117,148 +3046,6 @@ reload_configuration(bool* restart)
    }
 
    return true;
-
-error:
-   remove_pidfile();
-   exit(1);
-}
-
-static bool
-reload_services_only(void)
-{
-   char pgsql[MISC_LENGTH];
-   struct main_configuration* config;
-
-   config = (struct main_configuration*)shmem;
-
-   // Shutdown services
-   shutdown_io();
-
-   pgagroal_io_stop(&io_uds.watcher);
-   shutdown_uds(true);
-
-   for (int i = 0; i < metrics_fds_length; i++)
-   {
-      pgagroal_io_stop(&io_metrics[i].watcher);
-   }
-   shutdown_metrics();
-
-   for (int i = 0; i < management_fds_length; i++)
-   {
-      pgagroal_io_stop(&io_management[i].watcher);
-   }
-   shutdown_management(true);
-
-   for (int i = 0; i < console_fds_length; i++)
-   {
-      pgagroal_io_stop(&io_console[i].watcher);
-   }
-   shutdown_console();
-
-   // Instead, restart services with current memory configuration
-   pgagroal_log_debug("conf set: unix socket Bound to %s/.s.PGSQL.%d", config->unix_socket_dir, config->common.port);
-
-   // Restart Unix Domain Socket with NEW port from memory
-   memset(&pgsql, 0, sizeof(pgsql));
-   pgagroal_snprintf(&pgsql[0], sizeof(pgsql), PG_UDS);
-
-   if (pgagroal_bind_unix_socket(config->unix_socket_dir, &pgsql[0], &unix_pgsql_socket))
-   {
-      pgagroal_log_fatal("pgagroal: Could not bind to %s/%s.%d", config->unix_socket_dir, &pgsql[0], config->common.port);
-      goto error;
-   }
-
-   pgagroal_log_debug("conf set: main port and host Bound to %s:%d", config->common.host, config->common.port);
-
-   // Restart main sockets with NEW port from memory
-   free(main_fds);
-   main_fds = NULL;
-   main_fds_length = 0;
-
-   if (pgagroal_bind(config->common.host, config->common.port, &main_fds, &main_fds_length, config->nodelay, config->backlog))
-   {
-      pgagroal_log_fatal("pgagroal: Could not bind to %s:%d", config->common.host, config->common.port);
-      goto error;
-   }
-
-   if (main_fds_length > MAX_FDS)
-   {
-      pgagroal_log_fatal("pgagroal: Too many descriptors %d", main_fds_length);
-      goto error;
-   }
-
-   start_io();
-   start_uds();
-
-   // Restart metrics if enabled
-   if (config->common.metrics > 0)
-   {
-      free(metrics_fds);
-      metrics_fds = NULL;
-      metrics_fds_length = 0;
-
-      if (pgagroal_bind(config->common.host, config->common.metrics, &metrics_fds, &metrics_fds_length, config->nodelay, config->backlog))
-      {
-         pgagroal_log_fatal("pgagroal: Could not bind to %s:%d", config->common.host, config->common.metrics);
-         goto error;
-      }
-
-      if (metrics_fds_length > MAX_FDS)
-      {
-         pgagroal_log_fatal("pgagroal: Too many descriptors %d", metrics_fds_length);
-         goto error;
-      }
-
-      start_metrics();
-   }
-
-   // Restart management
-   if (config->management > 0)
-   {
-      free(management_fds);
-      management_fds = NULL;
-      management_fds_length = 0;
-
-      if (pgagroal_bind(config->common.host, config->management, &management_fds, &management_fds_length, config->nodelay, config->backlog))
-      {
-         pgagroal_log_warn("pgagroal: Could not rebind management port %s:%d, continuing without management", config->common.host, config->management);
-         config->management = 0;
-      }
-      else
-      {
-         if (management_fds_length <= MAX_FDS)
-         {
-            start_management();
-         }
-      }
-   }
-
-   // Restart console
-   if (config->console > 0)
-   {
-      free(console_fds);
-      console_fds = NULL;
-      console_fds_length = 0;
-
-      if (pgagroal_bind(config->common.host, config->console, &console_fds, &console_fds_length, config->nodelay, config->backlog))
-      {
-         pgagroal_log_warn("pgagroal: Could not rebind console port %s:%d, continuing without console", config->common.host, config->console);
-         config->console = 0;
-      }
-      else
-      {
-         if (console_fds_length <= MAX_FDS)
-         {
-            start_console();
-         }
-      }
-   }
-
-   pgagroal_log_info("conf set: Services restarted successfully");
-   return true;
-
-error:
-   return false;
 }
 
 static void
@@ -3286,14 +3073,24 @@ reload_set_configuration(SSL* ssl, int client_fd, uint8_t compression, uint8_t e
       exit(1);
    }
 
+   // Clean up resources before exiting the child process
+   pgagroal_disconnect(client_fd);
+   pgagroal_memory_destroy();
+   pgagroal_stop_logging();
+
    exit(0);
 }
 
 static void
 service_reload_cb(void)
 {
-   pgagroal_log_debug("pgagroal: service restart requested");
-   reload_services_only(); // Parent process restarts services
+   pgagroal_log_debug("pgagroal: service reload requested (SIGUSR1)");
+   pgagroal_stop_logging();
+   pgagroal_start_logging();
+   refresh_periodic_watchers();
+
+   /* Check if we need to start or stop workers based on modified shared memory */
+   manage_health_check_worker();
 }
 
 /**


### PR DESCRIPTION


- Refactored 'conf set' and 'conf reload' logic to enforce restart requirements for architectural settings (host, port, hugepage, max_connections, etc.).
- Removed legacy code that attempted to reload listener sockets and memory-critical arrays live, which previously led to inconsistencies.
- Updated documentation and manuals to reflect the changes in conf `reload` and `set`.

#767 