### PR TITLE
[#898] Use configured health_check_timeout instead of hardcoded 5s

### DIFF
--- a/src/include/server.h
+++ b/src/include/server.h
@@ -108,12 +108,13 @@ pgagroal_check_server_identifiers(bool strict);
  * @param user The username for the connection
  * @param database The database name for the connection
  * @param query The SQL query string
+ * @param timeout The timeout in seconds for server responses
  * @param auth_type The authentication type used, can be NULL
  * @param fd_out The resulting file descriptor for reading the response
  * @return 0 upon success, otherwise 1
  */
 int
-pgagroal_server_query_execute(int server_idx, char* user, char* database, char* query, int* auth_type, int* fd_out);
+pgagroal_server_query_execute(int server_idx, char* user, char* database, char* query, int timeout, int* auth_type, int* fd_out);
 
 /**
  * Get live PostgreSQL connectivity, role, and replication lag for one configured server.

--- a/src/libpgagroal/health.c
+++ b/src/libpgagroal/health.c
@@ -227,7 +227,12 @@ server_probe(int server_idx, bool* up, int* auth_type)
                       server_idx, config->servers[server_idx].host,
                       config->servers[server_idx].port, config->health_check_user);
 
-   if (pgagroal_server_query_execute(server_idx, config->health_check_user, config->health_check_user, "SELECT 1", auth_type, &fd) != 0)
+   if (pgagroal_server_query_execute(server_idx,
+                                     config->health_check_user,
+                                     config->health_check_user,
+                                     "SELECT 1",
+                                     MAX(1, (int)pgagroal_time_convert(config->health_check_timeout, FORMAT_TIME_S)),
+                                     auth_type, &fd) != 0)
    {
       pgagroal_log_debug("Health: Failed to connect to server %d", server_idx);
       return 1;
@@ -236,7 +241,9 @@ server_probe(int server_idx, bool* up, int* auth_type)
    /* Wait for query response */
    while (true)
    {
-      status = pgagroal_read_timeout_message(NULL, fd, 5, &msg);
+      status = pgagroal_read_timeout_message(NULL, fd,
+                                             MAX(1, (int)pgagroal_time_convert(config->health_check_timeout, FORMAT_TIME_S)),
+                                             &msg);
       if (status != MESSAGE_STATUS_OK || msg == NULL)
       {
          pgagroal_log_debug("Health: Failed to read query response (status %d)", status);

--- a/src/libpgagroal/server.c
+++ b/src/libpgagroal/server.c
@@ -328,7 +328,7 @@ pgagroal_check_server_identifiers(bool strict)
 }
 
 int
-pgagroal_server_query_execute(int server_idx, char* user, char* database, char* query, int* auth_type, int* fd_out)
+pgagroal_server_query_execute(int server_idx, char* user, char* database, char* query, int timeout, int* auth_type, int* fd_out)
 {
    struct main_configuration* config;
    struct server* srv;
@@ -375,7 +375,7 @@ pgagroal_server_query_execute(int server_idx, char* user, char* database, char* 
    startup_msg = NULL;
 
    /* Authentication Phase */
-   status = pgagroal_read_timeout_message(NULL, fd, 5, &msg);
+   status = pgagroal_read_timeout_message(NULL, fd, timeout, &msg);
    if (status != MESSAGE_STATUS_OK || msg == NULL || msg->kind != 'R')
    {
       pgagroal_log_debug("server_query: Expected 'R' but got %c (status %d)",
@@ -438,7 +438,7 @@ pgagroal_server_query_execute(int server_idx, char* user, char* database, char* 
    {
       if (msg == NULL)
       {
-         status = pgagroal_read_timeout_message(NULL, fd, 5, &msg);
+         status = pgagroal_read_timeout_message(NULL, fd, timeout, &msg);
          if (status != MESSAGE_STATUS_OK || msg == NULL)
          {
             pgagroal_log_debug("server_query: Failed to read from server (status %d)", status);
@@ -534,6 +534,7 @@ query_system_identifier(int server_idx, char* identifier, size_t id_size, int* p
                                      config->health_check_user,
                                      config->health_check_user,
                                      (char*)pgagroal_queries_system_identifier(),
+                                     MAX(1, (int)pgagroal_time_convert(config->health_check_timeout, FORMAT_TIME_S)),
                                      NULL, &fd) != 0)
    {
       return 1;
@@ -542,7 +543,9 @@ query_system_identifier(int server_idx, char* identifier, size_t id_size, int* p
    /* Parse query response and extract system_identifier from DataRow */
    while (true)
    {
-      status = pgagroal_read_timeout_message(NULL, fd, 5, &msg);
+      status = pgagroal_read_timeout_message(NULL, fd,
+                                             MAX(1, (int)pgagroal_time_convert(config->health_check_timeout, FORMAT_TIME_S)),
+                                             &msg);
       if (status != MESSAGE_STATUS_OK || msg == NULL)
       {
          goto error;
@@ -622,6 +625,7 @@ query_system_identifier(int server_idx, char* identifier, size_t id_size, int* p
    }
 
    (void)pgagroal_write_terminate(NULL, fd);
+
    pgagroal_disconnect(fd);
 
    pgagroal_log_debug("system_identifier: Server [%s] (%s:%d) = %s, pg_control_version = %d",
@@ -671,6 +675,7 @@ pgagroal_server_get_connectivity_info(int server, char** status, char** primary,
                                      config->health_check_user,
                                      config->health_check_user,
                                      (char*)pgagroal_queries_is_in_recovery(),
+                                     MAX(1, (int)pgagroal_time_convert(config->health_check_timeout, FORMAT_TIME_S)),
                                      NULL, &fd))
    {
       goto done;
@@ -701,6 +706,7 @@ pgagroal_server_get_connectivity_info(int server, char** status, char** primary,
                                      config->health_check_user,
                                      config->health_check_user,
                                      (char*)pgagroal_queries_replication_lag_bytes(),
+                                     MAX(1, (int)pgagroal_time_convert(config->health_check_timeout, FORMAT_TIME_S)),
                                      NULL, &fd))
    {
       return 0;


### PR DESCRIPTION
Fixes #898 