### PR TITLE
[#879] Add concurrent-holds test harness

### DIFF
--- a/test/conf/17/pgagroal.conf
+++ b/test/conf/17/pgagroal.conf
@@ -1,0 +1,22 @@
+[pgagroal]
+host = localhost
+port = 2345
+
+log_type = file
+log_level = debug5
+log_path = test.log
+
+# Short blocking_timeout makes the retry-path regression for #875
+# fail quickly when present: clients exceeding max_connections must
+# acquire freed slots before blocking_timeout fires.
+max_connections = 8
+blocking_timeout = 10
+idle_timeout = 600
+validation = off
+unix_socket_dir = /tmp/
+pipeline = performance
+
+
+[primary]
+host = localhost
+port = 5432

--- a/test/conf/17/pgagroal_hba.conf
+++ b/test/conf/17/pgagroal_hba.conf
@@ -1,0 +1,4 @@
+#
+# TYPE  DATABASE USER  ADDRESS  METHOD
+#
+host    all all all trust

--- a/test/include/tsclient.h
+++ b/test/include/tsclient.h
@@ -86,6 +86,21 @@ pgagroal_tsclient_execute_pgbench(char* user, char* database, bool select_only, 
 int
 pgagroal_tsclient_init_pgbench(char* user, char* database, int scale);
 
+/**
+ * Run client_count concurrent psql sessions through pgagroal, each holding a
+ * connection by executing 'BEGIN; SELECT pg_sleep(hold_seconds); COMMIT;'.
+ * Used to exercise the retry path of pgagroal_get_connection() under
+ * saturation: when client_count > max_connections, the surplus clients must
+ * acquire freed slots once early holders return their connections (issue #875).
+ * @param user name of the user
+ * @param database name of the database
+ * @param client_count number of concurrent psql sessions to spawn
+ * @param hold_seconds duration of the pg_sleep() hold per session
+ * @return 0 if every client returned success, otherwise 1
+ */
+int
+pgagroal_tsclient_execute_concurrent_holds(char* user, char* database, int client_count, int hold_seconds);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/libpgagroaltest/tsclient.c
+++ b/test/libpgagroaltest/tsclient.c
@@ -38,6 +38,7 @@
 /* system */
 #include <err.h>
 #include <getopt.h>
+#include <pthread.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -48,8 +49,15 @@
 
 char project_directory[BUFFER_SIZE];
 
+struct hold_thread_args
+{
+   char* command;
+   int   exit_status;
+};
+
 static char* get_configuration_path();
 static char* get_log_file_path();
+static void* hold_thread_main(void* arg);
 
 int
 pgagroal_tsclient_init(char* base_dir)
@@ -293,6 +301,123 @@ pgagroal_tsclient_init_pgbench(char* user, char* database, int scale)
    free(log_file_path);
 
    return ret;
+}
+
+int
+pgagroal_tsclient_execute_concurrent_holds(char* user, char* database, int client_count, int hold_seconds)
+{
+   struct main_configuration* config = NULL;
+   pthread_t* threads = NULL;
+   struct hold_thread_args* args = NULL;
+   char* log_file_path = NULL;
+   const char* password = NULL;
+   int failures = 0;
+   int spawned = 0;
+   int rc;
+
+   if (client_count <= 0 || hold_seconds < 0)
+   {
+      return 1;
+   }
+
+   config = (struct main_configuration*)shmem;
+   log_file_path = get_log_file_path();
+
+   /* Same precedence used by pgagroal_tsclient_execute_pgbench */
+   password = getenv("PGPASSWORD");
+   if (password == NULL)
+   {
+      password = getenv("PG_USER_PASSWORD");
+   }
+   if (password == NULL)
+   {
+      password = getenv("PG_UTF8_USER_PASSWORD");
+   }
+
+   threads = (pthread_t*)calloc(client_count, sizeof(pthread_t));
+   args = (struct hold_thread_args*)calloc(client_count, sizeof(struct hold_thread_args));
+   if (threads == NULL || args == NULL)
+   {
+      failures = client_count;
+      goto cleanup;
+   }
+
+   for (int i = 0; i < client_count; i++)
+   {
+      char* cmd = NULL;
+      char  sql[128];
+
+      snprintf(sql, sizeof(sql), "BEGIN; SELECT pg_sleep(%d); COMMIT;", hold_seconds);
+
+      if (password != NULL && strlen(password) > 0)
+      {
+         cmd = pgagroal_append(cmd, "PGPASSWORD=");
+         cmd = pgagroal_append(cmd, (char*)password);
+         cmd = pgagroal_append_char(cmd, ' ');
+      }
+
+      cmd = pgagroal_append(cmd, "psql -h ");
+      cmd = pgagroal_append(cmd, config->common.host);
+      cmd = pgagroal_append(cmd, " -p ");
+      cmd = pgagroal_append_int(cmd, config->common.port);
+      cmd = pgagroal_append(cmd, " -U ");
+      cmd = pgagroal_append(cmd, user);
+      cmd = pgagroal_append(cmd, " -d ");
+      cmd = pgagroal_append(cmd, database);
+      cmd = pgagroal_append(cmd, " -v ON_ERROR_STOP=1 -X -A -t -c \"");
+      cmd = pgagroal_append(cmd, sql);
+      cmd = pgagroal_append(cmd, "\" >> ");
+      cmd = pgagroal_append(cmd, log_file_path);
+      cmd = pgagroal_append(cmd, " 2>&1 < /dev/null");
+
+      args[i].command = cmd;
+      args[i].exit_status = -1;
+
+      rc = pthread_create(&threads[i], NULL, hold_thread_main, &args[i]);
+      if (rc != 0)
+      {
+         /* Could not spawn this client; count it as a failure and stop spawning */
+         failures++;
+         break;
+      }
+      spawned++;
+   }
+
+   for (int i = 0; i < spawned; i++)
+   {
+      pthread_join(threads[i], NULL);
+      if (args[i].exit_status != 0)
+      {
+         failures++;
+      }
+   }
+
+cleanup:
+   if (args != NULL)
+   {
+      for (int i = 0; i < client_count; i++)
+      {
+         free(args[i].command);
+      }
+      free(args);
+   }
+   free(threads);
+   free(log_file_path);
+
+   return (failures == 0) ? 0 : 1;
+}
+
+static void*
+hold_thread_main(void* arg)
+{
+   struct hold_thread_args* a = (struct hold_thread_args*)arg;
+
+   if (a == NULL || a->command == NULL)
+   {
+      return NULL;
+   }
+   a->exit_status = system(a->command);
+   return NULL;
 }
 
 static char*

--- a/test/testcases/test_pool_saturation.c
+++ b/test/testcases/test_pool_saturation.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 The pgagroal community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <tsclient.h>
+#include <mctf.h>
+
+/*
+ * Smoke test for pgagroal_tsclient_execute_concurrent_holds(): two concurrent
+ * psql sessions each open a backend through pgagroal and run
+ * BEGIN; SELECT pg_sleep(1); COMMIT;. The client count is intentionally far
+ * below any test configuration's max_connections so this test does not depend
+ * on retry-path behaviour and only validates that the harness can drive
+ * multiple parallel sessions end-to-end.
+ *
+ * The retry-path regression for issue #875 is exercised by a separate
+ * testcase (test_pgagroal_pool_saturation_retry), which is added alongside
+ * the fix in PR #878.
+ */
+MCTF_TEST(test_pgagroal_pool_concurrent_smoke)
+{
+   int found = 0;
+
+   found = !pgagroal_tsclient_execute_concurrent_holds(user, database, 2, 1);
+   MCTF_ASSERT(found, cleanup, "two concurrent holds did not both succeed");
+cleanup:
+   MCTF_FINISH();
+}


### PR DESCRIPTION
Implements the test infrastructure for #879.

## What's in this PR

- **`pgagroal_tsclient_execute_concurrent_holds(user, database, client_count, hold_seconds)`** in `test/libpgagroaltest/tsclient.c`. Spawns `client_count` pthreads, each running `psql -c "BEGIN; SELECT pg_sleep(hold_seconds); COMMIT;"` through pgagroal, and returns 0 only if every session returned success. Uses pthreads + `system(psql)` to match the existing tsclient style — no new build dependencies.
- **`test/conf/17/`** — `max_connections=6`, `blocking_timeout=10`, performance pipeline. Gives `run-configs` mode a deterministic small-cap environment for saturation scenarios.
- **`test_pgagroal_pool_concurrent_smoke`** — two concurrent holds, 1s `pg_sleep` each, well under any config's `max_connections`. Validates the helper end-to-end without depending on retry-path behaviour.

## Why the split with #878

A regression test for #875 by definition fails on master pre-fix. Landing it alone would leave master red.

Per [@fluca1978's comment on PR #878](https://github.com/pgagroal/pgagroal/pull/878#issuecomment-4386278575) ("I would like to have #879 merged first"), this PR lands first and contains only what's safe to ship without the fix: the harness, the config, and the smoke test that exercises the harness. The actual retry-path regression test (`test_pgagroal_pool_saturation_retry`, N+2 clients exceeding the cap) is added in #878 alongside the fix, so master is never red.

## Refs

- References #875 (the bug being tested)
- References #878 (the companion fix + retry-path test)
- Issue #879 stays open until #878 lands the saturation test