### PR TITLE
[#915] Configure cmake for both compiler choices

### DIFF
--- a/test/check.sh
+++ b/test/check.sh
@@ -1055,10 +1055,10 @@ do_setup() {
    else
      export CC=$(which gcc)
      echo "Using GCC compiler without coverage: $CC"
+   fi
    cmake -DCMAKE_C_COMPILER=$CC \
         -DCMAKE_BUILD_TYPE=Debug \
         ..
-   fi
    make -j$(nproc)
    cd ..
   fi


### PR DESCRIPTION
## Why

In `test/check.sh` the build step's `fi` sat after the `cmake` call, so `cmake` was configured only on the gcc path. In the default clang mode `cmake` was never invoked and `make` relied on a pre-existing `CMakeCache.txt` — failing on a fresh `build/` and silently reusing the cached build type otherwise.

## What

The `if/else` only selects the compiler (`CC`), so move the `fi` before the `cmake` call. `cmake` now runs unconditionally after the compiler is chosen.

## Testing

`bash -n` clean. The build step now configures with the selected compiler regardless of mode.

closes #915