### PR TITLE
[#926] Size port buffer for 5-digit ports in pgagroal_connect

### DIFF
--- a/src/libpgagroal/network.c
+++ b/src/libpgagroal/network.c
@@ -250,11 +250,11 @@ pgagroal_connect(const char* hostname, int port, int* fd, bool keep_alive, bool 
    int yes = 1;
    socklen_t optlen = sizeof(int);
    int rv;
-   char sport[5];
+   char sport[6];
    int error = 0;
 
    memset(&sport, 0, sizeof(sport));
-   sprintf(&sport[0], "%d", port);
+   pgagroal_snprintf(&sport[0], sizeof(sport), "%d", port);
 
    /* Connect to server */
    memset(&hints, 0, sizeof hints);


### PR DESCRIPTION
### What

`pgagroal_connect()` sized the backend port string as `char sport[5]`, one byte too small for a 5-digit port. `sprintf(sport, "%d", port)` writes six bytes (`"54318" + NUL`) for any port `>= 10000`, overflowing the stack buffer. Sized it to `char sport[6]`, matching the sibling resolver in the same file that already uses `calloc(1, 6)`.

Fixes #926.

### Why it matters

Any pgagroal pointing at a backend on a 5-digit port overflows on every connect. On `_FORTIFY_SOURCE` builds the abort is intercepted by the event-loop signal handler and the worker spins at 100% CPU instead of crashing, so no connection is established. The default port 5432 is four digits and fits, which is why CI (Postgres on 5432) never exercised it.

### Validation

- Before: a Debug build pointed at PostgreSQL 18 on port `54318` spins at 100% CPU in `pgagroal_connect` (confirmed by stack sample: `pgagroal_connect` -> `__sprintf_chk` -> `__chk_fail_overflow`); no client connection completes.
- After: the same client connects cleanly and the backend is established.
- `clang-format` clean; Debug build clean.

Note: `test/check.sh` runs its Postgres on a 4-digit port (`7432`), so the local suite does not exercise the 5-digit path; the fix was validated directly against a backend on a 5-digit port as above. CI runs the full suite on this PR.
