### PR TITLE
[#912] Fix double-free when startup packet omits database parameter

### DIFF
--- a/src/libpgagroal/utils.c
+++ b/src/libpgagroal/utils.c
@@ -148,7 +148,7 @@ pgagroal_extract_username_database(struct message* msg, char** username, char** 
 
    if (*database == NULL)
    {
-      *database = *username;
+      *database = strdup(*username);
    }
 
    pgagroal_log_trace("Username: %s", *username);


### PR DESCRIPTION
pgagroal_extract_username_database was aliasing *database to *username when no database was provided. Callers free both pointers independently, causing a double-free that silently killed the worker process.

Common trigger: HAProxy pgsql-check probes, which never include a database field, crashed a worker on every health check interval.

Fix by using strdup instead of aliasing.

Close #912