### PR TITLE
[#905] Expose per-rule backend_connections via pgagroal_limit

### DIFF
--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -1600,6 +1600,7 @@ home_page(SSL* client_ssl, int client_fd)
    data = pgagroal_append(data, "            <li>initial</li>\n");
    data = pgagroal_append(data, "            <li>max</li>\n");
    data = pgagroal_append(data, "            <li>active</li>\n");
+   data = pgagroal_append(data, "            <li>backend</li>\n");
    data = pgagroal_append(data, "          </ul>\n");
    data = pgagroal_append(data, "        </td>\n");
    data = pgagroal_append(data, "      </tr>\n");
@@ -2818,6 +2819,20 @@ limit_information(prometheus_metrics_container_t* container)
 
          data = pgagroal_append(data, "type=\"active\"} ");
          data = pgagroal_append_int(data, config->limits[i].active_connections);
+         data = pgagroal_append(data, "\n");
+
+         data = pgagroal_append(data, "pgagroal_limit{");
+
+         data = pgagroal_append(data, "user=\"");
+         data = pgagroal_append(data, config->limits[i].username);
+         data = pgagroal_append(data, "\",");
+
+         data = pgagroal_append(data, "database=\"");
+         data = pgagroal_append(data, config->limits[i].database);
+         data = pgagroal_append(data, "\",");
+
+         data = pgagroal_append(data, "type=\"backend\"} ");
+         data = pgagroal_append_int(data, config->limits[i].backend_connections);
          data = pgagroal_append(data, "\n");
       }
 


### PR DESCRIPTION
Closes #905.

The per-rule hard cap from #848 is enforced against `backend_connections` (live backends per rule, capped at `max_size`), but that counter lived only in shared memory and was not observable.

This adds a `type="backend"` series to the `pgagroal_limit` metric reporting `limits[i].backend_connections`, alongside the existing `min`/`initial`/`max`/`active` series, and lists it on the metrics HTML page. `active` reports `active_connections`, which counts in-use connections including reuse and so is not a faithful read of the cap state; `backend` is.

This also gives the #904 regression test an authoritative signal to assert the cap against, instead of a racy `pg_stat_activity` peak.