### PR TITLE
[#926] Size port buffer for 5-digit ports in pgagroal_connect

### DIFF
--- a/src/libpgagroal/network.c
+++ b/src/libpgagroal/network.c
@@ -250,11 +250,11 @@ pgagroal_connect(const char* hostname, int port, int* fd, bool keep_alive, bool 
    int yes = 1;
    socklen_t optlen = sizeof(int);
    int rv;
-   char sport[5];
+   char sport[6];
    int error = 0;
 
    memset(&sport, 0, sizeof(sport));
-   sprintf(&sport[0], "%d", port);
+   pgagroal_snprintf(&sport[0], sizeof(sport), "%d", port);
 
    /* Connect to server */
    memset(&hints, 0, sizeof hints);


### PR DESCRIPTION
Cross-port of #927 (master) to the 2.1.x maintenance branch.

`sport[5]` cannot hold a 5-digit port plus its NUL terminator, so a backend port in the 10000-65535 range overflows the stack buffer in `pgagroal_connect`. This widens the buffer to six bytes and replaces the unbounded `sprintf` with the bounded `pgagroal_snprintf`, matching the other formatted writes in this file.

Same two-line change as #927; the surrounding code is identical on this branch.

ref #926