### PR TITLE
[#904] Add per-rule max_size hard-cap regression test

### DIFF
--- a/test/conf/release-only/18/pgagroal.conf
+++ b/test/conf/release-only/18/pgagroal.conf
@@ -1,0 +1,33 @@
+[pgagroal]
+host = localhost
+port = 2345
+
+log_type = file
+log_level = debug5
+log_path = test.log
+
+metrics = 2346
+
+# max_connections is set above 2 * mydb max_size so the per-rule max_size cap
+# (not the global max_connections gate) is the binding constraint when
+# test_pgagroal_pool_max_size_cap oversubscribes the rule with 2 * max_size
+# concurrent holds.
+max_connections = 24
+blocking_timeout = 10
+idle_timeout = 600
+validation = off
+unix_socket_dir = /tmp/
+pipeline = performance
+
+# Pin the epoll event backend for this test. The max_size cap this test
+# verifies is enforced correctly on every backend, but the io_uring backend
+# has a separate liveness stall under this exact oversubscription shape
+# (tracked in #923) that would hang a waiter indefinitely. epoll is clean, so
+# the cap regression runs deterministically here. Remove this line once #923
+# is fixed to also exercise the default backend.
+ev_backend = epoll
+
+
+[primary]
+host = localhost
+port = 5432

--- a/test/conf/release-only/18/pgagroal_databases.conf
+++ b/test/conf/release-only/18/pgagroal_databases.conf
@@ -1,0 +1,15 @@
+#
+# DATABASE=ALIAS1,ALIAS2 USER MAX_SIZE INITIAL_SIZE MIN_SIZE
+#
+# max_size gives headroom above what the other run-configs testcases need:
+# the connection/alias load tests run pgbench -c 6 (~7 backends including
+# pgbench's setup connection), so max_size = 10 keeps them clear of the cap.
+# No prefill (initial/min = 0) so every acquisition is a fresh backend
+# creation -- prefilled connections would be reused rather than created and
+# would mask the per-rule max_size hard cap (#848) the cap testcase exercises
+# by oversubscribing with 2 * max_size holds. The utf8 rule mirrors the
+# default so utf8 testcases keep working when this configuration overrides the
+# default databases.conf in run-configs.
+#
+mydb=pgalias1,pgalias2 myuser 10 0 0
+utf8db utf8user 2 2 1

--- a/test/conf/release-only/18/pgagroal_hba.conf
+++ b/test/conf/release-only/18/pgagroal_hba.conf
@@ -1,0 +1,1 @@
+host    all all all trust

--- a/test/include/tsclient.h
+++ b/test/include/tsclient.h
@@ -102,6 +102,23 @@ pgagroal_tsclient_init_pgbench(char* user, char* database, int scale);
 int
 pgagroal_tsclient_execute_concurrent_holds(char* user, char* database, int client_count, int hold_seconds);
 
+/**
+ * Drive client_count concurrent holds against a per-rule max_size cap and
+ * sample pgagroal's own live-backend counter for the rule while they run.
+ * Reads the pgagroal_limit type="backend" series from the metrics endpoint
+ * (issue #905) and returns the peak observed during the hold window. Used to
+ * assert that the per-rule max_size hard cap (issue #848) is never exceeded
+ * under concurrent contention.
+ * @param user name of the user
+ * @param database name of the database
+ * @param client_count number of concurrent psql sessions to spawn
+ * @param hold_seconds duration of the pg_sleep() hold per session
+ * @return the peak per-rule live backend count, or -1 if the metrics endpoint
+ * is disabled or could not be scraped
+ */
+int
+pgagroal_tsclient_limit_backend_peak(char* user, char* database, int client_count, int hold_seconds);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/libpgagroaltest/tsclient.c
+++ b/test/libpgagroaltest/tsclient.c
@@ -43,6 +43,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -59,6 +60,8 @@ static char* get_configuration_path();
 static char* get_databases_path();
 static char* get_log_file_path();
 static void* hold_thread_main(void* arg);
+static int scrape_limit_backend(int metrics_port, char* host, char* user, char* database);
+static int compute_client_watchdog(struct main_configuration* config, int hold_seconds);
 
 int
 pgagroal_tsclient_init(char* base_dir)
@@ -327,6 +330,7 @@ pgagroal_tsclient_execute_concurrent_holds(char* user, char* database, int clien
    const char* password = NULL;
    int failures = 0;
    int spawned = 0;
+   int watchdog;
    int rc;
 
    if (client_count <= 0 || hold_seconds < 0)
@@ -356,6 +360,11 @@ pgagroal_tsclient_execute_concurrent_holds(char* user, char* database, int clien
       goto cleanup;
    }
 
+   /* Per-client watchdog: bound each psql invocation with timeout(1) so a
+    * client that never returns cannot leave the run hung in pthread_join. See
+    * compute_client_watchdog() for how the bound is derived. */
+   watchdog = compute_client_watchdog(config, hold_seconds);
+
    for (int i = 0; i < client_count; i++)
    {
       char* cmd = NULL;
@@ -370,7 +379,9 @@ pgagroal_tsclient_execute_concurrent_holds(char* user, char* database, int clien
          cmd = pgagroal_append_char(cmd, ' ');
       }
 
-      cmd = pgagroal_append(cmd, "psql -h ");
+      cmd = pgagroal_append(cmd, "timeout -k 5 ");
+      cmd = pgagroal_append_int(cmd, watchdog);
+      cmd = pgagroal_append(cmd, " psql -h ");
       cmd = pgagroal_append(cmd, config->common.host);
       cmd = pgagroal_append(cmd, " -p ");
       cmd = pgagroal_append_int(cmd, config->common.port);
@@ -419,6 +430,228 @@ cleanup:
    free(log_file_path);
 
    return (failures == 0) ? 0 : 1;
+}
+
+int
+pgagroal_tsclient_limit_backend_peak(char* user, char* database, int client_count, int hold_seconds)
+{
+   struct main_configuration* config = NULL;
+   pthread_t* threads = NULL;
+   struct hold_thread_args* args = NULL;
+   char* log_file_path = NULL;
+   const char* password = NULL;
+   int metrics_port;
+   int spawned = 0;
+   int peak = -1;
+   int watchdog;
+   int rc;
+
+   if (client_count <= 0 || hold_seconds <= 0)
+   {
+      return -1;
+   }
+
+   config = (struct main_configuration*)shmem;
+   metrics_port = config->common.metrics;
+   if (metrics_port <= 0)
+   {
+      /* Metrics endpoint disabled; the caller skips the assertion. */
+      return -1;
+   }
+
+   log_file_path = get_log_file_path();
+
+   /* Same precedence used by pgagroal_tsclient_execute_concurrent_holds */
+   password = getenv("PGPASSWORD");
+   if (password == NULL)
+   {
+      password = getenv("PG_USER_PASSWORD");
+   }
+   if (password == NULL)
+   {
+      password = getenv("PG_UTF8_USER_PASSWORD");
+   }
+
+   threads = (pthread_t*)calloc(client_count, sizeof(pthread_t));
+   args = (struct hold_thread_args*)calloc(client_count, sizeof(struct hold_thread_args));
+   if (threads == NULL || args == NULL)
+   {
+      goto cleanup;
+   }
+
+   /* Per-client watchdog. A psql session may legitimately wait up to
+    * blocking_timeout for a slot and then hold for hold_seconds (and the rule
+    * is oversubscribed here, so the surplus waits out a full hold wave before
+    * acquiring a freed slot). Bound each invocation generously above that with
+    * timeout(1) so a client that never returns -- e.g. a backend that stalls
+    * under oversubscription -- is killed and its thread can be joined, instead
+    * of leaving the run (and the CI job) hung indefinitely in pthread_join. */
+   watchdog = compute_client_watchdog(config, hold_seconds);
+
+   for (int i = 0; i < client_count; i++)
+   {
+      char* cmd = NULL;
+      char  sql[128];
+
+      snprintf(sql, sizeof(sql), "BEGIN; SELECT pg_sleep(%d); COMMIT;", hold_seconds);
+
+      if (password != NULL && strlen(password) > 0)
+      {
+         cmd = pgagroal_append(cmd, "PGPASSWORD=");
+         cmd = pgagroal_append(cmd, (char*)password);
+         cmd = pgagroal_append_char(cmd, ' ');
+      }
+
+      cmd = pgagroal_append(cmd, "timeout -k 5 ");
+      cmd = pgagroal_append_int(cmd, watchdog);
+      cmd = pgagroal_append(cmd, " psql -h ");
+      cmd = pgagroal_append(cmd, config->common.host);
+      cmd = pgagroal_append(cmd, " -p ");
+      cmd = pgagroal_append_int(cmd, config->common.port);
+      cmd = pgagroal_append(cmd, " -U ");
+      cmd = pgagroal_append(cmd, user);
+      cmd = pgagroal_append(cmd, " -d ");
+      cmd = pgagroal_append(cmd, database);
+      cmd = pgagroal_append(cmd, " -v ON_ERROR_STOP=1 -X -A -t -c \"");
+      cmd = pgagroal_append(cmd, sql);
+      cmd = pgagroal_append(cmd, "\" >> ");
+      cmd = pgagroal_append(cmd, log_file_path);
+      cmd = pgagroal_append(cmd, " 2>&1 < /dev/null");
+
+      args[i].command = cmd;
+      args[i].exit_status = -1;
+
+      rc = pthread_create(&threads[i], NULL, hold_thread_main, &args[i]);
+      if (rc != 0)
+      {
+         break;
+      }
+      spawned++;
+   }
+
+   /* Sample the per-rule live-backend metric while the holds are active. The
+    * first max_size clients take every backend slot and hold it for
+    * hold_seconds; the surplus block on the per-rule cap. The peak of the
+    * pgagroal_limit type="backend" series over the window is the live backend
+    * count for the rule, which the #848 hard cap bounds at max_size. Sampling
+    * spans roughly two hold cycles so both the first and the second wave are
+    * observed. */
+   if (spawned > 0)
+   {
+      struct timespec poll = {0, 200L * 1000L * 1000L};   /* 200ms */
+      int samples = ((hold_seconds * 2 + 1) * 1000) / 200;
+
+      for (int s = 0; s < samples; s++)
+      {
+         int v = scrape_limit_backend(metrics_port, config->common.host, user, database);
+         if (v > peak)
+         {
+            peak = v;
+         }
+         nanosleep(&poll, NULL);
+      }
+   }
+
+   for (int i = 0; i < spawned; i++)
+   {
+      pthread_join(threads[i], NULL);
+   }
+
+cleanup:
+   if (args != NULL)
+   {
+      for (int i = 0; i < client_count; i++)
+      {
+         free(args[i].command);
+      }
+      free(args);
+   }
+   free(threads);
+   free(log_file_path);
+
+   return peak;
+}
+
+static int
+scrape_limit_backend(int metrics_port, char* host, char* user, char* database)
+{
+   char tmp[] = "/tmp/pgagroal_metrics_XXXXXX";
+   char prefix[512];
+   char line[8192];
+   char* cmd = NULL;
+   FILE* f = NULL;
+   int fd;
+   int value = -1;
+
+   fd = mkstemp(tmp);
+   if (fd < 0)
+   {
+      return -1;
+   }
+   close(fd);
+
+   cmd = pgagroal_append(cmd, "curl -s -m 2 http://");
+   cmd = pgagroal_append(cmd, host);
+   cmd = pgagroal_append_char(cmd, ':');
+   cmd = pgagroal_append_int(cmd, metrics_port);
+   cmd = pgagroal_append(cmd, "/metrics -o ");
+   cmd = pgagroal_append(cmd, tmp);
+
+   if (system(cmd) != 0)
+   {
+      free(cmd);
+      unlink(tmp);
+      return -1;
+   }
+   free(cmd);
+
+   /* The metric is one line per rule:
+    * pgagroal_limit{user="U",database="D",type="backend"} N */
+   snprintf(prefix, sizeof(prefix),
+            "pgagroal_limit{user=\"%s\",database=\"%s\",type=\"backend\"", user, database);
+
+   f = fopen(tmp, "r");
+   if (f != NULL)
+   {
+      while (fgets(line, sizeof(line), f) != NULL)
+      {
+         if (strstr(line, prefix) != NULL)
+         {
+            char* p = strstr(line, "} ");
+            if (p != NULL)
+            {
+               value = atoi(p + 2);
+            }
+            break;
+         }
+      }
+      fclose(f);
+   }
+
+   unlink(tmp);
+   return value;
+}
+
+/*
+ * Compute a per-client watchdog (seconds) for the concurrent-hold helpers.
+ * A client may legitimately wait up to blocking_timeout for a slot and then
+ * hold for hold_seconds; under oversubscription the surplus rides out a full
+ * hold wave before acquiring a freed slot. The bound is generously above that
+ * worst-case legitimate runtime so it only fires on a genuinely stuck client.
+ * blocking_timeout may be -1 (treated as infinite by pgagroal); there a bare
+ * fixed ceiling is used so the run cannot hang forever.
+ */
+static int
+compute_client_watchdog(struct main_configuration* config, int hold_seconds)
+{
+   int64_t blocking = (config != NULL) ? config->blocking_timeout.s : 0;
+
+   if (blocking < 0)
+   {
+      return (hold_seconds * 2) + 60;
+   }
+
+   return (int)blocking + (hold_seconds * 2) + 10;
 }
 
 static void*

--- a/test/testcases/test_pool_saturation.c
+++ b/test/testcases/test_pool_saturation.c
@@ -31,6 +31,8 @@
 #include <tsclient.h>
 #include <mctf.h>
 
+#include <string.h>
+
 /* Upper bound on max_connections for the retry-path saturation test: above
  * this, oversubscribing the pool would spawn more backends than PostgreSQL's
  * default max_connections and the CI runner can sustain. */
@@ -115,6 +117,72 @@ MCTF_TEST(test_pgagroal_pool_saturation_retry)
    MCTF_ASSERT(ok, cleanup,
                "%d concurrent clients (max_connections + 2) did not all acquire freed slots within blocking_timeout (retry-path regression #875)",
                client_count);
+cleanup:
+   MCTF_FINISH();
+}
+
+/*
+ * Regression test for issue #848: the per-rule max_size cap must be a hard cap.
+ * Before #903 the sub-cap was a count-then-create check (TOCTOU): concurrent
+ * acquirers each read a stale per-rule count and then each created a backend,
+ * driving the rule's live backend count past max_size. The fix reserves
+ * against the cap atomically, so live backends for a rule never exceed
+ * max_size.
+ *
+ * The test oversubscribes a rule: it drives (2 * max_size) concurrent holds.
+ * The first max_size clients take every backend slot for the rule; the surplus
+ * block on the cap. While they hold, it samples pgagroal's own per-rule live
+ * backend counter (the pgagroal_limit type="backend" series exposed in #905)
+ * and asserts the peak never exceeds max_size. Sampling pgagroal's authoritative
+ * counter avoids the pg_stat_activity teardown-lag over-count that made the
+ * first attempt unreliable in CI.
+ *
+ * Parameters are derived from the live configuration. Configurations without
+ * the metrics endpoint enabled, or without a per-rule limit for this
+ * user/database, are skipped: there the cap counter cannot be observed.
+ */
+MCTF_TEST(test_pgagroal_pool_max_size_cap)
+{
+   struct main_configuration* config = (struct main_configuration*)shmem;
+   int max_size = 0;
+   int found_rule = 0;
+   int client_count = 0;
+   int peak = -1;
+
+   if (config == NULL)
+   {
+      MCTF_SKIP("configuration not available");
+   }
+   if (config->common.metrics <= 0)
+   {
+      MCTF_SKIP("metrics endpoint not enabled; cannot read the per-rule backend counter");
+   }
+
+   for (int i = 0; i < config->number_of_limits; i++)
+   {
+      if (!strcmp((const char*)config->limits[i].username, user) &&
+          !strcmp((const char*)config->limits[i].database, database))
+      {
+         max_size = config->limits[i].max_size;
+         found_rule = 1;
+         break;
+      }
+   }
+
+   if (!found_rule || max_size <= 0)
+   {
+      MCTF_SKIP("no per-rule max_size limit for %s/%s", user, database);
+   }
+
+   client_count = max_size * 2;
+
+   peak = pgagroal_tsclient_limit_backend_peak(user, database, client_count, 3);
+
+   MCTF_ASSERT(peak >= 0, cleanup,
+               "failed to sample the pgagroal_limit type=\"backend\" series for %s/%s", user, database);
+   MCTF_ASSERT(peak <= max_size, cleanup,
+               "per-rule live backends peaked at %d, exceeding max_size %d (cap regression #848)",
+               peak, max_size);
 cleanup:
    MCTF_FINISH();
 }


### PR DESCRIPTION
## Why

The per-rule `max_size` hard cap (#848 / #903) was validated by instrumented reproduction but had no automated regression coverage. An earlier attempt sampled `pg_stat_activity`, which over-counts during PG-side teardown lag and was unreliable in CI (#904).

## What

`test_pgagroal_pool_max_size_cap` oversubscribes a rule with `2 * max_size` concurrent holds and, while they run, samples pgagroal's own per-rule live backend counter — the `pgagroal_limit{type="backend"}` series (#905) — and asserts the peak never exceeds `max_size`. It fails on the pre-#903 count-then-create TOCTOU (over-creation past `max_size`) and passes with the hard cap. Sampling pgagroal's authoritative counter sidesteps the `pg_stat_activity` teardown-lag over-count.

- `pgagroal_tsclient_limit_backend_peak()` drives the holds and samples the metrics endpoint.
- The cap config (`test/conf/release-only/18`) enables metrics and ships a no-prefill rule, so every acquisition is a fresh backend creation — prefilled connections would be reused rather than created and would mask the cap.
- Parameters are derived from the live config; configurations without metrics or without a matching rule are skipped.

## Dependency

Stacked on #914 (#908): the cap config needs more connections than the Debug ceiling allows, so it lives in the build-type room and runs only against a non-Debug build. Review #914 first; this PR will rebase onto master once it merges.

## Testing

Built clean; the test links and registers. Fail-before/pass-after is exercised by the Release `run-configs` CI job, where the release-only config runs.

closes #904