### PR TITLE
[#856] Remove debug assertion on active connections <= max_connections

### DIFF
--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -1272,10 +1272,6 @@ pgagroal_pool_status(void)
       connection_details(i);
    }
 
-#ifdef DEBUG
-   assert(atomic_load(&config->active_connections) <= config->max_connections);
-#endif
-
    return 0;
 }
 


### PR DESCRIPTION
This PR removes the strict assertion in pgagroal_pool_status() that can cause a core dump when the pool is out of capacity.

The assertion assert(atomic_load(&config->active_connections) <= config->max_connections); assumes that the active connections count can never exceed the maximum. However, pgagroal_get_connection() utilizes an optimistic increment pattern (atomic_fetch_add), which allows the counter to temporarily overflow before being rolled back in the retry block.

Resolves #856 
