### PR TITLE
[pgagroal#891] add flush timeout to shutdown and flush commands

### DIFF
--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -44,6 +44,7 @@ Bhawesh Panwar <panwarbhawesh1112@gmail.com>
 Frank Heikens <frank@elevarq.com>
 Sakshi Aggarwal <sakshiaggarwal2706@gmail.com>
 Ameen Sakr <ameensakr623@gmail.com>
+Abdallah Hany Ragab <abdallah.hany1974@gmail.com>
 ```
 
 ## Committers

--- a/src/cli.c
+++ b/src/cli.c
@@ -70,15 +70,23 @@
 #define COMMAND_STATUS         "status"
 #define COMMAND_STATUS_DETAILS "status-details"
 #define COMMAND_SWITCH_TO      "switch-to"
-#define COMMAND_CONFIG_LS      "conf-ls"
-#define COMMAND_CONFIG_GET     "conf-get"
-#define COMMAND_CONFIG_SET     "conf-set"
-#define COMMAND_CONFIG_ALIAS   "conf-alias"
 
-#define OUTPUT_FORMAT_JSON     "json"
-#define OUTPUT_FORMAT_TEXT     "text"
+/* Wire-protocol value for the Timeout field on MANAGEMENT_SHUTDOWN_TIMEOUT and
+ * MANAGEMENT_FLUSH requests with mode=FLUSH_TIMEOUT. The action/mode itself
+ * signals "bound this with a timeout"; this value just carries how long.
+ *   0   -> no explicit seconds: daemon falls back to 'flush_timeout' from pgagroal.conf
+ *   > 0 -> explicit seconds from the CLI
+ */
+#define TIMEOUT_FROM_CONFIG  0
+#define COMMAND_CONFIG_LS    "conf-ls"
+#define COMMAND_CONFIG_GET   "conf-get"
+#define COMMAND_CONFIG_SET   "conf-set"
+#define COMMAND_CONFIG_ALIAS "conf-alias"
 
-#define UNSPECIFIED            "Unspecified"
+#define OUTPUT_FORMAT_JSON   "json"
+#define OUTPUT_FORMAT_TEXT   "text"
+
+#define UNSPECIFIED          "Unspecified"
 
 static void display_helper(char* command);
 static void help_cancel_shutdown(void);
@@ -100,8 +108,9 @@ static int conf_set(SSL* ssl, int socket, char* config_key, char* config_value, 
 static int details(SSL* ssl, int socket, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int disabledb(SSL* ssl, int socket, char* database, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int enabledb(SSL* ssl, int socket, char* database, uint8_t compression, uint8_t encryption, int32_t output_format);
-static int flush(SSL* ssl, int socket, int32_t mode, char* database, uint8_t compression, uint8_t encryption, int32_t output_format);
+static int flush(SSL* ssl, int socket, int32_t mode, char* database, int32_t timeout, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int gracefully(SSL* ssl, int socket, uint8_t compression, uint8_t encryption, int32_t output_format);
+static int shutdown_timeout(SSL* ssl, int socket, int32_t timeout, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int pgagroal_shutdown(SSL* ssl, int socket, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int ping(SSL* ssl, int socket, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int reload(SSL* ssl, int socket, uint8_t compression, uint8_t encryption, int32_t output_format);
@@ -219,6 +228,14 @@ const struct pgagroal_command command_table[] = {
       .log_message = "<shutdown cancel>"
    },
    {
+      .command = "shutdown",
+      .subcommand = "timeout",
+      .accepted_argument_count = {0, 1},
+      .action = MANAGEMENT_SHUTDOWN_TIMEOUT,
+      .deprecated = false,
+      .log_message = "<shutdown timeout>"
+   },
+   {
       .command = "conf",
       .subcommand = "reload",
       .accepted_argument_count = {0},
@@ -298,6 +315,16 @@ const struct pgagroal_command command_table[] = {
       .log_message = "<flush all> [%s]",
    },
    {
+      .command = "flush",
+      .subcommand = "timeout",
+      .accepted_argument_count = {0, 1, 2},
+      .action = MANAGEMENT_FLUSH,
+      .mode = FLUSH_TIMEOUT,
+      .default_argument = "*",
+      .deprecated = false,
+      .log_message = "<flush timeout> [%s]",
+   },
+   {
       .command = "clear",
       .subcommand = "prometheus",
       .accepted_argument_count = {0},
@@ -353,6 +380,9 @@ usage(void)
    printf("  flush [mode] [database]  Flush connections according to [mode].\n");
    printf("                           Allowed modes are:\n");
    printf("                           - 'gracefully' (default) to flush all connections gracefully\n");
+   printf("                           - 'timeout [SECONDS] [database]' graceful flush bounded by SECONDS\n");
+   printf("                             (or 'flush_timeout' from pgagroal.conf if SECONDS is omitted);\n");
+   printf("                             on expiry remaining connections are terminated (flush all)\n");
    printf("                           - 'idle' to flush only idle connections\n");
    printf("                           - 'all' to flush all connections. USE WITH CAUTION!\n");
    printf("                           If no [database] name is specified, applies to all databases.\n");
@@ -361,6 +391,9 @@ usage(void)
    printf("  disable  [database]      Disables the specified databases (or all databases)\n");
    printf("  shutdown [mode]          Stops pgagroal pooler. The [mode] can be:\n");
    printf("                           - 'gracefully' (default) waits for active connections to quit\n");
+   printf("                           - 'timeout [SECONDS]' graceful wait bounded by SECONDS (or\n");
+   printf("                             'flush_timeout' from pgagroal.conf if SECONDS is omitted);\n");
+   printf("                             on expiry forces an immediate shutdown\n");
    printf("                           - 'immediate' forces connections to close and terminate\n");
    printf("                           - 'cancel' avoid a previously issued 'shutdown gracefully'\n");
    printf("  status [details]         Status of pgagroal, with optional details\n");
@@ -761,7 +794,52 @@ username:
 
    if (parsed.cmd->action == MANAGEMENT_FLUSH)
    {
-      exit_code = flush(s_ssl, socket, parsed.cmd->mode, parsed.args[0], compression, encryption, output_format);
+      int32_t timeout = TIMEOUT_FROM_CONFIG;
+      char* database = parsed.args[0];
+
+      if (parsed.cmd->mode == FLUSH_TIMEOUT)
+      {
+         /* Layout:
+          *   flush timeout                       -> use config, db="*"
+          *   flush timeout <SECONDS>             -> explicit seconds, db="*"
+          *   flush timeout <SECONDS> <database>  -> explicit seconds, specific db
+          *
+          * parse_command fills args[0] with default_argument ("*") when no arg was
+          * passed, so we cannot rely on args[0] alone to detect "no args".
+          * When args[1] is set we treat args[0] as SECONDS and args[1] as the
+          * database; otherwise if args[0] is not the default ("*") it's SECONDS.
+          */
+         char* secs_str = NULL;
+         if (parsed.args[1] != NULL)
+         {
+            secs_str = parsed.args[0];
+            database = parsed.args[1];
+         }
+         else if (parsed.args[0] != NULL && strcmp(parsed.args[0], "*") != 0)
+         {
+            secs_str = parsed.args[0];
+            database = (char*)"*";
+         }
+         else
+         {
+            database = (char*)"*";
+         }
+
+         if (secs_str != NULL)
+         {
+            char* end = NULL;
+            long v = strtol(secs_str, &end, 10);
+            if (end == secs_str || *end != '\0' || v <= 0 || v > INT32_MAX)
+            {
+               warnx("pgagroal-cli: 'flush timeout' requires a positive integer number of seconds (got '%s')", secs_str);
+               exit_code = 1;
+               goto done;
+            }
+            timeout = (int32_t)v;
+         }
+      }
+
+      exit_code = flush(s_ssl, socket, parsed.cmd->mode, database, timeout, compression, encryption, output_format);
    }
    else if (parsed.cmd->action == MANAGEMENT_ENABLEDB)
    {
@@ -774,6 +852,25 @@ username:
    else if (parsed.cmd->action == MANAGEMENT_GRACEFULLY)
    {
       exit_code = gracefully(s_ssl, socket, compression, encryption, output_format);
+   }
+   else if (parsed.cmd->action == MANAGEMENT_SHUTDOWN_TIMEOUT)
+   {
+      int32_t timeout = TIMEOUT_FROM_CONFIG;
+
+      if (parsed.args[0] != NULL)
+      {
+         char* end = NULL;
+         long v = strtol(parsed.args[0], &end, 10);
+         if (end == parsed.args[0] || *end != '\0' || v <= 0 || v > INT32_MAX)
+         {
+            warnx("pgagroal-cli: 'shutdown timeout' requires a positive integer number of seconds (got '%s')", parsed.args[0]);
+            exit_code = 1;
+            goto done;
+         }
+         timeout = (int32_t)v;
+      }
+
+      exit_code = shutdown_timeout(s_ssl, socket, timeout, compression, encryption, output_format);
    }
    else if (parsed.cmd->action == MANAGEMENT_SHUTDOWN)
    {
@@ -873,7 +970,10 @@ static void
 help_shutdown(void)
 {
    printf("Shutdown pgagroal\n");
-   printf("  pgagroal-cli shutdown\n");
+   printf("  pgagroal-cli shutdown [gracefully|immediate|cancel]\n");
+   printf("  pgagroal-cli shutdown timeout [<SECONDS>]\n");
+   printf("    'timeout' bounds a graceful shutdown; SECONDS overrides 'flush_timeout' from pgagroal.conf.\n");
+   printf("    On expiry pgagroal forces an immediate shutdown.\n");
 }
 
 static void
@@ -927,6 +1027,9 @@ help_flush(void)
 {
    printf("Flush connections\n");
    printf("  pgagroal-cli flush [gracefully|idle|all] [*|<database>]\n");
+   printf("  pgagroal-cli flush timeout [<SECONDS>] [<database>]\n");
+   printf("    'timeout' bounds a graceful flush; SECONDS overrides 'flush_timeout' from pgagroal.conf.\n");
+   printf("    On expiry remaining marked connections are terminated.\n");
 }
 
 static void
@@ -991,9 +1094,9 @@ display_helper(char* command)
 }
 
 static int
-flush(SSL* ssl, int socket, int32_t mode, char* database, uint8_t compression, uint8_t encryption, int32_t output_format)
+flush(SSL* ssl, int socket, int32_t mode, char* database, int32_t timeout, uint8_t compression, uint8_t encryption, int32_t output_format)
 {
-   if (pgagroal_management_request_flush(ssl, socket, mode, database, compression, encryption, output_format))
+   if (pgagroal_management_request_flush(ssl, socket, mode, database, timeout, compression, encryption, output_format))
    {
       goto error;
    }
@@ -1054,6 +1157,26 @@ static int
 gracefully(SSL* ssl, int socket, uint8_t compression, uint8_t encryption, int32_t output_format)
 {
    if (pgagroal_management_request_gracefully(ssl, socket, compression, encryption, output_format))
+   {
+      goto error;
+   }
+
+   if (process_result(ssl, socket, output_format))
+   {
+      goto error;
+   }
+
+   return 0;
+
+error:
+
+   return 1;
+}
+
+static int
+shutdown_timeout(SSL* ssl, int socket, int32_t timeout, uint8_t compression, uint8_t encryption, int32_t output_format)
+{
+   if (pgagroal_management_request_shutdown_timeout(ssl, socket, timeout, compression, encryption, output_format))
    {
       goto error;
    }
@@ -2041,6 +2164,9 @@ translate_command(int32_t cmd_code)
          command_output = pgagroal_append(command_output, COMMAND_CLEAR_SERVER);
          break;
       case MANAGEMENT_SHUTDOWN:
+         command_output = pgagroal_append(command_output, COMMAND_SHUTDOWN);
+         break;
+      case MANAGEMENT_SHUTDOWN_TIMEOUT:
          command_output = pgagroal_append(command_output, COMMAND_SHUTDOWN);
          break;
       case MANAGEMENT_STATUS:

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -98,6 +98,7 @@ extern "C" {
 #define CONFIGURATION_ARGUMENT_ROTATE_FRONTEND_PASSWORD_TIMEOUT "rotate_frontend_password_timeout"
 #define CONFIGURATION_ARGUMENT_ROTATE_FRONTEND_PASSWORD_LENGTH  "rotate_frontend_password_length"
 #define CONFIGURATION_ARGUMENT_MAX_CONNECTION_AGE               "max_connection_age"
+#define CONFIGURATION_ARGUMENT_FLUSH_TIMEOUT                    "flush_timeout"
 #define CONFIGURATION_ARGUMENT_VALIDATION                       "validation"
 #define CONFIGURATION_ARGUMENT_STARTUP_VALIDATION               "startup_validation"
 #define CONFIGURATION_ARGUMENT_BACKGROUND_INTERVAL              "background_interval"

--- a/src/include/management.h
+++ b/src/include/management.h
@@ -67,31 +67,32 @@ extern "C" {
 /**
  * Management commands
  */
-#define MANAGEMENT_UNKNOWN         0
-#define MANAGEMENT_CANCEL_SHUTDOWN 1
-#define MANAGEMENT_CONFIG_LS       2
-#define MANAGEMENT_CONFIG_GET      3
-#define MANAGEMENT_CONFIG_SET      4
-#define MANAGEMENT_DETAILS         5
-#define MANAGEMENT_DISABLEDB       6
-#define MANAGEMENT_ENABLEDB        7
-#define MANAGEMENT_FLUSH           8
-#define MANAGEMENT_GET_PASSWORD    9
-#define MANAGEMENT_GRACEFULLY      10
-#define MANAGEMENT_PING            11
-#define MANAGEMENT_RELOAD          12
-#define MANAGEMENT_CLEAR           13
-#define MANAGEMENT_CLEAR_SERVER    14
-#define MANAGEMENT_SHUTDOWN        15
-#define MANAGEMENT_STATUS          16
-#define MANAGEMENT_SWITCH_TO       17
-#define MANAGEMENT_CONFIG_ALIAS    18
+#define MANAGEMENT_UNKNOWN          0
+#define MANAGEMENT_CANCEL_SHUTDOWN  1
+#define MANAGEMENT_CONFIG_LS        2
+#define MANAGEMENT_CONFIG_GET       3
+#define MANAGEMENT_CONFIG_SET       4
+#define MANAGEMENT_DETAILS          5
+#define MANAGEMENT_DISABLEDB        6
+#define MANAGEMENT_ENABLEDB         7
+#define MANAGEMENT_FLUSH            8
+#define MANAGEMENT_GET_PASSWORD     9
+#define MANAGEMENT_GRACEFULLY       10
+#define MANAGEMENT_PING             11
+#define MANAGEMENT_RELOAD           12
+#define MANAGEMENT_CLEAR            13
+#define MANAGEMENT_CLEAR_SERVER     14
+#define MANAGEMENT_SHUTDOWN         15
+#define MANAGEMENT_STATUS           16
+#define MANAGEMENT_SWITCH_TO        17
+#define MANAGEMENT_CONFIG_ALIAS     18
 
-#define MANAGEMENT_MASTER_KEY      19
-#define MANAGEMENT_ADD_USER        20
-#define MANAGEMENT_UPDATE_USER     21
-#define MANAGEMENT_REMOVE_USER     22
-#define MANAGEMENT_LIST_USERS      23
+#define MANAGEMENT_MASTER_KEY       19
+#define MANAGEMENT_ADD_USER         20
+#define MANAGEMENT_UPDATE_USER      21
+#define MANAGEMENT_REMOVE_USER      22
+#define MANAGEMENT_LIST_USERS       23
+#define MANAGEMENT_SHUTDOWN_TIMEOUT 24
 /**
  * Management arguments
  */
@@ -117,6 +118,7 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_MAX_CONNECTIONS     "MaxConnections"
 #define MANAGEMENT_ARGUMENT_MIN_CONNECTIONS     "MinConnections"
 #define MANAGEMENT_ARGUMENT_MODE                "Mode"
+#define MANAGEMENT_ARGUMENT_TIMEOUT             "Timeout"
 #define MANAGEMENT_ARGUMENT_NUMBER_OF_SERVERS   "NumberOfServers"
 #define MANAGEMENT_ARGUMENT_OUTPUT              "Output"
 #define MANAGEMENT_ARGUMENT_PASSWORD            "Password"
@@ -235,7 +237,7 @@ pgagroal_management_create_outcome_failure(struct json* json, int32_t error, str
  * @return 0 upon success, otherwise 1
  */
 int
-pgagroal_management_request_flush(SSL* ssl, int socket, int32_t mode, char* database, uint8_t compression, uint8_t encryption, int32_t output_format);
+pgagroal_management_request_flush(SSL* ssl, int socket, int32_t mode, char* database, int32_t timeout, uint8_t compression, uint8_t encryption, int32_t output_format);
 
 /**
  * Management operation: Enable database
@@ -274,6 +276,20 @@ pgagroal_management_request_disabledb(SSL* ssl, int socket, char* database, uint
  */
 int
 pgagroal_management_request_gracefully(SSL* ssl, int socket, uint8_t compression, uint8_t encryption, int32_t output_format);
+
+/**
+ * Management operation: shutdown gracefully with a bounded wait
+ * @param ssl The SSL connection
+ * @param socket The socket
+ * @param timeout Seconds to wait before forcing an immediate shutdown.
+ *                0 means "use 'flush_timeout' from pgagroal.conf"; >0 means explicit seconds.
+ * @param compression The compression method
+ * @param encryption The encryption method
+ * @param output_format The output format
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgagroal_management_request_shutdown_timeout(SSL* ssl, int socket, int32_t timeout, uint8_t compression, uint8_t encryption, int32_t output_format);
 
 /**
  * Management operation: Stop

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -78,6 +78,7 @@ extern "C" {
 #define DEFAULT_IDLE_TIMEOUT                     0
 #define DEFAULT_ROTATE_FRONTEND_PASSWORD_TIMEOUT 0
 #define DEFAULT_MAX_CONNECTION_AGE               0
+#define DEFAULT_FLUSH_TIMEOUT                    0
 #define DEFAULT_BACKGROUND_INTERVAL              300
 #define DEFAULT_HEALTH_CHECK_PERIOD              30
 #define DEFAULT_HEALTH_CHECK_TIMEOUT             5
@@ -158,6 +159,11 @@ extern "C" {
 #define FLUSH_IDLE                     0
 #define FLUSH_GRACEFULLY               1
 #define FLUSH_ALL                      2
+#define FLUSH_TIMEOUT                  3
+
+#define FLUSH_TIMEOUT_REASON_NONE      0
+#define FLUSH_TIMEOUT_REASON_SHUTDOWN  1
+#define FLUSH_TIMEOUT_REASON_FLUSH     2
 
 #define VALIDATION_OFF                 0
 #define VALIDATION_FOREGROUND          1
@@ -719,6 +725,7 @@ struct main_configuration
    pgagroal_time_t rotate_frontend_password_timeout; /**< The duration of rotate frontend password timeout (Default seconds) */
    int rotate_frontend_password_length;              /**< Length of randomised passwords */
    pgagroal_time_t max_connection_age;               /**< The duration of max connection age (Default seconds) */
+   pgagroal_time_t flush_timeout;                    /**< Default timeout (seconds) for 'flush timeout' / 'shutdown timeout' when no value is passed on the CLI (0 = no default) */
    int validation;                                   /**< Validation mode */
    pgagroal_time_t background_interval;              /**< The duration of background validation interval (Default seconds) */
    int max_retries;                                  /**< The maximum number of retries */

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -168,6 +168,7 @@ pgagroal_init_configuration(void* shm)
    config->rotate_frontend_password_timeout = PGAGROAL_TIME_SEC(DEFAULT_ROTATE_FRONTEND_PASSWORD_TIMEOUT);
    config->rotate_frontend_password_length = MIN_PASSWORD_LENGTH;
    config->max_connection_age = PGAGROAL_TIME_SEC(DEFAULT_MAX_CONNECTION_AGE);
+   config->flush_timeout = PGAGROAL_TIME_SEC(DEFAULT_FLUSH_TIMEOUT);
    config->validation = VALIDATION_OFF;
    config->background_interval = PGAGROAL_TIME_SEC(DEFAULT_BACKGROUND_INTERVAL);
    config->max_retries = 5;
@@ -3745,6 +3746,7 @@ transfer_configuration(struct main_configuration* config, struct main_configurat
    memcpy(&config->rotate_frontend_password_timeout, &reload->rotate_frontend_password_timeout, sizeof(config->rotate_frontend_password_timeout));
    config->rotate_frontend_password_length = reload->rotate_frontend_password_length;
    memcpy(&config->max_connection_age, &reload->max_connection_age, sizeof(config->max_connection_age));
+   memcpy(&config->flush_timeout, &reload->flush_timeout, sizeof(config->flush_timeout));
    config->validation = reload->validation;
    memcpy(&config->background_interval, &reload->background_interval, sizeof(config->background_interval));
    config->max_retries = reload->max_retries;
@@ -4930,6 +4932,10 @@ pgagroal_write_config_value(char* buffer, char* config_key, size_t buffer_size)
       {
          return to_int(buffer, (int)pgagroal_time_convert(config->max_connection_age, FORMAT_TIME_S));
       }
+      else if (!strncmp(key, "flush_timeout", MISC_LENGTH))
+      {
+         return to_int(buffer, (int)pgagroal_time_convert(config->flush_timeout, FORMAT_TIME_S));
+      }
       else if (!strncmp(key, "validation", MISC_LENGTH))
       {
          return to_validation(buffer, config->validation);
@@ -5981,6 +5987,13 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
          unknown = true;
       }
    }
+   else if (key_in_section("flush_timeout", section, key, true, &unknown))
+   {
+      if (as_seconds(value, &config->flush_timeout, PGAGROAL_TIME_SEC(DEFAULT_FLUSH_TIMEOUT)))
+      {
+         unknown = true;
+      }
+   }
    else if (key_in_section("validation", section, key, true, &unknown))
    {
       if (as_validation(value, &config->validation))
@@ -6806,6 +6819,7 @@ add_configuration_response(struct json* res)
    pgagroal_json_put_time_value(res, CONFIGURATION_ARGUMENT_ROTATE_FRONTEND_PASSWORD_TIMEOUT, config->rotate_frontend_password_timeout, FORMAT_TIME_S);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_ROTATE_FRONTEND_PASSWORD_LENGTH, (uintptr_t)config->rotate_frontend_password_length, ValueInt64);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_MAX_CONNECTION_AGE, (uintptr_t)pgagroal_time_convert(config->max_connection_age, FORMAT_TIME_S), ValueInt64);
+   pgagroal_json_put(res, CONFIGURATION_ARGUMENT_FLUSH_TIMEOUT, (uintptr_t)pgagroal_time_convert(config->flush_timeout, FORMAT_TIME_S), ValueInt64);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_VALIDATION, (uintptr_t)config->validation, ValueInt64);
    pgagroal_json_put_enum_value(res, CONFIGURATION_ARGUMENT_STARTUP_VALIDATION, config->startup_validation, to_startup_validation);
    pgagroal_json_put(res, CONFIGURATION_ARGUMENT_BACKGROUND_INTERVAL, (uintptr_t)pgagroal_time_convert(config->background_interval, FORMAT_TIME_S), ValueInt64);
@@ -7147,7 +7161,7 @@ pgagroal_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t compr
       pgagroal_json_put(response, CONFIGURATION_RESPONSE_CONFIG_KEY, (uintptr_t)config_key, ValueString);
       pgagroal_json_put(response, CONFIGURATION_RESPONSE_REQUESTED_VALUE, (uintptr_t)config_value, ValueString);
       pgagroal_json_put(response, CONFIGURATION_RESPONSE_CURRENT_VALUE, (uintptr_t)old_value, ValueString);
-      pgagroal_json_put(response, CONFIGURATION_RESPONSE_RESTART_REQUIRED, (uintptr_t)true, ValueBool);
+      pgagroal_json_put(response, CONFIGURATION_RESPONSE_RESTART_REQUIRED, (uintptr_t) true, ValueBool);
 
       pgagroal_log_info("Conf Set: Restart required for %s=%s. Current value: %s", config_key, config_value, old_value);
    }
@@ -7159,7 +7173,7 @@ pgagroal_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t compr
       pgagroal_json_put(response, CONFIGURATION_RESPONSE_CONFIG_KEY, (uintptr_t)config_key, ValueString);
       pgagroal_json_put(response, CONFIGURATION_RESPONSE_OLD_VALUE, (uintptr_t)old_value, ValueString);
       pgagroal_json_put(response, CONFIGURATION_RESPONSE_NEW_VALUE, (uintptr_t)new_value, ValueString);
-      pgagroal_json_put(response, CONFIGURATION_RESPONSE_RESTART_REQUIRED, (uintptr_t)false, ValueBool);
+      pgagroal_json_put(response, CONFIGURATION_RESPONSE_RESTART_REQUIRED, (uintptr_t) false, ValueBool);
 
       pgagroal_log_info("Conf Set: Successfully applied %s: %s -> %s", config_key, old_value, new_value);
    }

--- a/src/libpgagroal/management.c
+++ b/src/libpgagroal/management.c
@@ -69,7 +69,7 @@ static int write_socket(int socket, void* buf, size_t size);
 static int write_ssl(SSL* ssl, void* buf, size_t size);
 
 int
-pgagroal_management_request_flush(SSL* ssl, int socket, int32_t mode, char* database, uint8_t compression, uint8_t encryption, int32_t output_format)
+pgagroal_management_request_flush(SSL* ssl, int socket, int32_t mode, char* database, int32_t timeout, uint8_t compression, uint8_t encryption, int32_t output_format)
 {
    struct json* j = NULL;
    struct json* request = NULL;
@@ -86,6 +86,7 @@ pgagroal_management_request_flush(SSL* ssl, int socket, int32_t mode, char* data
 
    pgagroal_json_put(request, MANAGEMENT_ARGUMENT_MODE, (uintptr_t)mode, ValueInt32);
    pgagroal_json_put(request, MANAGEMENT_ARGUMENT_DATABASE, (uintptr_t)database, ValueString);
+   pgagroal_json_put(request, MANAGEMENT_ARGUMENT_TIMEOUT, (uintptr_t)timeout, ValueInt32);
 
    if (pgagroal_management_write_json(ssl, socket, compression, encryption, j))
    {
@@ -335,6 +336,40 @@ pgagroal_management_request_gracefully(SSL* ssl, int socket, uint8_t compression
    {
       goto error;
    }
+
+   if (pgagroal_management_write_json(ssl, socket, compression, encryption, j))
+   {
+      goto error;
+   }
+
+   pgagroal_json_destroy(j);
+
+   return 0;
+
+error:
+
+   pgagroal_json_destroy(j);
+
+   return 1;
+}
+
+int
+pgagroal_management_request_shutdown_timeout(SSL* ssl, int socket, int32_t timeout, uint8_t compression, uint8_t encryption, int32_t output_format)
+{
+   struct json* j = NULL;
+   struct json* request = NULL;
+
+   if (pgagroal_management_create_header(MANAGEMENT_SHUTDOWN_TIMEOUT, compression, encryption, output_format, &j))
+   {
+      goto error;
+   }
+
+   if (pgagroal_management_create_request(j, &request))
+   {
+      goto error;
+   }
+
+   pgagroal_json_put(request, MANAGEMENT_ARGUMENT_TIMEOUT, (uintptr_t)timeout, ValueInt32);
 
    if (pgagroal_management_write_json(ssl, socket, compression, encryption, j))
    {
@@ -832,7 +867,7 @@ pgagroal_management_create_outcome_success(struct json* json, time_t start_time,
 
    elapsed = pgagroal_get_timestamp_string(start_time, end_time, &total_seconds);
 
-   pgagroal_json_put(r, MANAGEMENT_ARGUMENT_STATUS, (uintptr_t)true, ValueBool);
+   pgagroal_json_put(r, MANAGEMENT_ARGUMENT_STATUS, (uintptr_t) true, ValueBool);
    pgagroal_json_put(r, MANAGEMENT_ARGUMENT_TIME, (uintptr_t)elapsed, ValueString);
 
    pgagroal_json_put(json, MANAGEMENT_CATEGORY_OUTCOME, (uintptr_t)r, ValueJSON);
@@ -864,7 +899,7 @@ pgagroal_management_create_outcome_failure(struct json* json, int32_t error, str
       goto error;
    }
 
-   pgagroal_json_put(r, MANAGEMENT_ARGUMENT_STATUS, (uintptr_t)false, ValueBool);
+   pgagroal_json_put(r, MANAGEMENT_ARGUMENT_STATUS, (uintptr_t) false, ValueBool);
    pgagroal_json_put(r, MANAGEMENT_ARGUMENT_ERROR, (uintptr_t)error, ValueInt32);
 
    pgagroal_json_put(json, MANAGEMENT_CATEGORY_OUTCOME, (uintptr_t)r, ValueJSON);

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -984,7 +984,7 @@ pgagroal_flush(int mode, char* database)
                pgagroal_kill_connection(i, NULL);
                prefill = true;
             }
-            else if (mode == FLUSH_ALL || mode == FLUSH_GRACEFULLY)
+            else if (mode == FLUSH_ALL || mode == FLUSH_GRACEFULLY || mode == FLUSH_TIMEOUT)
             {
                if (atomic_compare_exchange_strong(&config->states[i], &in_use, STATE_FLUSH))
                {
@@ -996,9 +996,21 @@ pgagroal_flush(int mode, char* database)
                      pgagroal_kill_connection(i, NULL);
                      prefill = true;
                   }
-                  else if (mode == FLUSH_GRACEFULLY)
+                  else if (mode == FLUSH_GRACEFULLY || mode == FLUSH_TIMEOUT)
                   {
                      atomic_store(&config->states[i], STATE_GRACEFULLY);
+                  }
+               }
+               else if (mode == FLUSH_ALL)
+               {
+                  signed char graceful = STATE_GRACEFULLY;
+                  if (atomic_compare_exchange_strong(&config->states[i], &graceful, STATE_FLUSH))
+                  {
+                     kill(config->connections[i].pid, SIGQUIT);
+                     pgagroal_prometheus_connection_flush();
+                     pgagroal_tracking_event_slot(TRACKER_FLUSH, i);
+                     pgagroal_kill_connection(i, NULL);
+                     prefill = true;
                   }
                }
             }

--- a/src/main.c
+++ b/src/main.c
@@ -93,6 +93,9 @@ static void max_connection_age_cb(void);
 static void rotate_frontend_password_cb(void);
 static void validation_cb(void);
 static void disconnect_client_cb(void);
+static void flush_timeout_cb(void);
+static void start_flush_timeout_timer(int reason, int32_t seconds, const char* database);
+static void stop_flush_timeout_timer(void);
 static void frontend_user_password_startup(struct main_configuration* config);
 static bool accept_fatal(int error);
 static void add_client(pid_t pid);
@@ -136,11 +139,15 @@ static struct periodic_watcher max_connection_age_watcher;
 static struct periodic_watcher validation_watcher;
 static struct periodic_watcher disconnect_client_watcher;
 static struct periodic_watcher rotate_frontend_password_watcher;
+static struct periodic_watcher flush_timeout_watcher;
 static bool idle_timeout_started = false;
 static bool max_connection_age_started = false;
 static bool validation_started = false;
 static bool disconnect_client_started = false;
 static bool rotate_frontend_password_started = false;
+static bool flush_timeout_started = false;
+static int flush_timeout_reason = FLUSH_TIMEOUT_REASON_NONE;
+static char flush_timeout_database[MAX_DATABASE_LENGTH];
 
 static void
 start_mgt(void)
@@ -1680,7 +1687,20 @@ accept_mgt_cb(struct io_watcher* watcher)
 
    if (id == MANAGEMENT_FLUSH)
    {
+      struct json* req = NULL;
+      int flush_mode = -1;
+      int32_t req_timeout = 0;
+      char* req_database = NULL;
+
       pgagroal_log_debug("pgagroal: Management flush");
+
+      req = (struct json*)pgagroal_json_get(payload, MANAGEMENT_CATEGORY_REQUEST);
+      if (req != NULL)
+      {
+         flush_mode = (int)pgagroal_json_get(req, MANAGEMENT_ARGUMENT_MODE);
+         req_timeout = (int32_t)pgagroal_json_get(req, MANAGEMENT_ARGUMENT_TIMEOUT);
+         req_database = (char*)pgagroal_json_get(req, MANAGEMENT_ARGUMENT_DATABASE);
+      }
 
       pid = fork();
       if (pid == -1)
@@ -1699,6 +1719,25 @@ accept_mgt_cb(struct io_watcher* watcher)
 
          pgagroal_set_proc_title(1, ai->argv, "flush", NULL);
          pgagroal_request_flush(NULL, client_fd, compression, encryption, pyl);
+      }
+      else
+      {
+         if (flush_mode == FLUSH_TIMEOUT)
+         {
+            int32_t secs = req_timeout;
+            if (secs <= 0)
+            {
+               secs = (int32_t)pgagroal_time_convert(config->flush_timeout, FORMAT_TIME_S);
+               if (secs <= 0)
+               {
+                  pgagroal_log_warn("pgagroal: 'flush timeout' requested with no SECONDS and 'flush_timeout' is not configured - proceeding unbounded");
+               }
+            }
+            if (secs > 0)
+            {
+               start_flush_timeout_timer(FLUSH_TIMEOUT_REASON_FLUSH, secs, req_database);
+            }
+         }
       }
    }
    else if (id == MANAGEMENT_ENABLEDB)
@@ -1729,7 +1768,7 @@ accept_mgt_cb(struct io_watcher* watcher)
          pgagroal_json_create(&js);
 
          pgagroal_json_put(js, MANAGEMENT_ARGUMENT_DATABASE, (uintptr_t)database, ValueString);
-         pgagroal_json_put(js, MANAGEMENT_ARGUMENT_ENABLED, (uintptr_t)true, ValueBool);
+         pgagroal_json_put(js, MANAGEMENT_ARGUMENT_ENABLED, (uintptr_t) true, ValueBool);
 
          pgagroal_json_append(databases, (uintptr_t)js, ValueJSON);
       }
@@ -1747,7 +1786,7 @@ accept_mgt_cb(struct io_watcher* watcher)
                pgagroal_json_create(&js);
 
                pgagroal_json_put(js, MANAGEMENT_ARGUMENT_DATABASE, (uintptr_t)database, ValueString);
-               pgagroal_json_put(js, MANAGEMENT_ARGUMENT_ENABLED, (uintptr_t)true, ValueBool);
+               pgagroal_json_put(js, MANAGEMENT_ARGUMENT_ENABLED, (uintptr_t) true, ValueBool);
 
                pgagroal_json_append(databases, (uintptr_t)js, ValueJSON);
 
@@ -1838,6 +1877,42 @@ accept_mgt_cb(struct io_watcher* watcher)
 
       pgagroal_management_response_ok(NULL, client_fd, start_time, end_time, compression, encryption, payload);
    }
+   else if (id == MANAGEMENT_SHUTDOWN_TIMEOUT)
+   {
+      struct json* req = NULL;
+      int32_t req_timeout = 0;
+      int32_t secs = 0;
+
+      pgagroal_log_debug("pgagroal: Management shutdown timeout");
+      pgagroal_pool_status();
+
+      start_time = time(NULL);
+
+      config->gracefully = true;
+
+      req = (struct json*)pgagroal_json_get(payload, MANAGEMENT_CATEGORY_REQUEST);
+      if (req != NULL)
+      {
+         req_timeout = (int32_t)pgagroal_json_get(req, MANAGEMENT_ARGUMENT_TIMEOUT);
+      }
+      secs = req_timeout;
+      if (secs <= 0)
+      {
+         secs = (int32_t)pgagroal_time_convert(config->flush_timeout, FORMAT_TIME_S);
+         if (secs <= 0)
+         {
+            pgagroal_log_warn("pgagroal: 'shutdown timeout' requested with no SECONDS and 'flush_timeout' is not configured - proceeding unbounded");
+         }
+      }
+      if (secs > 0)
+      {
+         start_flush_timeout_timer(FLUSH_TIMEOUT_REASON_SHUTDOWN, secs, NULL);
+      }
+
+      end_time = time(NULL);
+
+      pgagroal_management_response_ok(NULL, client_fd, start_time, end_time, compression, encryption, payload);
+   }
    else if (id == MANAGEMENT_SHUTDOWN)
    {
       pgagroal_log_debug("pgagroal: Management shutdown");
@@ -1849,6 +1924,7 @@ accept_mgt_cb(struct io_watcher* watcher)
 
       pgagroal_management_response_ok(NULL, client_fd, start_time, end_time, compression, encryption, payload);
 
+      stop_flush_timeout_timer();
       config->keep_running = false;
 
       pgagroal_event_loop_break();
@@ -1861,6 +1937,7 @@ accept_mgt_cb(struct io_watcher* watcher)
       start_time = time(NULL);
 
       config->gracefully = false;
+      stop_flush_timeout_timer();
 
       end_time = time(NULL);
 
@@ -1972,7 +2049,7 @@ accept_mgt_cb(struct io_watcher* watcher)
             pgagroal_json_create(&sobj);
             pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_HOST, (uintptr_t)config->servers[i].host, ValueString);
             pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_PORT, (uintptr_t)config->servers[i].port, ValueInt32);
-            pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_STATUS, (uintptr_t)"Invalid", ValueString);
+            pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_STATUS, (uintptr_t) "Invalid", ValueString);
 
             pgagroal_json_put(invalid_servers, config->servers[i].name, (uintptr_t)sobj, ValueJSON);
          }
@@ -2224,6 +2301,7 @@ accept_mgt_cb(struct io_watcher* watcher)
          if (atomic_load(&config->active_connections) == 0)
          {
             pgagroal_log_debug("pgagroal: graceful shutdown triggered  - connections=0, gracefully=true, keep_running=true");
+            stop_flush_timeout_timer();
             pgagroal_pool_status();
             pgagroal_event_loop_break();
          }
@@ -2680,6 +2758,7 @@ shutdown_cb(void)
    struct main_configuration* config = (struct main_configuration*)shmem;
 
    pgagroal_log_debug("pgagroal: shutdown requested");
+   stop_flush_timeout_timer();
    config->keep_running = false;
    pgagroal_pool_status();
    pgagroal_health_check_stop();
@@ -2708,6 +2787,7 @@ graceful_cb(void)
 
    if (atomic_load(&config->active_connections) == 0)
    {
+      stop_flush_timeout_timer();
       pgagroal_pool_status();
 
       pgagroal_event_loop_break();
@@ -2778,6 +2858,46 @@ disconnect_client_cb(void)
       shutdown_ports(false);
       main_pipeline.periodic();
    }
+}
+
+static void
+flush_timeout_cb(void)
+{
+   struct main_configuration* config = (struct main_configuration*)shmem;
+   int reason = flush_timeout_reason;
+   char db[MAX_DATABASE_LENGTH];
+   if (reason == FLUSH_TIMEOUT_REASON_NONE)
+   {
+      return;
+   }
+
+   memcpy(db, flush_timeout_database, sizeof(db));
+
+   stop_flush_timeout_timer();
+
+   if (reason == FLUSH_TIMEOUT_REASON_SHUTDOWN)
+   {
+      pgagroal_log_warn("pgagroal: flush timeout expired - forcing immediate shutdown");
+      config->gracefully = false;
+      config->keep_running = false;
+      pgagroal_event_loop_break();
+   }
+   else if (reason == FLUSH_TIMEOUT_REASON_FLUSH)
+   {
+      pgagroal_log_warn("pgagroal: flush timeout expired - forcing FLUSH_ALL on database '%s'",
+                        db[0] ? db : "*");
+      if (!fork())
+      {
+         pgagroal_flush(FLUSH_ALL, db[0] ? db : "*");
+         exit(0);
+      }
+   }
+   else
+   {
+      pgagroal_log_debug("pgagroal: flush_timeout fired with no reason set - ignoring");
+   }
+
+   pgagroal_pool_status();
 }
 
 static void
@@ -2940,9 +3060,74 @@ stop_periodic_watcher(struct periodic_watcher* watcher, bool* started)
          pgagroal_log_warn("Unable to stop periodic watcher");
       }
 
-      memset(watcher, 0, sizeof(struct periodic_watcher));
+      /* Intentionally NOT memsetting the watcher here. The io_uring backend
+       * arms periodic watchers with IORING_TIMEOUT_MULTISHOT and stops them
+       * by submitting a cancel SQE. The kernel responds with a final
+       * -ECANCELED CQE that still carries the original user_data pointer
+       * (this watcher). The event dispatcher then reads watcher->type to
+       * route the CQE; if we zeroed type here it would trip the "Unknown
+       * event type: 0" FATAL in ev.c. Leaving type and cb intact lets the
+       * stale CQE dispatch into the original cb, which is expected to be
+       * idempotent (re-armed elsewhere via pgagroal_periodic_init).
+       */
       *started = false;
    }
+}
+
+static void
+start_flush_timeout_timer(int reason, int32_t seconds, const char* database)
+{
+   if (seconds <= 0)
+   {
+      return;
+   }
+
+   if (flush_timeout_started)
+   {
+      pgagroal_log_debug("pgagroal: flush timeout re-armed (was reason=%d, now reason=%d)",
+                         flush_timeout_reason, reason);
+      stop_flush_timeout_timer();
+   }
+
+   memset(flush_timeout_database, 0, sizeof(flush_timeout_database));
+   if (database != NULL)
+   {
+      strncpy(flush_timeout_database, database, sizeof(flush_timeout_database) - 1);
+   }
+   else
+   {
+      strncpy(flush_timeout_database, "*", sizeof(flush_timeout_database) - 1);
+   }
+
+   flush_timeout_reason = reason;
+   start_periodic_watcher(&flush_timeout_watcher, &flush_timeout_started, flush_timeout_cb,
+                          (int)(1000 * (int64_t)seconds));
+
+   if (flush_timeout_started)
+   {
+      pgagroal_log_info("pgagroal: flush timeout armed (%ds, reason=%s, db=%s)",
+                        seconds,
+                        reason == FLUSH_TIMEOUT_REASON_SHUTDOWN ? "shutdown" : "flush",
+                        flush_timeout_database);
+   }
+   else
+   {
+      pgagroal_log_warn("pgagroal: failed to arm flush_timeout watcher");
+      flush_timeout_reason = FLUSH_TIMEOUT_REASON_NONE;
+   }
+}
+
+static void
+stop_flush_timeout_timer(void)
+{
+   if (!flush_timeout_started)
+   {
+      return;
+   }
+
+   stop_periodic_watcher(&flush_timeout_watcher, &flush_timeout_started);
+   flush_timeout_reason = FLUSH_TIMEOUT_REASON_NONE;
+   memset(flush_timeout_database, 0, sizeof(flush_timeout_database));
 }
 
 static void


### PR DESCRIPTION
## Summary

Adds a new `flush_timeout` configuration option and two new CLI commands:

- `flush timeout [SECONDS] [database]`
- `shutdown timeout [SECONDS]`

These commands perform graceful operations bounded by a timeout.

If the timeout expires:

- bounded flush escalates remaining graceful connections to `FLUSH_ALL`
- bounded shutdown escalates to immediate shutdown

`SECONDS` provided on the CLI overrides the configured `flush_timeout`.
If omitted, pgagroal uses the configured value.
If `flush_timeout = 0`, the operation remains unbounded.