### PR TITLE
[#848] Enforce per-rule max_size as a hard cap in every pipeline mode

### DIFF
--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -457,6 +457,7 @@ struct limit
    char aliases[MAX_ALIASES][MAX_DATABASE_LENGTH]; /**< The aliases for the database */
    int aliases_count;                              /**< The number of aliases */
    atomic_ushort active_connections;               /**< The active number of connections */
+   atomic_ushort backend_connections;              /**< Live backend connections for the rule (hard-capped at max_size) */
    int max_size;                                   /**< The maximum pool size */
    int initial_size;                               /**< The initial pool size */
    int min_size;                                   /**< The minimum pool size */

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -1458,6 +1458,7 @@ pgagroal_read_limit_configuration(void* shm, char* filename)
                }
 
                atomic_init(&config->limits[index].active_connections, 0);
+               atomic_init(&config->limits[index].backend_connections, 0);
 
                index++;
 

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -153,9 +153,18 @@ start:
    {
       if (best_rule >= 0)
       {
-         int rule_count = get_connection_count_for_limit_rule(best_rule, username);
-         if (rule_count >= config->limits[best_rule].max_size)
+         /* Atomically reserve a backend against the per-rule max_size cap
+          * before creating one. This mirrors the global max_connections gate
+          * above (fetch-add, then test the prior value, rolling back on
+          * overshoot) and replaces the previous count-then-create check, which
+          * was a TOCTOU: concurrent acquirers each read a stale sub-cap count
+          * and then each created a backend, driving the rule past max_size
+          * (issue #848). The reservation is the serialization point, so live
+          * backends for the rule never exceed max_size. */
+         unsigned short reserved = atomic_fetch_add(&config->limits[best_rule].backend_connections, 1);
+         if (reserved >= config->limits[best_rule].max_size)
          {
+            atomic_fetch_sub(&config->limits[best_rule].backend_connections, 1);
             goto retry;
          }
       }
@@ -171,6 +180,14 @@ start:
             do_init = true;
          }
       }
+
+      if (*slot == -1 && best_rule >= 0)
+      {
+         /* Held a rule reservation but no NOTINIT slot remained (lost the race
+          * for the last global slot); release it so the reservation is not
+          * leaked, then fall through to the blocking-timeout retry path. */
+         atomic_fetch_sub(&config->limits[best_rule].backend_connections, 1);
+      }
    }
 
    if (*slot != -1)
@@ -183,6 +200,11 @@ start:
          /* We need to find the server for the connection */
          if (pgagroal_get_primary(&server))
          {
+            if (best_rule >= 0)
+            {
+               /* The backend was reserved but never established; release it. */
+               atomic_fetch_sub(&config->limits[best_rule].backend_connections, 1);
+            }
             config->connections[*slot].limit_rule = -1;
             config->connections[*slot].pid = -1;
             atomic_store(&config->states[*slot], STATE_NOTINIT);
@@ -214,6 +236,11 @@ start:
          if (ret)
          {
             pgagroal_log_error("pgagroal: No connection to %s:%d", config->servers[server].host, config->servers[server].port);
+            if (best_rule >= 0)
+            {
+               /* The backend was reserved but never established; release it. */
+               atomic_fetch_sub(&config->limits[best_rule].backend_connections, 1);
+            }
             config->connections[*slot].limit_rule = -1;
             config->connections[*slot].pid = -1;
             atomic_store(&config->states[*slot], STATE_NOTINIT);
@@ -610,6 +637,17 @@ pgagroal_kill_connection(int slot, SSL* ssl)
    else
    {
       result = 1;
+   }
+
+   if (config->connections[slot].limit_rule >= 0)
+   {
+      /* Release the rule's hard-cap reservation (issue #848). Unlike the
+       * per-rule active_connections below, backend_connections tracks live
+       * backends rather than checkouts, so it must be released on every kill
+       * of a rule-bound backend -- including idle/flush kills of pooled
+       * connections, where pid == -1 and the checkout counter was already
+       * decremented on return. */
+      atomic_fetch_sub(&config->limits[config->connections[slot].limit_rule].backend_connections, 1);
    }
 
    if (config->connections[slot].pid != -1)

--- a/test/include/tsclient.h
+++ b/test/include/tsclient.h
@@ -43,6 +43,7 @@ extern "C" {
 
 #define PGBENCH_LOG_FILE_TRAIL       "/log/pgbench.log"
 #define PGAGROAL_CONFIGURATION_TRAIL "/pgagroal-testsuite/conf/pgagroal.conf"
+#define PGAGROAL_DATABASES_TRAIL     "/pgagroal-testsuite/conf/pgagroal_databases.conf"
 
 extern char project_directory[BUFFER_SIZE];
 extern char* user;

--- a/test/libpgagroaltest/tsclient.c
+++ b/test/libpgagroaltest/tsclient.c
@@ -49,6 +49,7 @@
 char project_directory[BUFFER_SIZE];
 
 static char* get_configuration_path();
+static char* get_databases_path();
 static char* get_log_file_path();
 
 int
@@ -57,6 +58,7 @@ pgagroal_tsclient_init(char* base_dir)
    int ret;
    size_t size;
    char* configuration_path = NULL;
+   char* limit_path = NULL;
 
    memset(project_directory, 0, sizeof(project_directory));
    memcpy(project_directory, base_dir, strlen(base_dir));
@@ -82,6 +84,18 @@ pgagroal_tsclient_init(char* base_dir)
    {
       goto error;
    }
+
+   /* Also load the LIMIT configuration so limit-aware tests can see the rules
+    * in shmem (pgagroal_read_configuration only reads pgagroal.conf). Best
+    * effort: a configuration directory without a databases file just leaves
+    * number_of_limits at 0, exactly as before. */
+   limit_path = get_databases_path();
+   if (limit_path != NULL)
+   {
+      pgagroal_read_limit_configuration(shmem, limit_path);
+      free(limit_path);
+   }
+
    pgagroal_start_logging();
 
    free(configuration_path);
@@ -181,7 +195,7 @@ pgagroal_tsclient_execute_pgbench(char* user, char* database, bool select_only, 
       size_t pwd_len = strlen(password);
       /* Format: "PGPASSWORD=%s %s\0" = 11 + pwd_len + 1 + cmd_len + 1 */
       size_t total_len = 11 + pwd_len + 1 + cmd_len + 1;
-      
+
       command_with_password = (char*)calloc(total_len, sizeof(char));
       if (command_with_password != NULL)
       {
@@ -308,6 +322,21 @@ get_configuration_path()
    memcpy(configuration_path + project_directory_length, PGAGROAL_CONFIGURATION_TRAIL, configuration_trail_length);
 
    return configuration_path;
+}
+
+static char*
+get_databases_path()
+{
+   char* databases_path = NULL;
+   int project_directory_length = strlen(project_directory);
+   int databases_trail_length = strlen(PGAGROAL_DATABASES_TRAIL);
+
+   databases_path = (char*)calloc(project_directory_length + databases_trail_length + 1, sizeof(char));
+
+   memcpy(databases_path, project_directory, project_directory_length);
+   memcpy(databases_path + project_directory_length, PGAGROAL_DATABASES_TRAIL, databases_trail_length);
+
+   return databases_path;
 }
 
 static char*


### PR DESCRIPTION
Implements the per-rule max_size hard cap discussed in #848.

Behaviour confirmed on the issue by @fluca1978 and @jesperpedersen: when the
rule cap is reached, a further request waits on the existing exhaustion/retry
path until blocking_timeout and then returns the standard "pool is full"
error. No new config, no new error type.

Approach: replace the non-atomic count-then-create check in
pgagroal_get_connection with an atomic reservation against a new per-rule
counter (struct limit.backend_connections), mirroring the global
max_connections gate. Lock-free, no new mutex. Full rationale and the rollback
sites are in the commit message.

Regression test: test/conf/18 (transaction pipeline, max_size=5) drives more
concurrent holds than the cap and asserts the peak pgagroal-owned backend count
on the primary never exceeds max_size. Fails on master, passes with this fix.

Note: stacked on #887 (concurrent-holds harness), which it reuses. Until #887
merges this PR shows its commit too; will rebase once #887 lands.