### PR TITLE
[#918] Add a performance-regression check to CI

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,120 @@
+name: Performance
+
+# On-demand only: trigger from the Actions tab (Run workflow) with the number
+# of the pull request to benchmark. The PR head is measured A/B against the
+# current master on the same runner.
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Pull request number to benchmark (head vs current master)"
+        required: true
+        type: string
+
+permissions:
+  contents: read   # results go to the job summary + artifacts; no PR write needed
+
+jobs:
+  perf:
+    runs-on: ubuntu-latest
+    # Advisory only: a shared GitHub runner is too noisy to gate merges on, so
+    # a red run is informational, not a failure to fix. The A/B comparison is
+    # published to the job summary and the raw results are uploaded as an
+    # artifact for humans to inspect.
+    continue-on-error: true
+    container:
+      image: rockylinux/rockylinux:10
+      options: --security-opt seccomp=unconfined
+    timeout-minutes: 30
+    env:
+      PGA_PORT: "6432"
+      PGHOST: localhost
+      PGPORT: "5432"
+      PGUSER: bench
+      PGDATABASE: benchdb
+      PGPASSWORD: benchpass
+      PGAGROAL_RUN_AS: pg
+      PERF_DURATION: "20"
+      PERF_CLIENTS: "16"
+    steps:
+      - uses: actions/checkout@v6   # the PR head
+        with:
+          ref: refs/pull/${{ inputs.pr }}/head
+
+      - name: Check out base for A/B
+        uses: actions/checkout@v6
+        with:
+          ref: master
+          path: base-src
+
+      - name: Install dependencies
+        run: |
+          dnf -y install dnf-plugins-core
+          dnf config-manager --set-enabled crb
+          dnf -y install epel-release
+          dnf -y install \
+            git gcc clang cmake make \
+            openssl openssl-devel \
+            systemd systemd-devel zlib zlib-devel \
+            libzstd libzstd-devel lz4 lz4-devel \
+            libatomic liburing liburing-devel \
+            python3 python3-docutils bzip2 bzip2-devel \
+            net-tools procps-ng util-linux sudo which
+
+      - name: Install PostgreSQL
+        run: |
+          dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-10-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+          dnf -qy module disable postgresql 2>/dev/null || true
+          dnf install -y postgresql17 postgresql17-server postgresql17-contrib postgresql17-libs postgresql17-devel
+
+      - name: Set PostgreSQL on PATH
+        run: echo "PATH=/usr/pgsql-17/bin:$PATH" >> "$GITHUB_ENV"
+
+      - name: Start PostgreSQL and init pgbench
+        run: |
+          useradd -m pg || true
+          rm -rf /tmp/pgdata && mkdir -p /tmp/pgdata && chown pg /tmp/pgdata
+          # trust auth: a vault-less pgagroal pass-through works with trust/password/md5,
+          # not scram. The auth method is incidental to a relative A/B benchmark.
+          sudo -u pg /usr/pgsql-17/bin/initdb -D /tmp/pgdata --auth-local=trust --auth-host=trust
+          sudo -u pg /usr/pgsql-17/bin/pg_ctl -D /tmp/pgdata -w -t 30 -l /tmp/pg.log -o "-c listen_addresses='localhost' -c unix_socket_directories='/tmp'" start || { tail -20 /tmp/pg.log; exit 1; }
+          for _ in $(seq 1 30); do /usr/pgsql-17/bin/pg_isready -h localhost -p 5432 && break; sleep 1; done
+          sudo -u pg /usr/pgsql-17/bin/psql -h localhost -p 5432 -d postgres -c "CREATE ROLE \"${PGUSER}\" LOGIN PASSWORD '${PGPASSWORD}';"
+          sudo -u pg /usr/pgsql-17/bin/createdb -h localhost -p 5432 -O "${PGUSER}" "${PGDATABASE}"
+          # run_ab.sh re-initialises (resets) the pgbench DB before each measured run.
+
+      - name: Build base
+        run: |
+          cmake -S "$GITHUB_WORKSPACE/base-src" -B "$GITHUB_WORKSPACE/base-src/build" -DCMAKE_BUILD_TYPE=Release -DDOCS=FALSE
+          make -C "$GITHUB_WORKSPACE/base-src/build" -j"$(nproc)"
+
+      - name: Build PR
+        run: |
+          cmake -S "$GITHUB_WORKSPACE" -B "$GITHUB_WORKSPACE/build" -DCMAKE_BUILD_TYPE=Release -DDOCS=FALSE
+          make -C "$GITHUB_WORKSPACE/build" -j"$(nproc)"
+
+      - name: Run A/B measurements
+        run: |
+          bash "$GITHUB_WORKSPACE/test/perf/run_ab.sh" \
+            "$GITHUB_WORKSPACE/base-src/build/src" \
+            "$GITHUB_WORKSPACE/build/src" \
+            "$RUNNER_TEMP/results"
+
+      - name: Compare and publish summary
+        shell: bash
+        run: |
+          # Integrity failures (missing/null data) exit non-zero and mark this step
+          # failed; a measured regression is advisory (informational) while variance
+          # is calibrated. The job is continue-on-error, so neither blocks the PR.
+          python3 "$GITHUB_WORKSPACE/test/perf/compare.py" \
+            --base "$RUNNER_TEMP/results"/base-*.json \
+            --pr   "$RUNNER_TEMP/results"/pr-*.json | tee -a "$GITHUB_STEP_SUMMARY"
+          exit "${PIPESTATUS[0]}"
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-results
+          path: ${{ runner.temp }}/results
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 _site/
 build/
 vendor/
+__pycache__/
+*.pyc

--- a/test/perf/README.md
+++ b/test/perf/README.md
@@ -1,0 +1,65 @@
+# Performance-regression check
+
+An on-demand performance check that detects throughput/latency regressions, run
+by `.github/workflows/perf.yml`.
+
+## Triggering a run
+
+The workflow does not run automatically. To benchmark a pull request, go to
+**Actions → Performance → Run workflow** and enter the PR number; the PR head
+is then measured A/B against the current `master`.
+
+## Principle
+
+**Fail loudly when it cannot measure; be advisory only when it measures an
+apparent regression.** An inability to measure (pgbench error/timeout, pgagroal
+that won't start, missing/`null`/zero results) is an *error* that fails the job —
+never a placeholder result. Only a *valid* comparison whose deltas exceed the
+thresholds is informational (while CI variance is being calibrated).
+
+## Why A/B, alternating, on the same runner
+
+CI runs on `ubuntu-latest` — shared runners with 20–50% run-to-run variance — so
+an absolute baseline would be flaky. Instead both the PR and its base are built
+and measured on the **same runner**, in **alternating order (base, PR, PR, base)**,
+**re-initialising the pgbench database before each measured run** (so no run sees
+a warmed/mutated DB), with a **warm-up** before each recorded result. Results are
+aggregated by **median** per side. There is no static baseline to maintain.
+
+## Workloads
+
+`run_bench.sh` drives three pgbench workloads through pgagroal:
+`read_only` (`-S`), `read_write` (TPC-B-like), `connect` (`-C -S`, reconnect per
+transaction — stresses the pooler). Each is `timeout`-capped so the job can't hang.
+
+## Pieces
+
+| File | Role |
+|------|------|
+| `run_bench.sh` | one measurement: warm-up + measured run per workload → JSON; fails on any fault |
+| `measure.sh` | start pgagroal from a build dir (non-root), readiness-or-fail-with-log, trap-stop, run `run_bench.sh` |
+| `run_ab.sh` | alternating base/PR/PR/base measurement with DB reset before each run |
+| `compare.py` | aggregate by median, validate, emit Markdown; integrity → exit 2, regression → advisory (exit 0) or blocking (exit 1 with `--fail-on-regression`) |
+| `test_compare.py` | unit tests for `compare.py` (normal, thresholds, zeros, nulls, malformed, bad args, median) |
+| `test_run_bench_failure.sh` | failure-path test: a failing pgbench → non-zero exit, no output |
+| `../../.github/workflows/perf.yml` | orchestration; publishes to the job summary + uploads results as an artifact |
+
+## Output & rollout
+
+Results are written to **`$GITHUB_STEP_SUMMARY`** and uploaded as the
+**`perf-results`** artifact (the per-run JSONs). No PR comment is posted — the
+job builds and runs code from the PR head (often a fork), so it is kept on
+read-only permissions. If automated PR comments are wanted later, add a
+separate trusted `workflow_run` workflow that only reads the `perf-results`
+artifact and posts the comment.
+
+Thresholds are **informational** for now (`compare.py` is run without
+`--fail-on-regression`). Promote to blocking once several CI runs establish the
+expected variance.
+
+## Running the harness tests locally
+
+```sh
+python3 test/perf/test_compare.py        # pure-Python, no deps
+bash    test/perf/test_run_bench_failure.sh   # skips without timeout(1)
+```

--- a/test/perf/compare.py
+++ b/test/perf/compare.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2025 The pgagroal community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Aggregate and compare pgbench A/B results (base vs PR, measured on the same
+# runner). Each input file is one measurement: {workload: {tps, p99_ms}}. Several
+# files per side are aggregated by median, then PR is compared to base per
+# workload.
+#
+# Exit codes (the central distinction — see PR #918):
+#   0  valid comparison (even if a regression is flagged, in advisory mode)
+#   1  valid comparison with a regression AND --fail-on-regression (blocking mode)
+#   2  DATA-INTEGRITY failure: missing/empty inputs, missing workload, or a
+#      non-positive/None tps or p99 — i.e. we could not actually measure.
+#
+# "Fail loudly when you cannot measure; be advisory only when you measured an
+# apparent regression."
+#
+# Usage:
+#   compare.py --base b1.json [b2.json ...] --pr p1.json [p2.json ...]
+#              [--tps-drop PCT] [--p99-rise PCT] [--fail-on-regression]
+
+import argparse
+import json
+import statistics
+import sys
+
+WORKLOADS = ["read_only", "read_write", "connect"]
+INTEGRITY_EXIT = 2
+REGRESSION_EXIT = 1
+
+
+class IntegrityError(Exception):
+    pass
+
+
+def load_side(label, paths):
+    """Load + validate one side's measurement files. Raises IntegrityError on any
+    missing file, malformed JSON, missing workload, or non-positive metric."""
+    if not paths:
+        raise IntegrityError(f"{label}: no measurement files provided")
+    runs = []
+    for p in paths:
+        try:
+            with open(p) as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            raise IntegrityError(f"{label}: cannot read/parse {p}: {e}")
+        for wl in WORKLOADS:
+            if wl not in data:
+                raise IntegrityError(f"{label}: {p} missing workload '{wl}'")
+            for metric in ("tps", "p99_ms"):
+                v = data[wl].get(metric)
+                if not isinstance(v, (int, float)) or isinstance(v, bool):
+                    raise IntegrityError(f"{label}: {p} {wl}.{metric} is not numeric ({v!r})")
+                if v <= 0:
+                    raise IntegrityError(f"{label}: {p} {wl}.{metric} is non-positive ({v})")
+        runs.append(data)
+    return runs
+
+
+def median_metric(runs, wl, metric):
+    return statistics.median(r[wl][metric] for r in runs)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", nargs="+", required=True)
+    ap.add_argument("--pr", nargs="+", required=True)
+    ap.add_argument("--tps-drop", type=float, default=5.0)
+    ap.add_argument("--p99-rise", type=float, default=10.0)
+    ap.add_argument("--fail-on-regression", action="store_true")
+    args = ap.parse_args()
+
+    try:
+        base_runs = load_side("base", args.base)
+        pr_runs = load_side("pr", args.pr)
+    except IntegrityError as e:
+        print(f"PERF INTEGRITY FAILURE: {e}", file=sys.stderr)
+        # Also emit a Markdown note so the summary explains the failure.
+        print(f"### Performance A/B — could not measure\n\n**Integrity failure:** {e}\n")
+        return INTEGRITY_EXIT
+
+    lines = [
+        "### Performance A/B — PR vs base (same runner, median of "
+        f"{len(base_runs)} base / {len(pr_runs)} PR runs)",
+        "",
+        "| Workload | TPS (base → PR) | ΔTPS | p99 ms (base → PR) | Δp99 | |",
+        "|---|---|---|---|---|:--:|",
+    ]
+    flagged = False
+    for wl in WORKLOADS:
+        bt = median_metric(base_runs, wl, "tps")
+        pt = median_metric(pr_runs, wl, "tps")
+        bp = median_metric(base_runs, wl, "p99_ms")
+        pp = median_metric(pr_runs, wl, "p99_ms")
+        td = (pt - bt) / bt * 100.0
+        pd = (pp - bp) / bp * 100.0
+        row_flag = td < -args.tps_drop or pd > args.p99_rise
+        flagged = flagged or row_flag
+        mark = "⚠️" if row_flag else "✅"
+        lines.append(
+            f"| {wl} | {bt:.0f} → {pt:.0f} | {td:+.1f}% "
+            f"| {bp:.2f} → {pp:.2f} | {pd:+.1f}% | {mark} |"
+        )
+
+    lines.append("")
+    if flagged:
+        lines.append(f"⚠️ **Apparent regression** (TPS drop > {args.tps_drop:g}% or p99 rise > {args.p99_rise:g}%).")
+    else:
+        lines.append(f"✅ Within thresholds (TPS drop > {args.tps_drop:g}%, p99 rise > {args.p99_rise:g}%).")
+    mode = "blocking" if args.fail_on_regression else "advisory (informational while variance is calibrated)"
+    lines.append(f"\n_Mode: {mode}. Measured PR-vs-base back-to-back on the same runner._")
+
+    print("\n".join(lines))
+
+    if flagged and args.fail_on_regression:
+        return REGRESSION_EXIT
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/perf/measure.sh
+++ b/test/perf/measure.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+#
+# Copyright (C) 2025 The pgagroal community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Start pgagroal from a built binary dir against the already-running local
+# PostgreSQL, run one benchmark measurement through it, and stop it. Startup and
+# teardown are deterministic: pgagroal is always stopped via an EXIT trap (even
+# if the workload fails), the port is freed before starting, and an unreachable
+# pgagroal fails the run with its log.
+#
+# Usage: measure.sh <pgagroal_bindir> <label> <out.json>
+#   bindir = .../build/src ; label names the per-run log (/tmp/pgagroal-<label>.log)
+# Env: PGA_PORT, PGHOST, PGPORT, PGUSER, PGDATABASE, PERF_DURATION, PERF_CLIENTS,
+#      PGAGROAL_RUN_AS (run pgagroal as this user when current uid is 0).
+
+set -uo pipefail
+
+BINDIR="$(cd "${1:?bindir}" && pwd)"
+LABEL="${2:?label}"
+OUT="${3:?out.json}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PGA_PORT="${PGA_PORT:-6432}"
+BACKEND_HOST="${PGHOST:-localhost}"
+BACKEND_PORT="${PGPORT:-5432}"
+DUR="${PERF_DURATION:-20}"
+CLIENTS="${PERF_CLIENTS:-16}"
+LOG="/tmp/pgagroal-${LABEL}.log"
+
+fail() { echo "PERF MEASURE FAILURE: $*" >&2; [ -f "$LOG" ] && sed 's/^/  log| /' "$LOG" >&2; exit 1; }
+
+# pgagroal refuses root; run as PGAGROAL_RUN_AS when we are root, else directly.
+run_pgagroal() {
+   if [ -n "${PGAGROAL_RUN_AS:-}" ] && [ "$(id -u)" = "0" ]; then
+      sudo -u "$PGAGROAL_RUN_AS" env "LD_LIBRARY_PATH=$BINDIR" "$@"
+   else
+      LD_LIBRARY_PATH="$BINDIR" "$@"
+   fi
+}
+
+CFG="$(mktemp -d)"
+chmod 755 "$CFG"
+
+cat > "$CFG/pgagroal.conf" <<EOF
+[pgagroal]
+host = localhost
+port = $PGA_PORT
+log_type = file
+log_path = $LOG
+log_level = warn
+max_connections = 100
+pipeline = performance
+unix_socket_dir = /tmp/
+
+[primary]
+host = $BACKEND_HOST
+port = $BACKEND_PORT
+EOF
+printf 'host all all all all\n' > "$CFG/pgagroal_hba.conf"
+chmod 644 "$CFG"/*.conf
+
+stop_pgagroal() {
+   run_pgagroal "$BINDIR/pgagroal-cli" -c "$CFG/pgagroal.conf" shutdown >/dev/null 2>&1 || true
+   # Belt and braces: kill anything still bound to our config, then wait for the port.
+   pkill -f "$CFG/pgagroal.conf" 2>/dev/null || true
+   for _ in $(seq 1 10); do pg_isready -h localhost -p "$PGA_PORT" >/dev/null 2>&1 || break; sleep 1; done
+}
+trap 'stop_pgagroal; rm -rf "$CFG"' EXIT
+
+# Ensure the port is free before we start (a previous run may not have released it).
+if pg_isready -h localhost -p "$PGA_PORT" >/dev/null 2>&1; then
+   fail "port $PGA_PORT already in use before starting pgagroal ($LABEL)"
+fi
+
+# Do not pre-create the log: pgagroal runs as the unprivileged PGAGROAL_RUN_AS
+# user and must own the file it writes (a root-created log is not writable by it).
+# Remove any stale file from a prior run so pgagroal creates it fresh.
+rm -f "$LOG" 2>/dev/null || true
+run_pgagroal "$BINDIR/pgagroal" -c "$CFG/pgagroal.conf" -a "$CFG/pgagroal_hba.conf" -d \
+   || fail "pgagroal failed to launch ($LABEL)"
+
+reachable=0
+for _ in $(seq 1 30); do
+   if pg_isready -h localhost -p "$PGA_PORT" >/dev/null 2>&1; then reachable=1; break; fi
+   sleep 1
+done
+[ "$reachable" = "1" ] || fail "pgagroal did not become reachable on port $PGA_PORT ($LABEL)"
+
+"$HERE/run_bench.sh" localhost "$PGA_PORT" "$PGUSER" "$PGDATABASE" "$DUR" "$CLIENTS" "$OUT"

--- a/test/perf/run_ab.sh
+++ b/test/perf/run_ab.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Copyright (C) 2025 The pgagroal community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Alternating A/B measurement to reduce ordering/warming bias: measure
+# base, PR, PR, base. Before each measured run the pgbench database is reset
+# (re-initialised) so no run sees a database warmed or mutated by a prior run.
+# Each run writes one JSON file into <outdir>; compare.py then aggregates by
+# median per side.
+#
+# Any measurement or reset failure aborts with a non-zero exit (integrity).
+#
+# Usage: run_ab.sh <base_bindir> <pr_bindir> <outdir>
+# Env: PGUSER, PGDATABASE, PGPASSWORD, PGHOST, PGPORT, PERF_SCALE, plus the
+#      measure.sh / run_bench.sh variables.
+
+set -uo pipefail
+
+BASE_BIN="${1:?base bindir}"
+PR_BIN="${2:?pr bindir}"
+OUTDIR="${3:?outdir}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+mkdir -p "$OUTDIR"
+
+: "${PGUSER:?PGUSER required}"
+: "${PGDATABASE:?PGDATABASE required}"
+SCALE="${PERF_SCALE:-10}"
+
+reset_db() {
+   PGPASSWORD="${PGPASSWORD:-}" pgbench -i -q -s "$SCALE" \
+      -h "${PGHOST:-localhost}" -p "${PGPORT:-5432}" -U "$PGUSER" "$PGDATABASE" >/dev/null 2>&1
+}
+
+i=0
+for spec in "base:$BASE_BIN" "pr:$PR_BIN" "pr:$PR_BIN" "base:$BASE_BIN"; do
+   label="${spec%%:*}"
+   bin="${spec#*:}"
+   i=$((i + 1))
+   echo "::group::measure ${label} (run ${i})"
+   reset_db || { echo "PERF MEASURE FAILURE: pgbench DB reset failed before ${label}-${i}" >&2; exit 1; }
+   "$HERE/measure.sh" "$bin" "${label}-${i}" "$OUTDIR/${label}-${i}.json" || exit 1
+   echo "::endgroup::"
+done
+
+echo "collected base runs: $(ls "$OUTDIR"/base-*.json 2>/dev/null | wc -l | tr -d ' '), pr runs: $(ls "$OUTDIR"/pr-*.json 2>/dev/null | wc -l | tr -d ' ')"

--- a/test/perf/run_bench.sh
+++ b/test/perf/run_bench.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+# Copyright (C) 2025 The pgagroal community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Run pgbench workloads through a running pgagroal and emit TPS + p99 latency as
+# JSON: one measurement. A short warm-up precedes each recorded workload.
+#
+# This script FAILS LOUDLY (non-zero exit, nothing written to <out.json>) on any
+# integrity fault — pgbench error, timeout, missing output, missing/empty latency
+# log, or a non-numeric result. It must never emit null/placeholder values: an
+# inability to measure is an error, not a result (see PR #918).
+#
+# Usage: run_bench.sh <host> <port> <user> <db> <duration_s> <clients> <out.json>
+
+set -uo pipefail
+
+HOST="${1:?host}"
+PORT="${2:?port}"
+USER="${3:?user}"
+DB="${4:?db}"
+DUR="${5:?duration_s}"
+CLIENTS="${6:?clients}"
+OUT="${7:?out.json}"
+
+JOBS="$(nproc 2>/dev/null || echo 2)"
+WARMUP="${PERF_WARMUP:-3}"
+CAP=$((DUR + WARMUP + 60))     # hard timeout per pgbench invocation
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "PERF MEASURE FAILURE: $*" >&2; exit 1; }
+
+# Echo one JSON member: "name": {tps, p99_ms}. Warm-up first (discarded), then
+# the measured run. Any fault exits non-zero (caught by the caller's `|| exit`).
+run_one()
+{
+   local name="$1"; shift
+   local pfx="$TMP/$name"
+   local out="$TMP/$name.out"
+   local rc tps p99
+
+   # Warm-up (pool fill, page cache); results discarded but failures still fatal.
+   timeout "$CAP" pgbench -h "$HOST" -p "$PORT" -U "$USER" -d "$DB" \
+      -T "$WARMUP" -c "$CLIENTS" -j "$JOBS" "$@" >/dev/null 2>&1
+   rc=$?
+   [ "$rc" -eq 124 ] && fail "$name warm-up timed out"
+   [ "$rc" -ne 0 ] && fail "$name warm-up failed (pgbench exit $rc)"
+
+   timeout "$CAP" pgbench -h "$HOST" -p "$PORT" -U "$USER" -d "$DB" \
+      -T "$DUR" -c "$CLIENTS" -j "$JOBS" -l --log-prefix="$pfx" "$@" > "$out" 2>&1
+   rc=$?
+   [ "$rc" -eq 124 ] && { sed 's/^/  | /' "$out" >&2; fail "$name measured run timed out"; }
+   [ "$rc" -ne 0 ] && { sed 's/^/  | /' "$out" >&2; fail "$name pgbench exited $rc"; }
+
+   tps="$(grep -oE 'tps = [0-9.]+' "$out" | head -1 | awk '{print $3}')"
+   [ -n "$tps" ] || { sed 's/^/  | /' "$out" >&2; fail "$name produced no TPS"; }
+
+   ls "$pfx".* >/dev/null 2>&1 || fail "$name produced no latency log"
+   p99="$(cat "$pfx".* | awk '{print $3}' | sort -n \
+      | awk 'END {if (NR == 0) exit 1} {a[NR]=$1} END {printf "%.3f", a[int(NR*0.99)]/1000.0}')" \
+      || fail "$name latency log was empty"
+
+   printf '"%s": {"tps": %s, "p99_ms": %s}' "$name" "$tps" "$p99"
+}
+
+m_ro="$(run_one read_only -S)" || exit 1
+m_rw="$(run_one read_write)" || exit 1
+m_co="$(run_one connect -C -S)" || exit 1
+
+printf '{%s, %s, %s}\n' "$m_ro" "$m_rw" "$m_co" > "$OUT"
+cat "$OUT"

--- a/test/perf/test_compare.py
+++ b/test/perf/test_compare.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2025 The pgagroal community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Fast unit tests for compare.py. Run: python3 test/perf/test_compare.py
+# Exercises the central distinction: integrity failures (exit 2) vs valid
+# comparisons (exit 0, or 1 with --fail-on-regression).
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+COMPARE = os.path.join(HERE, "compare.py")
+
+GOOD = {
+    "read_only": {"tps": 1000, "p99_ms": 2.0},
+    "read_write": {"tps": 500, "p99_ms": 4.0},
+    "connect": {"tps": 200, "p99_ms": 9.0},
+}
+
+_tmp = tempfile.mkdtemp()
+_n = 0
+failures = []
+
+
+def write(obj):
+    global _n
+    _n += 1
+    if isinstance(obj, str):
+        path = os.path.join(_tmp, f"f{_n}.json")
+        with open(path, "w") as f:
+            f.write(obj)
+    else:
+        path = os.path.join(_tmp, f"f{_n}.json")
+        with open(path, "w") as f:
+            json.dump(obj, f)
+    return path
+
+
+def run(args):
+    p = subprocess.run([sys.executable, COMPARE] + args, capture_output=True, text=True)
+    return p.returncode, p.stdout + p.stderr
+
+
+def check(name, cond):
+    print(f"{'ok  ' if cond else 'FAIL'}  {name}")
+    if not cond:
+        failures.append(name)
+
+
+def deepcopy(d):
+    return json.loads(json.dumps(d))
+
+
+# 1. normal, no regression -> exit 0, within thresholds
+rc, out = run(["--base", write(GOOD), "--pr", write(GOOD)])
+check("normal: exit 0", rc == 0)
+check("normal: within thresholds", "Within thresholds" in out)
+
+# 2. regression (tps -20% on read_write), advisory -> exit 0, flagged
+pr = deepcopy(GOOD); pr["read_write"]["tps"] = 400
+rc, out = run(["--base", write(GOOD), "--pr", write(pr)])
+check("regression advisory: exit 0", rc == 0)
+check("regression advisory: flagged", "Apparent regression" in out)
+
+# 3. regression + --fail-on-regression -> exit 1
+rc, out = run(["--base", write(GOOD), "--pr", write(pr), "--fail-on-regression"])
+check("regression blocking: exit 1", rc == 1)
+
+# 4. p99 regression (+30%) -> flagged
+pr2 = deepcopy(GOOD); pr2["connect"]["p99_ms"] = 12.0
+rc, out = run(["--base", write(GOOD), "--pr", write(pr2)])
+check("p99 regression: flagged", "Apparent regression" in out and rc == 0)
+
+# 5. null value -> integrity exit 2
+bad = deepcopy(GOOD); bad["read_only"]["tps"] = None
+rc, out = run(["--base", write(GOOD), "--pr", write(bad)])
+check("null tps: integrity exit 2", rc == 2)
+check("null tps: integrity message", "INTEGRITY" in out)
+
+# 6. zero value -> integrity exit 2
+bad = deepcopy(GOOD); bad["read_write"]["p99_ms"] = 0
+rc, out = run(["--base", write(GOOD), "--pr", write(bad)])
+check("zero p99: integrity exit 2", rc == 2)
+
+# 7. missing workload -> integrity exit 2
+bad = deepcopy(GOOD); del bad["connect"]
+rc, out = run(["--base", write(GOOD), "--pr", write(bad)])
+check("missing workload: integrity exit 2", rc == 2)
+
+# 8. malformed JSON -> integrity exit 2
+rc, out = run(["--base", write(GOOD), "--pr", write("{not json")])
+check("malformed json: integrity exit 2", rc == 2)
+
+# 9. bad CLI args (no --pr) -> non-zero (argparse exit 2)
+rc, out = run(["--base", write(GOOD)])
+check("missing --pr: non-zero", rc != 0)
+
+# 10. median across runs: base tps medians 1000/500/200; pr two runs whose
+# medians equal base -> within thresholds (proves median, not mean/first)
+b1 = deepcopy(GOOD)
+b2 = deepcopy(GOOD); b2["read_only"]["tps"] = 1200  # median of (1000,1200)=1100
+pr_a = deepcopy(GOOD); pr_a["read_only"]["tps"] = 1050
+pr_b = deepcopy(GOOD); pr_b["read_only"]["tps"] = 1150  # median 1100 == base median
+rc, out = run(["--base", write(b1), write(b2), "--pr", write(pr_a), write(pr_b)])
+check("median aggregation: exit 0 within thresholds", rc == 0 and "Within thresholds" in out)
+check("median aggregation: reports 2 base / 2 PR runs", "2 base / 2 PR" in out)
+
+print()
+if failures:
+    print(f"FAILED ({len(failures)}): {failures}")
+    sys.exit(1)
+print("all compare.py tests passed")

--- a/test/perf/test_run_bench_failure.sh
+++ b/test/perf/test_run_bench_failure.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Copyright (C) 2025 The pgagroal community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Failure-path test for run_bench.sh: a failing pgbench must make the script
+# exit non-zero and write NO output (an inability to measure is an error, not a
+# null result). Uses a stub pgbench; skips where timeout(1) is unavailable
+# (e.g. stock macOS), since run_bench.sh relies on it.
+
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v timeout >/dev/null 2>&1; then
+   echo "SKIP: timeout(1) not available"
+   exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Stub pgbench that always fails.
+cat > "$TMP/pgbench" <<'STUB'
+#!/bin/bash
+echo "stub pgbench: simulated failure" >&2
+exit 1
+STUB
+chmod +x "$TMP/pgbench"
+
+OUT="$TMP/out.json"
+PATH="$TMP:$PATH" bash "$HERE/run_bench.sh" localhost 6432 u d 1 1 "$OUT" >/dev/null 2>&1
+rc=$?
+
+fail=0
+if [ "$rc" -eq 0 ]; then
+   echo "FAIL: run_bench.sh exited 0 despite a failing pgbench"
+   fail=1
+fi
+if [ -f "$OUT" ]; then
+   echo "FAIL: run_bench.sh wrote output ($OUT) despite a failing pgbench"
+   fail=1
+fi
+
+[ "$fail" -eq 0 ] && echo "ok: run_bench.sh fails loudly and writes no output on pgbench failure"
+exit "$fail"


### PR DESCRIPTION
## Why

Performance is a core pgagroal claim, but nothing guards it from regression today.

## What

An **advisory** per-PR performance check. CI runs on `ubuntu-latest`, whose run-to-run variance makes an absolute baseline flaky, so this measures the **PR relative to its base on the same runner** (A/B): it builds and benchmarks both back-to-back and reports the PR-vs-base delta — no static baseline to maintain.

- `test/perf/run_bench.sh` — read-only / read-write / connect-heavy pgbench through pgagroal → TPS + p99 JSON; each workload is `timeout`-capped so the job can't hang.
- `test/perf/bench_ref.sh` — build a source tree, start pgagroal against the local PostgreSQL, run the workloads, stop it.
- `test/perf/compare.py` — diff base vs PR; flags TPS drop > 5% or p99 rise > 10%.
- `.github/workflows/perf.yml` — orchestrates the A/B run and posts the delta as a comment.

## Rollout

Advisory for now — it comments, it does not fail the build. Promote to blocking (`--fail-on-regression`) once it's proven stable over real PRs.

## Note

`pull_request` workflows run from the base branch's copy, so this won't run on its own PR — it first executes on the next PR after merge.

closes #918