### PR TITLE
Stop logging backend_secret in cancel-request paths

### DIFF
--- a/src/libpgagroal/pipeline_session.c
+++ b/src/libpgagroal/pipeline_session.c
@@ -251,9 +251,9 @@ session_periodic(void)
 
                   if (ret == 0)
                   {
-                     pgagroal_log_debug("Cancel request for %s/%s using slot %d (pid %d secret %d)",
+                     pgagroal_log_debug("Cancel request for %s/%s using slot %d (pid %d)",
                                         config->connections[i].database, config->connections[i].username,
-                                        i, config->connections[i].backend_pid, config->connections[i].backend_secret);
+                                        i, config->connections[i].backend_pid);
 
                      pgagroal_write_message(NULL, socket, cancel_msg);
                   }


### PR DESCRIPTION
The PostgreSQL `backend_secret` authenticates cancel requests against a specific backend pid. Anyone who captures pgagroal logs (debug or trace level) and reads the secret can forge cancel requests for the matching session.

Removed in two places:

- `pipeline_session.c:254` — `pgagroal_log_debug` for the cancel request that pgagroal itself emits during graceful client disconnect.
- `pool.c` — the eight per-state `Backend Secret: %d` `pgagroal_log_trace` lines in `pgagroal_pool_status`.

The backend `pid` is kept where it was already logged. The pid is useful for cross-referencing with `pg_stat_activity` and is not a secret on its own.

No functional change to the cancel-request mechanism — the secret is still passed correctly to `pgagroal_create_cancel_request_message` (`pipeline_session.c:235`) and stored on the connection (`pool.c:644`, `security.c:2467/2563`).