### PR TITLE
[#910] Document pgagroal_limit and pgagroal_limit_awaiting metrics

### DIFF
--- a/doc/PROMETHEUS.md
+++ b/doc/PROMETHEUS.md
@@ -76,6 +76,14 @@ The total number of connections
 
 The maximum number of connections
 
+**pgagroal_limit**
+
+Per-rule limit information, labeled by `user`, `database` and `type`. The `type` label selects the reported value: `min`, `initial` and `max` are the rule's configured sizes, `active` is the current number of checkouts, and `backend` is the current number of live backends for the rule.
+
+**pgagroal_limit_awaiting**
+
+The number of connections awaiting (on hold) per limit rule, labeled by `user` and `database`.
+
 **pgagroal_connection**
 
 The connection information

--- a/doc/manual/en/11-prometheus.md
+++ b/doc/manual/en/11-prometheus.md
@@ -78,6 +78,14 @@ The total number of connections
 
 The maximum number of connections
 
+**pgagroal_limit**
+
+Per-rule limit information, labeled by `user`, `database` and `type`. The `type` label selects the reported value: `min`, `initial` and `max` are the rule's configured sizes, `active` is the current number of checkouts, and `backend` is the current number of live backends for the rule.
+
+**pgagroal_limit_awaiting**
+
+The number of connections awaiting (on hold) per limit rule, labeled by `user` and `database`.
+
 **pgagroal_connection**
 
 The connection information


### PR DESCRIPTION
Closes #910.

The Prometheus metrics reference in `doc/PROMETHEUS.md` (and the mirrored `doc/manual/en/11-prometheus.md`) documented the exported series but omitted `pgagroal_limit` and `pgagroal_limit_awaiting` entirely.

This adds both, matching the existing terse entry style:
- `pgagroal_limit` — its `user`, `database` and `type` labels, and the values `type` can take: `min`, `initial`, `max`, `active` (current checkouts) and `backend` (current live backends for the rule). The `backend` series was added in #906.
- `pgagroal_limit_awaiting` — its `user` and `database` labels.

Label names and descriptions match the metric explanation served at `/` (`src/libpgagroal/prometheus.c`). Documentation-only change; no behavior change.