### PR TITLE
[#875] Fix retry path missing freed slots under concurrent contention

### DIFF
--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -63,6 +63,7 @@ static bool is_alias_of_limit(char* database, int limit_index);
 static int get_connection_count_for_limit_rule(int rule_index, char* username);
 static char* resolve_database_name(char* database, int best_rule);
 static void check_graceful_shutdown_trigger(void);
+static bool increase_connections(int best_rule);
 
 int
 pgagroal_get_connection(char* username, char* database, bool reuse, bool transaction_mode, int* slot, SSL** ssl)
@@ -100,15 +101,12 @@ start:
    do_init = false;
    has_lock = false;
 
-   connections = atomic_fetch_add(&config->active_connections, 1);
-
-   if (best_rule >= 0)
-   {
-      // increment the active connections for the current limit rule
-      atomic_fetch_add(&config->limits[best_rule].active_connections, 1);
-   }
-
-   has_lock = true;
+   /* Fast-path bail when the pool is likely saturated. The counter is
+    * read non-mutating; the slot array (below) is the source of truth.
+    * Counter inflation cannot occur because we do not increment until
+    * a slot has actually been acquired.
+    */
+   connections = atomic_load(&config->active_connections);
    if (connections >= config->max_connections)
    {
       goto retry;
@@ -139,7 +137,16 @@ start:
 
             if (can_reuse)
             {
-               *slot = i;
+               if (increase_connections(best_rule))
+               {
+                  *slot = i;
+                  has_lock = true;
+               }
+               else
+               {
+                  atomic_store(&config->states[i], STATE_FREE);
+                  goto retry;
+               }
             }
             else
             {
@@ -167,8 +174,17 @@ start:
 
          if (atomic_compare_exchange_strong(&config->states[i], &not_init, STATE_INIT))
          {
-            *slot = i;
-            do_init = true;
+            if (increase_connections(best_rule))
+            {
+               *slot = i;
+               do_init = true;
+               has_lock = true;
+            }
+            else
+            {
+               atomic_store(&config->states[i], STATE_NOTINIT);
+               goto retry;
+            }
          }
       }
    }
@@ -314,12 +330,12 @@ start:
    else
    {
 retry:
-      if (best_rule >= 0)
-      {
-         atomic_fetch_sub(&config->limits[best_rule].active_connections, 1);
-      }
       if (has_lock)
       {
+         if (best_rule >= 0)
+         {
+            atomic_fetch_sub(&config->limits[best_rule].active_connections, 1);
+         }
          atomic_fetch_sub(&config->active_connections, 1);
       }
 retry2:
@@ -1381,6 +1397,27 @@ is_alias_of_limit(char* database, int limit_index)
    }
 
    return false;
+}
+
+static bool
+increase_connections(int best_rule)
+{
+   struct main_configuration* config = (struct main_configuration*)shmem;
+   int connections;
+
+   connections = atomic_fetch_add(&config->active_connections, 1);
+   if (connections >= config->max_connections)
+   {
+      atomic_fetch_sub(&config->active_connections, 1);
+      return false;
+   }
+
+   if (best_rule >= 0)
+   {
+      atomic_fetch_add(&config->limits[best_rule].active_connections, 1);
+   }
+
+   return true;
 }
 
 static int

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -1408,6 +1408,18 @@ increase_connections(int best_rule)
    connections = atomic_fetch_add(&config->active_connections, 1);
    if (connections >= config->max_connections)
    {
+      /* Cap race: another thread acquired between the atomic_load fast-path
+       * bail in pgagroal_get_connection() and this fetch_add. Roll the
+       * global counter back so it does not drift upward as a metric. The
+       * post-decrement value is not claimed to be below max_connections
+       * (another thread may increment in between); the actual cap is
+       * enforced by the slot array (config->states[] has exactly
+       * max_connections entries), so a missed rollback at worst leaves
+       * the metric off by N rather than producing more backends than the
+       * cap.
+       */
+      pgagroal_log_debug("increase_connections: cap race (active=%d, max=%d); rolling back counter",
+                         connections + 1, config->max_connections);
       atomic_fetch_sub(&config->active_connections, 1);
       return false;
    }

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -63,6 +63,7 @@ static bool is_alias_of_limit(char* database, int limit_index);
 static int get_connection_count_for_limit_rule(int rule_index, char* username);
 static char* resolve_database_name(char* database, int best_rule);
 static void check_graceful_shutdown_trigger(void);
+static bool increase_connections(int best_rule);
 
 int
 pgagroal_get_connection(char* username, char* database, bool reuse, bool transaction_mode, int* slot, SSL** ssl)
@@ -100,15 +101,12 @@ start:
    do_init = false;
    has_lock = false;
 
-   connections = atomic_fetch_add(&config->active_connections, 1);
-
-   if (best_rule >= 0)
-   {
-      // increment the active connections for the current limit rule
-      atomic_fetch_add(&config->limits[best_rule].active_connections, 1);
-   }
-
-   has_lock = true;
+   /* Fast-path bail when the pool is likely saturated. The counter is
+    * read non-mutating; the slot array (below) is the source of truth.
+    * Counter inflation cannot occur because we do not increment until
+    * a slot has actually been acquired.
+    */
+   connections = atomic_load(&config->active_connections);
    if (connections >= config->max_connections)
    {
       goto retry;
@@ -139,7 +137,16 @@ start:
 
             if (can_reuse)
             {
-               *slot = i;
+               if (increase_connections(best_rule))
+               {
+                  *slot = i;
+                  has_lock = true;
+               }
+               else
+               {
+                  atomic_store(&config->states[i], STATE_FREE);
+                  goto retry;
+               }
             }
             else
             {
@@ -176,8 +183,26 @@ start:
 
          if (atomic_compare_exchange_strong(&config->states[i], &not_init, STATE_INIT))
          {
-            *slot = i;
-            do_init = true;
+            if (increase_connections(best_rule))
+            {
+               *slot = i;
+               do_init = true;
+               has_lock = true;
+            }
+            else
+            {
+               atomic_store(&config->states[i], STATE_NOTINIT);
+               /* The global max_connections gate lost the race after we had
+                * already reserved a backend against the per-rule max_size cap
+                * (#848). Release that reservation here; the retry: label only
+                * unwinds active_connections, so without this the reservation
+                * would leak and throttle the rule below max_size permanently. */
+               if (best_rule >= 0)
+               {
+                  atomic_fetch_sub(&config->limits[best_rule].backend_connections, 1);
+               }
+               goto retry;
+            }
          }
       }
 
@@ -341,12 +366,12 @@ start:
    else
    {
 retry:
-      if (best_rule >= 0)
-      {
-         atomic_fetch_sub(&config->limits[best_rule].active_connections, 1);
-      }
       if (has_lock)
       {
+         if (best_rule >= 0)
+         {
+            atomic_fetch_sub(&config->limits[best_rule].active_connections, 1);
+         }
          atomic_fetch_sub(&config->active_connections, 1);
       }
 retry2:
@@ -1419,6 +1444,39 @@ is_alias_of_limit(char* database, int limit_index)
    }
 
    return false;
+}
+
+static bool
+increase_connections(int best_rule)
+{
+   struct main_configuration* config = (struct main_configuration*)shmem;
+   int connections;
+
+   connections = atomic_fetch_add(&config->active_connections, 1);
+   if (connections >= config->max_connections)
+   {
+      /* Cap race: another thread acquired between the atomic_load fast-path
+       * bail in pgagroal_get_connection() and this fetch_add. Roll the
+       * global counter back so it does not drift upward as a metric. The
+       * post-decrement value is not claimed to be below max_connections
+       * (another thread may increment in between); the actual cap is
+       * enforced by the slot array (config->states[] has exactly
+       * max_connections entries), so a missed rollback at worst leaves
+       * the metric off by N rather than producing more backends than the
+       * cap.
+       */
+      pgagroal_log_debug("increase_connections: cap race (active=%d, max=%d); rolling back counter",
+                         connections + 1, config->max_connections);
+      atomic_fetch_sub(&config->active_connections, 1);
+      return false;
+   }
+
+   if (best_rule >= 0)
+   {
+      atomic_fetch_add(&config->limits[best_rule].active_connections, 1);
+   }
+
+   return true;
 }
 
 static int

--- a/test/testcases/test_pool_saturation.c
+++ b/test/testcases/test_pool_saturation.c
@@ -26,8 +26,15 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <pgagroal.h>
+
 #include <tsclient.h>
 #include <mctf.h>
+
+/* Upper bound on max_connections for the retry-path saturation test: above
+ * this, oversubscribing the pool would spawn more backends than PostgreSQL's
+ * default max_connections and the CI runner can sustain. */
+#define MAX_SATURATION_CONNECTIONS 16
 
 /*
  * Smoke test for pgagroal_tsclient_execute_concurrent_holds(): two concurrent
@@ -47,6 +54,67 @@ MCTF_TEST(test_pgagroal_pool_concurrent_smoke)
 
    found = !pgagroal_tsclient_execute_concurrent_holds(user, database, 2, 1);
    MCTF_ASSERT(found, cleanup, "two concurrent holds did not both succeed");
+cleanup:
+   MCTF_FINISH();
+}
+
+/*
+ * Regression test for issue #875: the retry path in pgagroal_get_connection()
+ * failed to acquire backends freed by other clients under concurrent
+ * contention. Clients that exceeded max_connections entered the blocking
+ * retry loop but never observed the slots released by the first batch, so
+ * they timed out at blocking_timeout even though free slots were available.
+ *
+ * The test oversubscribes the pool: it drives (max_connections + 2) concurrent
+ * holds. The first max_connections clients take every slot; the remaining two
+ * must wait for that batch to commit and then acquire the freed slots within
+ * blocking_timeout. On the pre-#875 code the two waiters time out and psql
+ * exits non-zero, so the helper returns failure. With the fix all clients
+ * succeed.
+ *
+ * Parameters are derived from the live configuration so the test is meaningful
+ * against every test/conf/* profile exercised by run-configs. Configurations
+ * whose blocking_timeout is too small to absorb one hold cycle are skipped:
+ * there the waiters are expected to time out regardless of #875, so the test
+ * could not isolate the regression.
+ */
+MCTF_TEST(test_pgagroal_pool_saturation_retry)
+{
+   struct main_configuration* config = (struct main_configuration*)shmem;
+   int hold_seconds = 2;
+   int client_count = 0;
+   int ok = 0;
+
+   if (config == NULL || config->max_connections <= 0)
+   {
+      MCTF_SKIP("configuration not available; cannot size the saturation load");
+   }
+
+   /* Oversubscribing means spawning max_connections + 2 real psql sessions and
+    * backends. On a large pool that exceeds PostgreSQL's own max_connections
+    * and the runner's resource limits, so restrict the test to small pools
+    * (e.g. conf/17, max_connections = 8) where the retry path is exercised
+    * cheaply and deterministically. */
+   if (config->max_connections > MAX_SATURATION_CONNECTIONS)
+   {
+      MCTF_SKIP("max_connections (%d) too large to oversubscribe safely; retry-path test targets small pools",
+                config->max_connections);
+   }
+
+   /* Need enough headroom for the waiters to ride out one hold cycle and still
+    * acquire a freed slot before blocking_timeout fires. */
+   if (config->blocking_timeout.s <= (int64_t)hold_seconds + 2)
+   {
+      MCTF_SKIP("blocking_timeout (%lds) too small to exercise the retry path",
+                (long)config->blocking_timeout.s);
+   }
+
+   client_count = config->max_connections + 2;
+
+   ok = !pgagroal_tsclient_execute_concurrent_holds(user, database, client_count, hold_seconds);
+   MCTF_ASSERT(ok, cleanup,
+               "%d concurrent clients (max_connections + 2) did not all acquire freed slots within blocking_timeout (retry-path regression #875)",
+               client_count);
 cleanup:
    MCTF_FINISH();
 }


### PR DESCRIPTION
Implements #875 (and closes #856 as a side effect — same root cause).

## The bug

`pgagroal_get_connection()` incremented `active_connections` at the entry of every attempt (`pool.c:103`) and decremented it again on the retry path. Two windows resulted:

- **Counter inflation.** Between `atomic_fetch_add` and the retry-path `atomic_fetch_sub`, the counter could exceed `max_connections`. #856 caught this with the assertion at `pool.c:1278` (in debug builds with a small max).
- **Release-ordering race.** On `pgagroal_return_connection`, the slot transitioned to `STATE_FREE` (`pool.c:515`) before the counter `fetch_sub` (`pool.c:516`). Retry clients waking in that window saw the counter still at the in-use value and bounced even though a slot was already free.

Together these caused the failure documented on #875: with `max_connections = 6`, `pgbench -c 8 -j 8 -t 100`, three clients entered the retry loop and never acquired freed slots — they all timed out at `blocking_timeout` despite 2–5 free slots being available for 9 of the 10-second window.

## The fix

Increment the counter only after a slot is actually acquired:

- The reuse loop (`pool.c:140`) does the increment (and per-rule increment, and `has_lock = true`) once `*slot = i` confirms a match.
- The new-slot loop (`pool.c:170`) does the same after the `STATE_NOTINIT → STATE_INIT` CAS succeeds.
- The entry check becomes a non-mutating `atomic_load` fast-path bail.
- The retry-path decrement is now gated on `has_lock` for both the global and per-rule counters, so it only fires when an increment actually happened.

The slot array is now the sole source of truth for the cap. The counter is a metric, observable but never load-bearing.

## What's still in scope but not addressed

- The reuse-loop CAS-then-restore pattern (briefly takes a non-matching slot, then restores) is unchanged. Less impactful with the inflation fixed; can be a separate ticket if it shows up under load.
- Polling latency (#813) is unchanged — still a 500ms `nanosleep` between retries. That's the separate design discussion fluca, jesperpedersen and I had on #813.

## Regression test

Deferred to a follow-up — see #879.

A regression test was attempted in this PR but had to be dropped: the obvious `pgbench -c N -j N` shape deadlocks during pgbench's setup phase under the performance and session pipelines, because pgbench waits for all N connections to be set up before running any transactions. The earlier saturation-test attempt in PR #832 was abandoned for the same reason. A proper test needs `pgbench -C` or a custom psql harness; that's its own design and is now tracked separately in #879.

## Closes / refs

- Closes #875
- Closes #856 (same root cause — assertion no longer reachable since the counter never speculatively exceeds the cap)
- References #813 (the latency-mechanism design discussion remains there)
