### PR TITLE
[#843] Handle server identifier validation on conf reload

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -94,7 +94,7 @@ The available keys and their accepted values are reported in the table below.
 | health_check_period | 30 | Int | No | The interval in seconds between health check scans. |
 | health_check_timeout | 5 | String | No | The amount of time the process will wait for a response during a health check. If this value is specified without units, it is taken as seconds. It supports the following units as suffixes: 'S' for seconds (default), 'M' for minutes, 'H' for hours, 'D' for days, and 'W' for weeks. |
 | health_check_user | | String | Yes (if health_check=on) | The user used for connecting to the health check. This user will also be used as the database name. This credential is also used at startup for the `startup_validation` check. It is best practice to configure `health_check_user` on all servers, even if `health_check` is disabled, so that startup validation can verify server identifiers. |
-| startup_validation | `try` | String | No | Controls startup validation of server system identifiers. `on`: fail startup if identifiers cannot be fetched or if duplicates are detected (requires `health_check_user`). `try`: attempt the check if `health_check_user` is set, otherwise log an INFO message and continue. `off`: skip identifier checks entirely. |
+| startup_validation | `try` | String | No | Controls validation of server system identifiers at startup and during configuration reload. `on`: fail startup if identifiers cannot be fetched or if duplicates are detected (requires `health_check_user`). `try`: attempt the check if `health_check_user` is set, otherwise log an INFO message and continue. `off`: skip identifier checks entirely. Note: during reload, duplicates result in the conflicting server being marked as invalid rather than failing the reload. |
 
 
 __Danger zone__
@@ -123,10 +123,15 @@ Note, that if `host` starts with a `/` it represents a path and [**pgagroal**](h
 
 ### system_identifier duplicate behavior
 
-At startup, pgagroal validates each configured server's PostgreSQL `system_identifier` when `startup_validation` is enabled (subject to the configured `health_check_user` mode).
+At startup and upon configuration reload, pgagroal validates each configured server's PostgreSQL `system_identifier` when `startup_validation` is enabled (subject to the configured `health_check_user` mode). During startup, duplicates result in a fatal error. During a reload, duplicates result in the conflicting server being marked as invalid instead.
 
 - If two non-primary servers (`primary = off`) report the same `system_identifier`, startup validation fails.
 - If a duplicate pair includes a server configured with `primary = on`, startup validation does not fail for that pair.
+
+When a conflicting server needs to be marked as invalid during a configuration reload, pgagroal uses the following tie-breaking rules to determine which server to keep:
+1. A server with active connections is kept over one without.
+2. A primary server is kept over a standby.
+3. If both are equal, the server defined earlier in the configuration is kept.
 
 This behavior is consistent with PostgreSQL replication semantics: a standby created from a primary backup remains part of the same cluster and therefore shares the same `system_identifier` as its primary.
 

--- a/doc/manual/en/04-configuration.md
+++ b/doc/manual/en/04-configuration.md
@@ -76,7 +76,7 @@ The available keys and their accepted values are reported in the table below.
 | health_check_period | 30 | Int | No | The interval in seconds between health check scans. |
 | health_check_timeout | 5 | String | No | The amount of time the process will wait for a response during a health check. If this value is specified without units, it is taken as seconds. It supports the following units as suffixes: 'S' for seconds (default), 'M' for minutes, 'H' for hours, 'D' for days, and 'W' for weeks. |
 | health_check_user | | String | Yes (if health_check=on) | The user used for connecting to the health check. This user will also be used as the database name. This credential is also used at startup for the `startup_validation` check. It is best practice to configure `health_check_user` on all servers, even if `health_check` is disabled, so that startup validation can verify server identifiers. See [Health Check](./19-health_check.md) for setup details and security considerations. |
-| startup_validation | `try` | String | No | Controls startup validation of server system identifiers. `on`: fail startup if identifiers cannot be fetched or if duplicates are detected (requires `health_check_user`). `try`: attempt the check if `health_check_user` is set, otherwise log an INFO message and continue. `off`: skip identifier checks entirely. |
+| startup_validation | `try` | String | No | Controls validation of server system identifiers at startup and during configuration reload. `on`: fail startup if identifiers cannot be fetched or if duplicates are detected (requires `health_check_user`). `try`: attempt the check if `health_check_user` is set, otherwise log an INFO message and continue. `off`: skip identifier checks entirely. Note: during reload, duplicates result in the conflicting server being marked as invalid rather than failing the reload. |
 
 
 __Danger zone__
@@ -106,10 +106,15 @@ Note, that if `host` starts with a `/` it represents a path and [**pgagroal**](h
 
 ### system_identifier duplicate behavior
 
-At startup, pgagroal checks each configured server's PostgreSQL `system_identifier` when `startup_validation` is enabled (and `health_check_user` is configured according to the selected mode).
+At startup and upon configuration reload, pgagroal checks each configured server's PostgreSQL `system_identifier` when `startup_validation` is enabled (and `health_check_user` is configured according to the selected mode). During startup, duplicates result in a fatal error. During a reload, duplicates result in the conflicting server being marked as invalid instead.
 
 - If two non-primary servers (`primary = off`) expose the same `system_identifier`, startup validation fails.
 - If a duplicate pair includes a server with `primary = on`, startup validation does not fail for that pair.
+
+When a conflicting server needs to be marked as invalid during a configuration reload, pgagroal uses the following tie-breaking rules to determine which server to keep:
+1. A server with active connections is kept over one without.
+2. A primary server is kept over a standby.
+3. If both are equal, the server defined earlier in the configuration is kept.
 
 This behavior is consistent with PostgreSQL replication semantics: a standby created from a primary backup remains part of the same cluster and therefore shares the same `system_identifier` as its primary.
 

--- a/doc/manual/en/19-health_check.md
+++ b/doc/manual/en/19-health_check.md
@@ -76,14 +76,18 @@ To set up a dedicated health check user:
 
 * **Always configure `health_check_user`**: It is best practice to set `health_check_user` on all configured servers, even when `health_check` is disabled. This allows pgagroal to verify server system identifiers at startup and detect misconfigured duplicate servers before they cause problems.
 
-* **Use `startup_validation`**: The `startup_validation` parameter controls how strictly pgagroal validates server identifiers at startup:
+* **Use `startup_validation`**: The `startup_validation` parameter controls how strictly pgagroal validates server identifiers at startup and configuration reload:
 
   | Value | Behavior |
   |-------|----------|
   | `on`  | Fail startup if `health_check_user` is not configured, if any server identifier cannot be fetched, or if duplicate identifiers are detected. Recommended for production. |
-  | `try` | (Default) Attempt the check if `health_check_user` is set. If not set, log an INFO message and continue. If a query fails, log a warning but continue. Duplicates still cause a fatal error. |
+  | `try` | (Default) Attempt the check if `health_check_user` is set. If not set, log an INFO message and continue. If a query fails, log a warning but continue. Duplicates still cause a fatal error at startup. |
   | `off` | Skip identifier checks entirely. |
 
+  *Note: During configuration reload, duplicates result in the conflicting server being marked as invalid rather than a fatal error. The server to invalidate is chosen based on the following tie-breaking rules:*
+  1. *A server with active connections is kept over one without.*
+  2. *A primary server is kept over a standby.*
+  3. *If both are equal, the server defined earlier in the configuration is kept.*
   Example configuration for strict startup validation:
   ```ini
   [pgagroal]

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -388,6 +388,7 @@ struct server
    int minor_version;            /**< The minor version of the server */
    char system_identifier[64];   /**< The system identifier of the server */
    bool tls;                     /**< Use TLS if possible */
+   bool valid;                   /**< Is the server valid */
    char tls_cert_file[MAX_PATH]; /**< TLS certificate path */
    char tls_key_file[MAX_PATH];  /**< TLS key path */
    char tls_ca_file[MAX_PATH];   /**< TLS CA certificate path */
@@ -397,6 +398,14 @@ struct server
    atomic_schar auth_type;       /**< The authentication type used for health check */
    int lineno;                   /**< The line number within the configuration file */
 } __attribute__((aligned(64)));
+
+#define FOREACH_SERVER for (int i = 0; i < config->number_of_servers; i++)
+#define FOREACH_VALID_SERVER                           \
+   for (int i = 0; i < config->number_of_servers; i++) \
+      if (config->servers[i].valid)
+#define FOREACH_INVALID_SERVER                         \
+   for (int i = 0; i < config->number_of_servers; i++) \
+      if (!config->servers[i].valid)
 
 /** @struct connection
  * Defines a connection

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -100,7 +100,7 @@ pgagroal_server_switch(char* server);
  * @return 0 upon success, otherwise 1
  */
 int
-pgagroal_check_server_identifiers(void);
+pgagroal_check_server_identifiers(bool strict);
 
 /**
  * Connect to a server, authenticate, and execute a simple query
@@ -126,6 +126,14 @@ pgagroal_server_query_execute(int server_idx, char* user, char* database, char* 
  */
 int
 pgagroal_server_get_connectivity_info(int server, char** status, char** primary, int64_t* behind_bytes);
+
+/**
+ * Check if the server is a primary server
+ * @param server The server index
+ * @return true if primary, false otherwise
+ */
+bool
+pgagroal_server_is_primary(int server);
 
 #ifdef __cplusplus
 }

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -36,6 +36,7 @@
 #include <network.h>
 #include <pipeline.h>
 #include <security.h>
+#include <server.h>
 #include <shmem.h>
 #include <utils.h>
 #include <utf8.h>
@@ -303,6 +304,7 @@ pgagroal_read_configuration(void* shm, char* filename, bool emit_warnings)
                atomic_init(&srv.state, SERVER_NOTINIT);
                memcpy(&srv.name, &section, strlen(section));
                srv.lineno = lineno;
+               srv.valid = true;
                idx_server++;
             }
          }
@@ -650,7 +652,7 @@ pgagroal_validate_configuration(void* shm, bool has_unix_socket, bool has_main_s
       return 1;
    }
 
-   for (int i = 0; i < config->number_of_servers; i++)
+   FOREACH_VALID_SERVER
    {
       if (strlen(config->servers[i].host) == 0)
       {
@@ -672,7 +674,7 @@ pgagroal_validate_configuration(void* shm, bool has_unix_socket, bool has_main_s
    }
 
    // check for duplicated servers
-   for (int i = 0; i < config->number_of_servers; i++)
+   FOREACH_VALID_SERVER
    {
       for (int j = i + 1; j < config->number_of_servers; j++)
       {
@@ -692,7 +694,7 @@ pgagroal_validate_configuration(void* shm, bool has_unix_socket, bool has_main_s
    // check for multiple primary servers
    {
       int primary_count = 0;
-      for (int i = 0; i < config->number_of_servers; i++)
+      FOREACH_VALID_SERVER
       {
          if (atomic_load(&config->servers[i].state) == SERVER_NOTINIT_PRIMARY)
          {
@@ -755,7 +757,7 @@ pgagroal_validate_configuration(void* shm, bool has_unix_socket, bool has_main_s
          }
       }
 
-      for (int i = 0; i < config->number_of_servers; i++)
+      FOREACH_VALID_SERVER
       {
          if (config->servers[i].tls)
          {
@@ -3850,6 +3852,9 @@ transfer_configuration(struct main_configuration* config, struct main_configurat
    memset(&config->superuser, 0, sizeof(struct user));
    copy_user(&config->superuser, &reload->superuser);
 
+   /* Runtime revalidation: check for duplicate system identifiers after reload */
+   pgagroal_check_server_identifiers(false);
+
    /* prometheus */
    /* connections[] */
 
@@ -4036,6 +4041,9 @@ copy_server(struct server* dst, struct server* src)
    memcpy(&dst->tls_cert_file[0], &src->tls_cert_file[0], MAX_PATH);
    memcpy(&dst->tls_key_file[0], &src->tls_key_file[0], MAX_PATH);
    memcpy(&dst->tls_ca_file[0], &src->tls_ca_file[0], MAX_PATH);
+   memcpy(&dst->system_identifier[0], &src->system_identifier[0], 64);
+   dst->valid = src->valid;
+
    atomic_init(&dst->state, state);
 }
 
@@ -6782,7 +6790,7 @@ add_servers_configuration_response(struct json* res)
       goto error;
    }
 
-   for (int i = 0; i < config->number_of_servers; i++)
+   FOREACH_VALID_SERVER
    {
       if (pgagroal_json_create(&server_conf))
       {
@@ -7253,7 +7261,7 @@ is_valid_config_key(const char* config_key, struct config_key_info* key_info)
       case 1: // Server section
       {
          bool server_found = false;
-         for (int i = 0; i < config->number_of_servers; i++)
+         FOREACH_VALID_SERVER
          {
             if (!strncmp(config->servers[i].name, key_info->context, MISC_LENGTH))
             {
@@ -7354,7 +7362,7 @@ reset_server_failures(void)
 {
    struct main_configuration* config = (struct main_configuration*)shmem;
 
-   for (int i = 0; i < config->number_of_servers; i++)
+   FOREACH_VALID_SERVER
    {
       config->servers[i].failures = 0;
    }

--- a/src/libpgagroal/health.c
+++ b/src/libpgagroal/health.c
@@ -159,7 +159,7 @@ health_check_loop(void)
 
       pgagroal_log_debug("Health check run");
 
-      for (int i = 0; i < config->number_of_servers; i++)
+      FOREACH_VALID_SERVER
       {
          int auth = HEALTH_CHECK_AUTH_UNKNOWN;
          up = false;

--- a/src/libpgagroal/management.c
+++ b/src/libpgagroal/management.c
@@ -960,7 +960,7 @@ pgagroal_management_response_error(SSL* ssl, int socket, char* server, int32_t e
       }
       else
       {
-         for (int i = 0; i < config->number_of_servers; i++)
+         FOREACH_VALID_SERVER
          {
             if (!strcmp(server, config->servers[i].name))
             {

--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -1144,7 +1144,7 @@ pgagroal_prometheus_failed_servers(void)
 
    count = 0;
 
-   for (int i = 0; i < config->number_of_servers; i++)
+   FOREACH_VALID_SERVER
    {
       signed char state = atomic_load(&config->servers[i].state);
       if (state == SERVER_FAILED)
@@ -2332,7 +2332,7 @@ general_information(prometheus_metrics_container_t* container)
 
    data = pgagroal_append(data, "#HELP pgagroal_server_error The number of errors for servers\n");
    data = pgagroal_append(data, "#TYPE pgagroal_server_error counter\n");
-   for (int i = 0; i < config->number_of_servers; i++)
+   FOREACH_VALID_SERVER
    {
       int state = atomic_load(&config->servers[i].state);
 
@@ -2426,7 +2426,7 @@ general_information(prometheus_metrics_container_t* container)
    pgagroal_log_debug("Prometheus: Appending server health for %d servers", config->number_of_servers);
    data = pgagroal_append(data, "#HELP pgagroal_server_health The health state of the server (0 = DOWN, 1 = UP, 2 = UNKNOWN)\n");
    data = pgagroal_append(data, "#TYPE pgagroal_server_health gauge\n");
-   for (int i = 0; i < config->number_of_servers; i++)
+   FOREACH_VALID_SERVER
    {
       pgagroal_log_debug("Prometheus: Server %d", i);
       int health_state = atomic_load(&config->servers[i].health_state);
@@ -2472,7 +2472,7 @@ general_information(prometheus_metrics_container_t* container)
 
    data = pgagroal_append(data, "#HELP pgagroal_server_version The PostgreSQL major version for each server\n");
    data = pgagroal_append(data, "#TYPE pgagroal_server_version gauge\n");
-   for (int i = 0; i < config->number_of_servers; i++)
+   FOREACH_VALID_SERVER
    {
       if (config->servers[i].version <= 0)
       {
@@ -3963,6 +3963,10 @@ pgagroal_update_main_certificate_metrics(struct main_configuration* config)
    // Parse server TLS certificates
    for (int i = 0; i < config->number_of_servers && cert_index < MAX_CERTIFICATES; i++)
    {
+      if (!config->servers[i].valid)
+      {
+         continue;
+      }
       if (strlen(config->servers[i].tls_cert_file) > 0)
       {
          cert_info = &cert_metrics->certs[cert_index];

--- a/src/libpgagroal/server.c
+++ b/src/libpgagroal/server.c
@@ -52,6 +52,97 @@
 static int failover(int old_primary);
 static int process_server_parameters(int server, struct deque* server_parameters);
 static int query_system_identifier(int server_idx, char* identifier, size_t id_size, int* pg_version);
+static bool has_active_connections(int server_idx);
+static int determine_loser(int i, int j);
+
+/**
+ * Check if a server has active connections in the pool.
+ *
+ * @param server_idx The server index
+ * @return true if the server has at least one active connection
+ */
+static bool
+has_active_connections(int server_idx)
+{
+   struct main_configuration* config;
+
+   config = (struct main_configuration*)shmem;
+
+   for (int k = 0; k < config->max_connections; k++)
+   {
+      signed char state = atomic_load(&config->states[k]);
+      if (state != STATE_NOTINIT && state != STATE_INIT && state != STATE_FREE)
+      {
+         if (config->connections[k].server == server_idx)
+         {
+            return true;
+         }
+      }
+   }
+
+   return false;
+}
+
+/**
+ * Determine which of two duplicate servers to invalidate.
+ *
+ * Tie-breaking rules:
+ * 1. If one server has active connections, keep it
+ * 2. If one server is PRIMARY, keep it
+ * 3. Otherwise keep the lower index (first in config order)
+ *
+ * @param i First server index
+ * @param j Second server index
+ * @return The index of the server to invalidate (the "loser")
+ */
+static int
+determine_loser(int i, int j)
+{
+   bool i_active;
+   bool j_active;
+
+   i_active = has_active_connections(i);
+   j_active = has_active_connections(j);
+
+   /* Rule 1: Keep the server with active connections */
+   if (i_active && !j_active)
+   {
+      return j;
+   }
+   if (j_active && !i_active)
+   {
+      return i;
+   }
+
+   /* Rule 2: Keep the PRIMARY server */
+
+   if (pgagroal_server_is_primary(i) && !pgagroal_server_is_primary(j))
+   {
+      return j;
+   }
+   if (pgagroal_server_is_primary(j) && !pgagroal_server_is_primary(i))
+   {
+      return i;
+   }
+
+   /* Rule 3: Keep the lower index (first in config order) */
+   return i < j ? i : j;
+}
+
+/**
+ * Check if the server is a primary server
+ */
+bool
+pgagroal_server_is_primary(int server)
+{
+   struct main_configuration* config;
+   signed char state;
+
+   config = (struct main_configuration*)shmem;
+   state = atomic_load(&config->servers[server].state);
+
+   return state == SERVER_PRIMARY || state == SERVER_NOTINIT_PRIMARY;
+}
 
 /**
  * Check server system identifiers for duplicates.
@@ -60,17 +151,19 @@ static int query_system_identifier(int server_idx, char* identifier, size_t id_s
  *   off: skip entirely
  *   try: run check if health_check_user is set, otherwise log INFO and continue
  *   on:  require health_check_user and fail on any query error or duplicate
+ *
+ * When strict is true (startup), duplicates cause a fatal error.
+ * When strict is false (reload), duplicates cause the losing server to be
+ * marked as invalid using tie-breaking rules.
  */
 int
-pgagroal_check_server_identifiers(void)
+pgagroal_check_server_identifiers(bool strict)
 {
    struct main_configuration* config;
    char identifiers[NUMBER_OF_SERVERS][64];
    int versions[NUMBER_OF_SERVERS];
-   int num_servers;
 
    config = (struct main_configuration*)shmem;
-   num_servers = config->number_of_servers;
 
    if (config->startup_validation == STARTUP_VALIDATION_OFF)
    {
@@ -82,8 +175,16 @@ pgagroal_check_server_identifiers(void)
    {
       if (config->startup_validation == STARTUP_VALIDATION_ON)
       {
-         pgagroal_log_fatal("startup_validation is set to 'on' but health_check_user is not configured");
-         return 1;
+         if (strict)
+         {
+            pgagroal_log_fatal("startup_validation is set to 'on' but health_check_user is not configured");
+            return 1;
+         }
+         else
+         {
+            pgagroal_log_warn("startup_validation is set to 'on' but health_check_user is not configured");
+            return 0;
+         }
       }
 
       /* try mode: no health_check_user, just inform and continue */
@@ -93,7 +194,7 @@ pgagroal_check_server_identifiers(void)
 
    pgagroal_log_info("Checking server system identifiers");
 
-   for (int i = 0; i < num_servers; i++)
+   FOREACH_VALID_SERVER
    {
       versions[i] = 0;
 
@@ -103,9 +204,17 @@ pgagroal_check_server_identifiers(void)
       {
          if (config->startup_validation == STARTUP_VALIDATION_ON)
          {
-            pgagroal_log_fatal("Could not query system_identifier for server [%s] (%s:%d)",
-                               config->servers[i].name, config->servers[i].host, config->servers[i].port);
-            return 1;
+            if (strict)
+            {
+               pgagroal_log_fatal("Could not query system_identifier for server [%s] (%s:%d)",
+                                  config->servers[i].name, config->servers[i].host, config->servers[i].port);
+               return 1;
+            }
+            else
+            {
+               pgagroal_log_warn("Could not query system_identifier for server [%s] (%s:%d)",
+                                 config->servers[i].name, config->servers[i].host, config->servers[i].port);
+            }
          }
 
          pgagroal_log_warn("Could not query system_identifier for server [%s] (%s:%d)",
@@ -121,34 +230,58 @@ pgagroal_check_server_identifiers(void)
       }
    }
 
-   for (int i = 0; i < num_servers; i++)
+   FOREACH_VALID_SERVER
    {
-      signed char state_i = atomic_load(&config->servers[i].state);
-
-      if (!strlen(identifiers[i]) ||
-          state_i == SERVER_PRIMARY ||
-          state_i == SERVER_NOTINIT_PRIMARY)
+      if (!strlen(identifiers[i]) || pgagroal_server_is_primary(i))
       {
          continue;
       }
-      for (int j = i + 1; j < num_servers; j++)
+      for (int j = i + 1; j < config->number_of_servers; j++)
       {
-         signed char state_j = atomic_load(&config->servers[j].state);
+         if (!config->servers[j].valid)
+         {
+            continue;
+         }
 
-         if (!strlen(identifiers[j]) ||
-             state_j == SERVER_PRIMARY ||
-             state_j == SERVER_NOTINIT_PRIMARY)
+         if (!strlen(identifiers[j]) || pgagroal_server_is_primary(j))
          {
             continue;
          }
          if (!strcmp(identifiers[i], identifiers[j]))
          {
-            pgagroal_log_fatal("Servers [%s] (%s:%d) and [%s] (%s:%d) have the same system_identifier (%s) "
-                               "- they point to the same PostgreSQL cluster",
-                               config->servers[i].name, config->servers[i].host, config->servers[i].port,
-                               config->servers[j].name, config->servers[j].host, config->servers[j].port,
-                               identifiers[i]);
-            return 1;
+            if (strict)
+            {
+               pgagroal_log_fatal("Servers [%s] (%s:%d) and [%s] (%s:%d) have the same system_identifier (%s) "
+                                  "- they point to the same PostgreSQL cluster",
+                                  config->servers[i].name, config->servers[i].host, config->servers[i].port,
+                                  config->servers[j].name, config->servers[j].host, config->servers[j].port,
+                                  identifiers[i]);
+               return 1;
+            }
+            else
+            {
+               int loser = determine_loser(i, j);
+               int winner = (loser == i) ? j : i;
+
+               pgagroal_log_warn("Servers [%s] (%s:%d) and [%s] (%s:%d) have the same system_identifier (%s) "
+                                 "- marking [%s] as invalid",
+                                 config->servers[i].name, config->servers[i].host, config->servers[i].port,
+                                 config->servers[j].name, config->servers[j].host, config->servers[j].port,
+                                 identifiers[i],
+                                 config->servers[loser].name);
+
+               config->servers[loser].valid = false;
+
+               pgagroal_log_info("Keeping server [%s] (%s:%d), invalidated [%s] (%s:%d)",
+                                 config->servers[winner].name, config->servers[winner].host, config->servers[winner].port,
+                                 config->servers[loser].name, config->servers[loser].host, config->servers[loser].port);
+
+               /* If the loser is server i, break inner loop since i is now invalid */
+               if (loser == i)
+               {
+                  break;
+               }
+            }
          }
       }
    }
@@ -156,7 +289,7 @@ pgagroal_check_server_identifiers(void)
    /* Check for version mismatches against the primary server */
    int primary_server = -1;
 
-   for (int i = 0; i < num_servers; i++)
+   FOREACH_VALID_SERVER
    {
       if (versions[i] == 0)
       {
@@ -172,7 +305,7 @@ pgagroal_check_server_identifiers(void)
 
    if (primary_server != -1)
    {
-      for (int i = 0; i < num_servers; i++)
+      FOREACH_VALID_SERVER
       {
          if (i == primary_server || versions[i] == 0)
          {
@@ -618,6 +751,10 @@ pgagroal_get_primary(int* server)
    /* Find PRIMARY */
    for (int i = 0; primary == -1 && i < config->number_of_servers; i++)
    {
+      if (!config->servers[i].valid)
+      {
+         continue;
+      }
       server_state = atomic_load(&config->servers[i].state);
       if (server_state == SERVER_PRIMARY)
       {
@@ -629,6 +766,10 @@ pgagroal_get_primary(int* server)
    /* Find NOTINIT_PRIMARY */
    for (int i = 0; primary == -1 && i < config->number_of_servers; i++)
    {
+      if (!config->servers[i].valid)
+      {
+         continue;
+      }
       server_state = atomic_load(&config->servers[i].state);
       if (server_state == SERVER_NOTINIT_PRIMARY)
       {
@@ -640,6 +781,10 @@ pgagroal_get_primary(int* server)
    /* Find the first valid server */
    for (int i = 0; primary == -1 && i < config->number_of_servers; i++)
    {
+      if (!config->servers[i].valid)
+      {
+         continue;
+      }
       server_state = atomic_load(&config->servers[i].state);
       if (server_state != SERVER_FAILOVER && server_state != SERVER_FAILED)
       {
@@ -851,7 +996,7 @@ pgagroal_server_clear(char* server)
 
    config = (struct main_configuration*)shmem;
 
-   for (int i = 0; i < config->number_of_servers; i++)
+   FOREACH_VALID_SERVER
    {
       if (!strcmp(config->servers[i].name, server))
       {
@@ -882,7 +1027,7 @@ pgagroal_server_switch(char* server)
    pgagroal_log_debug("pgagroal: Attempting to switch to server '%s'", server);
 
    // Find current primary server
-   for (int i = 0; i < config->number_of_servers; i++)
+   FOREACH_VALID_SERVER
    {
       state = atomic_load(&config->servers[i].state);
       if (state == SERVER_PRIMARY)
@@ -892,7 +1037,7 @@ pgagroal_server_switch(char* server)
       }
    }
    // Find target server by name
-   for (int i = 0; i < config->number_of_servers; i++)
+   FOREACH_VALID_SERVER
    {
       if (!strcmp(config->servers[i].name, server))
       {
@@ -990,7 +1135,7 @@ notify_standbys(int old_primary, int new_primary)
       args[idx++] = config->servers[new_primary].host;
       args[idx++] = new_port;
 
-      for (int i = 0; i < config->number_of_servers; i++)
+      FOREACH_VALID_SERVER
       {
          if (i == old_primary || i == new_primary)
             continue;
@@ -1039,6 +1184,10 @@ failover(int old_primary)
 
    for (int i = 0; new_primary == -1 && i < config->number_of_servers; i++)
    {
+      if (!config->servers[i].valid)
+      {
+         continue;
+      }
       state = atomic_load(&config->servers[i].state);
       if (state == SERVER_NOTINIT || state == SERVER_NOTINIT_PRIMARY || state == SERVER_REPLICA)
       {

--- a/src/libpgagroal/status.c
+++ b/src/libpgagroal/status.c
@@ -194,7 +194,7 @@ status_details(bool details, struct json* response)
 
    pgagroal_json_create(&servers);
 
-   for (int i = 0; i < config->number_of_servers; i++)
+   FOREACH_VALID_SERVER
    {
       struct json* js = NULL;
       const char* health_str = "UNKNOWN";
@@ -233,6 +233,33 @@ status_details(bool details, struct json* response)
    }
 
    pgagroal_json_put(response, MANAGEMENT_ARGUMENT_SERVERS, (uintptr_t)servers, ValueJSON);
+
+   /* Show invalid servers separately */
+   {
+      struct json* invalid_servers = NULL;
+      pgagroal_json_create(&invalid_servers);
+
+      FOREACH_INVALID_SERVER
+      {
+         struct json* js = NULL;
+
+         if (strlen(config->servers[i].name) == 0)
+         {
+            continue;
+         }
+
+         pgagroal_json_create(&js);
+
+         pgagroal_json_put(js, MANAGEMENT_ARGUMENT_SERVER, (uintptr_t)config->servers[i].name, ValueString);
+         pgagroal_json_put(js, MANAGEMENT_ARGUMENT_HOST, (uintptr_t)config->servers[i].host, ValueString);
+         pgagroal_json_put(js, MANAGEMENT_ARGUMENT_PORT, (uintptr_t)config->servers[i].port, ValueInt32);
+         pgagroal_json_put(js, MANAGEMENT_ARGUMENT_STATE, (uintptr_t)"Invalid", ValueString);
+
+         pgagroal_json_put(invalid_servers, config->servers[i].name, (uintptr_t)js, ValueJSON);
+      }
+
+      pgagroal_json_put(response, "invalid_servers", (uintptr_t)invalid_servers, ValueJSON);
+   }
 
    if (details)
    {

--- a/src/main.c
+++ b/src/main.c
@@ -1259,7 +1259,7 @@ read_superuser_path:
       pgagroal_health_check(argc, argv);
    }
 
-   if (pgagroal_check_server_identifiers())
+   if (pgagroal_check_server_identifiers(true))
    {
       pgagroal_log_fatal("pgagroal: Duplicate server system identifiers detected");
 #ifdef HAVE_SYSTEMD
@@ -1952,7 +1952,7 @@ accept_mgt_cb(struct io_watcher* watcher)
       pgagroal_management_create_response(payload, -1, &response);
       pgagroal_json_create(&servers);
 
-      for (int i = 0; i < config->number_of_servers; i++)
+      FOREACH_VALID_SERVER
       {
          struct json* sobj = NULL;
          char* srv_status = NULL;
@@ -1980,6 +1980,31 @@ accept_mgt_cb(struct io_watcher* watcher)
       }
 
       pgagroal_json_put(response, MANAGEMENT_ARGUMENT_SERVERS, (uintptr_t)servers, ValueJSON);
+
+      /* Show invalid servers */
+      {
+         struct json* invalid_servers = NULL;
+         pgagroal_json_create(&invalid_servers);
+
+         FOREACH_INVALID_SERVER
+         {
+            struct json* sobj = NULL;
+
+            if (strlen(config->servers[i].name) == 0)
+            {
+               continue;
+            }
+
+            pgagroal_json_create(&sobj);
+            pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_HOST, (uintptr_t)config->servers[i].host, ValueString);
+            pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_PORT, (uintptr_t)config->servers[i].port, ValueInt32);
+            pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_STATUS, (uintptr_t)"Invalid", ValueString);
+
+            pgagroal_json_put(invalid_servers, config->servers[i].name, (uintptr_t)sobj, ValueJSON);
+         }
+
+         pgagroal_json_put(response, "invalid_servers", (uintptr_t)invalid_servers, ValueJSON);
+      }
 
       end_time = time(NULL);
 

--- a/test/testcases/test_startup_validation.c
+++ b/test/testcases/test_startup_validation.c
@@ -172,7 +172,7 @@ MCTF_TEST(test_server_validation_duplicate_system_identifier_primary_on_off)
    snprintf(config->servers[1].host, MISC_LENGTH, "%s", backup.servers[0].host);
    config->servers[1].port = backup.servers[0].port;
 
-   ret = pgagroal_check_server_identifiers();
+   ret = pgagroal_check_server_identifiers(true);
 
    MCTF_ASSERT_INT_EQ(ret, 0, cleanup,
                       "check_server_identifiers should pass when only one duplicate is primary");
@@ -209,7 +209,7 @@ MCTF_TEST(test_server_validation_duplicate_system_identifier_primary_off_off)
    snprintf(config->servers[1].host, MISC_LENGTH, "%s", backup.servers[0].host);
    config->servers[1].port = backup.servers[0].port;
 
-   ret = pgagroal_check_server_identifiers();
+   ret = pgagroal_check_server_identifiers(true);
 
    MCTF_ASSERT(ret != 0, cleanup,
                "check_server_identifiers should fail when duplicate non-primary servers share identifier");
@@ -240,7 +240,7 @@ MCTF_TEST(test_startup_validation_off)
    ret = pgagroal_read_configuration(config, path, false);
    MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "pgagroal_read_configuration should succeed");
 
-   ret = pgagroal_check_server_identifiers();
+   ret = pgagroal_check_server_identifiers(true);
 
    MCTF_ASSERT_INT_EQ(ret, 0, cleanup,
                       "check_server_identifiers should return 0 when startup_validation is off");
@@ -271,7 +271,7 @@ MCTF_TEST(test_startup_validation_try_no_user)
    ret = pgagroal_read_configuration(config, path, false);
    MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "pgagroal_read_configuration should succeed");
 
-   ret = pgagroal_check_server_identifiers();
+   ret = pgagroal_check_server_identifiers(true);
 
    MCTF_ASSERT_INT_EQ(ret, 0, cleanup,
                       "check_server_identifiers should return 0 in try mode without health_check_user");
@@ -302,7 +302,7 @@ MCTF_TEST(test_startup_validation_on_no_user)
    ret = pgagroal_read_configuration(config, path, false);
    MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "pgagroal_read_configuration should succeed");
 
-   ret = pgagroal_check_server_identifiers();
+   ret = pgagroal_check_server_identifiers(true);
 
    MCTF_ASSERT(ret != 0, cleanup,
                "check_server_identifiers should fail in on mode without health_check_user");
@@ -337,7 +337,7 @@ MCTF_TEST(test_startup_validation_single_server_pg_control_version_and_system_id
    snprintf(config->servers[0].host, MISC_LENGTH, "%s", backup.servers[0].host);
    config->servers[0].port = backup.servers[0].port;
 
-   ret = pgagroal_check_server_identifiers();
+   ret = pgagroal_check_server_identifiers(true);
 
    MCTF_ASSERT_INT_EQ(ret, 0, cleanup,
                       "check_server_identifiers should succeed for a single valid server");
@@ -347,6 +347,118 @@ MCTF_TEST(test_startup_validation_single_server_pg_control_version_and_system_id
 
    MCTF_ASSERT(strlen(config->servers[0].system_identifier) > 0, cleanup,
                "server system_identifier should be populated alongside version after startup validation");
+
+cleanup:
+   /* Restore original config */
+   memcpy(config, &backup, sizeof(struct main_configuration));
+   MCTF_FINISH();
+}
+
+// duplicate system_identifier with primary=on + primary=off (runtime): should pass and both remain valid
+MCTF_TEST(test_runtime_validation_duplicate_system_identifier_primary_on_off)
+{
+   struct main_configuration* config;
+   struct main_configuration backup;
+   char path[MAX_PATH];
+   int ret;
+
+   config = (struct main_configuration*)shmem;
+
+   /* Save original state */
+   memcpy(&backup, config, sizeof(struct main_configuration));
+
+   MCTF_ASSERT(build_test_conf_path("15", path, sizeof(path)) == 0,
+               cleanup, "Failed to build config path");
+
+   pgagroal_init_configuration(config);
+   ret = pgagroal_read_configuration(config, path, false);
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "pgagroal_read_configuration should succeed");
+   config->max_connections = MIN(config->max_connections, MAX_NUMBER_OF_CONNECTIONS);
+
+   /* Point both servers to the same live instance to force equal system_identifier */
+   snprintf(config->servers[0].host, MISC_LENGTH, "%s", backup.servers[0].host);
+   config->servers[0].port = backup.servers[0].port;
+   snprintf(config->servers[1].host, MISC_LENGTH, "%s", backup.servers[0].host);
+   config->servers[1].port = backup.servers[0].port;
+
+   ret = pgagroal_check_server_identifiers(false);
+
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup,
+                      "check_server_identifiers should pass when only one duplicate is primary during reload");
+   MCTF_ASSERT(config->servers[0].valid, cleanup, "Primary server should remain valid");
+   MCTF_ASSERT(config->servers[1].valid, cleanup, "Standby server should remain valid since its duplicate is a primary");
+
+cleanup:
+   /* Restore original config */
+   memcpy(config, &backup, sizeof(struct main_configuration));
+   MCTF_FINISH();
+}
+
+// duplicate system_identifier with primary=off + primary=off (runtime): should pass but invalidate one
+MCTF_TEST(test_runtime_validation_duplicate_system_identifier_primary_off_off)
+{
+   struct main_configuration* config;
+   struct main_configuration backup;
+   char path[MAX_PATH];
+   int ret;
+
+   config = (struct main_configuration*)shmem;
+
+   /* Save original state */
+   memcpy(&backup, config, sizeof(struct main_configuration));
+
+   MCTF_ASSERT(build_test_conf_path("16", path, sizeof(path)) == 0,
+               cleanup, "Failed to build config path");
+
+   pgagroal_init_configuration(config);
+   ret = pgagroal_read_configuration(config, path, false);
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "pgagroal_read_configuration should succeed");
+   config->max_connections = MIN(config->max_connections, MAX_NUMBER_OF_CONNECTIONS);
+
+   /* Point both servers to the same live instance to force equal system_identifier */
+   snprintf(config->servers[0].host, MISC_LENGTH, "%s", backup.servers[0].host);
+   config->servers[0].port = backup.servers[0].port;
+   snprintf(config->servers[1].host, MISC_LENGTH, "%s", backup.servers[0].host);
+   config->servers[1].port = backup.servers[0].port;
+
+   ret = pgagroal_check_server_identifiers(false);
+
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup,
+                      "check_server_identifiers should not fail during reload when duplicate non-primary servers share identifier");
+   MCTF_ASSERT(config->servers[0].valid != config->servers[1].valid, cleanup,
+               "One and only one of the duplicate servers should be marked as invalid");
+
+cleanup:
+   /* Restore original config */
+   memcpy(config, &backup, sizeof(struct main_configuration));
+   MCTF_FINISH();
+}
+
+// startup_validation = on with no health_check_user (runtime): should pass with a warning
+MCTF_TEST(test_runtime_validation_on_no_user)
+{
+   struct main_configuration* config;
+   struct main_configuration backup;
+   char path[MAX_PATH];
+   int ret;
+
+   config = (struct main_configuration*)shmem;
+
+   /* Save original state */
+   memcpy(&backup, config, sizeof(struct main_configuration));
+
+   MCTF_ASSERT(build_test_conf_path("13", path, sizeof(path)) == 0,
+               cleanup, "Failed to build config path");
+
+   pgagroal_init_configuration(config);
+   ret = pgagroal_read_configuration(config, path, false);
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "pgagroal_read_configuration should succeed");
+   config->max_connections = MIN(config->max_connections, MAX_NUMBER_OF_CONNECTIONS);
+
+   ret = pgagroal_check_server_identifiers(false);
+
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup,
+                      "check_server_identifiers should not fail during reload in on mode without health_check_user");
 
 cleanup:
    /* Restore original config */


### PR DESCRIPTION
resolved #843 

## Changes

1. Added new field attribute `valid` to `struct server`, and define new macros `FOREACH_SERVER`, `FOREACH_VALID_SERVER`, `FOREACH_INVALID_SERVER` .
2. Implemented new utilities `pgagroal_server_is_primary(srv_idx)` , and `has_active_connections(srv_idx)`
3. Add a new mechanism func `determine_loser` to detect invalid server between two ones based on rules 
   1. If one server has active connections, keep it
   2. If one server is PRIMARY, keep it
   3. Otherwise keep the lower index (first in config order)
4. Extend `pgagroal_check_server_identifiers` to have parameter `bool strict` to just warn in runtime server validation and mark invalid server (no stop for pgagroal)