### PR TITLE
[#834] Read complete SCRAM messages before parsing

### DIFF
--- a/src/include/message.h
+++ b/src/include/message.h
@@ -66,6 +66,21 @@ int
 pgagroal_read_block_message(SSL* ssl, int socket, struct message** msg);
 
 /**
+ * Read a complete typed message in blocking mode. The message must carry the
+ * standard header (1 byte kind + 4 byte length); the read continues until the
+ * number of bytes declared in the header has arrived, so a message split
+ * across multiple network segments is never returned partially. A message
+ * whose declared length is malformed (less than 4 bytes or larger than the
+ * parse buffer) is an error.
+ * @param ssl The SSL struct
+ * @param socket The socket descriptor
+ * @param msg The resulting message
+ * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
+ */
+int
+pgagroal_read_complete_message(SSL* ssl, int socket, struct message** msg);
+
+/**
  * Read a message with a timeout
  * @param ssl The SSL struct
  * @param socket The socket descriptor

--- a/src/libpgagroal/message.c
+++ b/src/libpgagroal/message.c
@@ -62,6 +62,105 @@ pgagroal_read_block_message(SSL* ssl, int socket, struct message** msg)
    return ssl_read_message(ssl, 0, msg);
 }
 
+static int
+read_append(SSL* ssl, int socket, struct message* m, size_t needed)
+{
+   ssize_t numbytes;
+
+   while ((size_t)m->length < needed)
+   {
+      if (ssl != NULL)
+      {
+         numbytes = SSL_read(ssl, m->data + m->length, MESSAGE_PARSE_BUFFER_SIZE - m->length);
+
+         if (numbytes <= 0)
+         {
+            int err = SSL_get_error(ssl, numbytes);
+            ERR_clear_error();
+
+            switch (err)
+            {
+               case SSL_ERROR_WANT_READ:
+               case SSL_ERROR_WANT_WRITE:
+                  continue;
+               case SSL_ERROR_ZERO_RETURN:
+                  return MESSAGE_STATUS_ZERO;
+               default:
+                  return MESSAGE_STATUS_ERROR;
+            }
+         }
+      }
+      else
+      {
+         numbytes = read(socket, m->data + m->length, MESSAGE_PARSE_BUFFER_SIZE - m->length);
+
+         if (numbytes == 0)
+         {
+            return MESSAGE_STATUS_ZERO;
+         }
+         else if (numbytes < 0)
+         {
+            if (errno == EAGAIN || errno == EWOULDBLOCK)
+            {
+               errno = 0;
+               continue;
+            }
+
+            pgagroal_log_error("read error: fd=%d errno=%d", socket, errno);
+            errno = 0;
+            return MESSAGE_STATUS_ERROR;
+         }
+      }
+
+      m->length += numbytes;
+   }
+
+   return MESSAGE_STATUS_OK;
+}
+
+int
+pgagroal_read_complete_message(SSL* ssl, int socket, struct message** msg)
+{
+   int status;
+   int32_t length;
+   size_t total;
+   struct message* m = NULL;
+
+   *msg = NULL;
+
+   status = pgagroal_read_block_message(ssl, socket, &m);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      return status;
+   }
+
+   /* kind (1 byte) + length (4 bytes, includes itself) */
+   status = read_append(ssl, socket, m, 5);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      return status;
+   }
+
+   length = pgagroal_read_int32(m->data + 1);
+   if (length < 4 || (size_t)length + 1 > MESSAGE_PARSE_BUFFER_SIZE)
+   {
+      pgagroal_log_error("Invalid message length: fd=%d kind=%c length=%d", socket, m->kind, length);
+      return MESSAGE_STATUS_ERROR;
+   }
+
+   total = (size_t)length + 1;
+
+   status = read_append(ssl, socket, m, total);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      return status;
+   }
+
+   *msg = m;
+
+   return MESSAGE_STATUS_OK;
+}
+
 int
 pgagroal_read_timeout_message(SSL* ssl, int socket, int timeout, struct message** msg)
 {

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -1004,7 +1004,7 @@ pgagroal_remote_management_scram_sha256(char* username, char* password, int serv
       goto error;
    }
 
-   status = pgagroal_read_block_message(ssl, server_fd, &msg);
+   status = pgagroal_read_complete_message(ssl, server_fd, &msg);
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;
@@ -1035,7 +1035,7 @@ pgagroal_remote_management_scram_sha256(char* username, char* password, int serv
       goto error;
    }
 
-   status = pgagroal_read_block_message(ssl, server_fd, &msg);
+   status = pgagroal_read_complete_message(ssl, server_fd, &msg);
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;
@@ -1047,12 +1047,23 @@ pgagroal_remote_management_scram_sha256(char* username, char* password, int serv
       goto error;
    }
 
+   /* 'R' + length + AuthenticationSASLContinue + payload */
+   if (sasl_continue->length <= 9)
+   {
+      goto error;
+   }
+
    get_scram_attribute('r', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &combined_nounce);
    get_scram_attribute('s', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &base64_salt);
    get_scram_attribute('i', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &iteration_string);
    get_scram_attribute('e', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &err);
 
    if (err != NULL)
+   {
+      goto error;
+   }
+
+   if (combined_nounce == NULL || base64_salt == NULL || iteration_string == NULL)
    {
       goto error;
    }
@@ -1093,13 +1104,19 @@ pgagroal_remote_management_scram_sha256(char* username, char* password, int serv
       goto error;
    }
 
-   status = pgagroal_read_block_message(ssl, server_fd, &msg);
+   status = pgagroal_read_complete_message(ssl, server_fd, &msg);
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;
    }
 
    if (pgagroal_extract_message('R', msg, &sasl_final))
+   {
+      goto error;
+   }
+
+   /* 'R' + length + AuthenticationSASLFinal + 'v' attribute */
+   if (sasl_final->length <= 11)
    {
       goto error;
    }
@@ -1900,11 +1917,23 @@ retry:
       goto error;
    }
 
+   /* 'p' + length + mechanism + "n,,n=,r=" + nounce */
+   if (msg->length <= 26)
+   {
+      goto error;
+   }
+
    client_first_message_bare = calloc(1, msg->length - 25);
 
    memcpy(client_first_message_bare, msg->data + 26, msg->length - 26);
 
    get_scram_attribute('r', (char*)msg->data + 26, msg->length - 26, &client_nounce);
+
+   if (client_nounce == NULL)
+   {
+      goto error;
+   }
+
    generate_nounce(&server_nounce);
    generate_salt(&salt, &salt_length);
    pgagroal_base64_encode(salt, salt_length, &base64_salt, &base64_salt_length);
@@ -1936,7 +1965,19 @@ retry:
       goto error;
    }
 
+   /* 'p' + length + "c=biws,r=" + nounces (57 bytes) + ",p=" + proof */
+   if (msg->length < 62)
+   {
+      goto error;
+   }
+
    get_scram_attribute('p', (char*)msg->data + 5, msg->length - 5, &base64_client_proof);
+
+   if (base64_client_proof == NULL)
+   {
+      goto error;
+   }
+
    pgagroal_base64_decode(base64_client_proof, strlen(base64_client_proof), (void**)&client_proof_received, &client_proof_received_length);
 
    client_final_message_without_proof = calloc(1, 58);
@@ -2591,7 +2632,12 @@ server_scram256(char* username, char* password, int slot, SSL* server_ssl)
       goto error;
    }
 
-   status = pgagroal_read_block_message(server_ssl, server_fd, &msg);
+   status = pgagroal_read_complete_message(server_ssl, server_fd, &msg);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      goto error;
+   }
+
    if (msg->length > SECURITY_BUFFER_SIZE)
    {
       pgagroal_log_message(msg);
@@ -2601,6 +2647,12 @@ server_scram256(char* username, char* password, int slot, SSL* server_ssl)
 
    sasl_continue = pgagroal_copy_message(msg);
    if (((char*)sasl_continue->data)[0] == 'E')
+   {
+      goto error;
+   }
+
+   /* 'R' + length + AuthenticationSASLContinue + payload */
+   if (sasl_continue->length <= 9)
    {
       goto error;
    }
@@ -2617,6 +2669,11 @@ server_scram256(char* username, char* password, int slot, SSL* server_ssl)
    if (err != NULL)
    {
       pgagroal_log_error("SCRAM-SHA-256: %s", err);
+      goto error;
+   }
+
+   if (combined_nounce == NULL || base64_salt == NULL || iteration_string == NULL)
+   {
       goto error;
    }
 
@@ -2660,7 +2717,12 @@ server_scram256(char* username, char* password, int slot, SSL* server_ssl)
       goto error;
    }
 
-   status = pgagroal_read_block_message(server_ssl, server_fd, &msg);
+   status = pgagroal_read_complete_message(server_ssl, server_fd, &msg);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      goto error;
+   }
+
    if (msg->length > SECURITY_BUFFER_SIZE)
    {
       pgagroal_log_message(msg);
@@ -2673,6 +2735,12 @@ server_scram256(char* username, char* password, int slot, SSL* server_ssl)
    auth_index++;
 
    if (pgagroal_extract_message('R', msg, &sasl_final))
+   {
+      goto error;
+   }
+
+   /* 'R' + length + AuthenticationSASLFinal + 'v' attribute */
+   if (sasl_final->length <= 11)
    {
       goto error;
    }
@@ -4774,7 +4842,7 @@ pgagroal_scram_client_auth(char* username, char* password, int socket, SSL* serv
       goto error;
    }
 
-   status = pgagroal_read_block_message(server_ssl, socket, &msg);
+   status = pgagroal_read_complete_message(server_ssl, socket, &msg);
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;
@@ -4793,6 +4861,12 @@ pgagroal_scram_client_auth(char* username, char* password, int socket, SSL* serv
       goto error;
    }
 
+   /* 'R' + length + AuthenticationSASLContinue + payload */
+   if (sasl_continue->length <= 9)
+   {
+      goto error;
+   }
+
    get_scram_attribute('r', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &combined_nounce);
    get_scram_attribute('s', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &base64_salt);
    get_scram_attribute('i', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &iteration_string);
@@ -4801,6 +4875,11 @@ pgagroal_scram_client_auth(char* username, char* password, int socket, SSL* serv
    if (err != NULL)
    {
       pgagroal_log_error("SCRAM-SHA-256: %s", err);
+      goto error;
+   }
+
+   if (combined_nounce == NULL || base64_salt == NULL || iteration_string == NULL)
+   {
       goto error;
    }
 
@@ -4840,7 +4919,7 @@ pgagroal_scram_client_auth(char* username, char* password, int socket, SSL* serv
       goto error;
    }
 
-   status = pgagroal_read_block_message(server_ssl, socket, &msg);
+   status = pgagroal_read_complete_message(server_ssl, socket, &msg);
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;
@@ -4864,6 +4943,12 @@ pgagroal_scram_client_auth(char* username, char* password, int socket, SSL* serv
    }
 
    if (pgagroal_extract_message('R', msg, &sasl_final))
+   {
+      goto error;
+   }
+
+   /* 'R' + length + AuthenticationSASLFinal + 'v' attribute */
+   if (sasl_final->length <= 11)
    {
       goto error;
    }
@@ -5145,10 +5230,23 @@ retry:
    }
 
    /* Start the flow */
+
+   /* 'p' + length + mechanism + "n,,n=,r=" + nounce */
+   if (msg->length <= 26)
+   {
+      goto error;
+   }
+
    client_first_message_bare = calloc(1, msg->length - 25);
    memcpy(client_first_message_bare, msg->data + 26, msg->length - 26);
 
    get_scram_attribute('r', (char*)msg->data + 26, msg->length - 26, &client_nounce);
+
+   if (client_nounce == NULL)
+   {
+      goto error;
+   }
+
    generate_nounce(&server_nounce);
 
    server_first_message = calloc(1, 89);
@@ -5172,7 +5270,19 @@ retry:
       goto error;
    }
 
+   /* 'p' + length + "c=biws,r=" + nounces (57 bytes) + ",p=" + proof */
+   if (msg->length < 62)
+   {
+      goto error;
+   }
+
    get_scram_attribute('p', (char*)msg->data + 5, msg->length - 5, &base64_client_proof);
+
+   if (base64_client_proof == NULL)
+   {
+      goto error;
+   }
+
    pgagroal_base64_decode(base64_client_proof, strlen(base64_client_proof), (void**)&client_proof_received, &client_proof_received_length);
 
    client_final_message_without_proof = calloc(1, 58);
@@ -5890,6 +6000,12 @@ pgagroal_scram_client_authenticate(char* username, char* password, int server_fd
    pgagroal_free_message(msg);
    msg = NULL;
 
+   /* 'R' + length + AuthenticationSASLContinue + payload */
+   if (sasl_continue->length <= 9)
+   {
+      goto error;
+   }
+
    get_scram_attribute('r', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &combined_nounce);
    get_scram_attribute('s', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &base64_salt);
    get_scram_attribute('i', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &iteration_string);
@@ -5898,6 +6014,11 @@ pgagroal_scram_client_authenticate(char* username, char* password, int server_fd
    if (err != NULL)
    {
       pgagroal_log_error("SCRAM-SHA-256: %s", err);
+      goto error;
+   }
+
+   if (combined_nounce == NULL || base64_salt == NULL || iteration_string == NULL)
+   {
       goto error;
    }
 
@@ -5943,26 +6064,34 @@ pgagroal_scram_client_authenticate(char* username, char* password, int server_fd
 
    if (pgagroal_extract_message('R', msg, &sasl_final))
    {
-      base64_server_signature = sasl_final->data + 11;
+      goto error;
+   }
 
-      pgagroal_base64_decode(base64_server_signature, sasl_final->length - 11,
-                             (void**)&server_signature_received, &server_signature_received_length);
+   /* 'R' + length + AuthenticationSASLFinal + 'v' attribute */
+   if (sasl_final->length <= 11)
+   {
+      goto error;
+   }
 
-      if (server_signature(password_prep, salt, salt_length, iteration,
-                           NULL, 0,
-                           client_first_message_bare, sasl_response->length - 26,
-                           server_first_message, sasl_continue->length - 9,
-                           &wo_proof[0], strlen(wo_proof),
-                           &server_signature_calc, &server_signature_calc_length))
-      {
-         goto error;
-      }
+   base64_server_signature = sasl_final->data + 11;
 
-      if (server_signature_calc_length != server_signature_received_length ||
-          memcmp(server_signature_received, server_signature_calc, server_signature_calc_length) != 0)
-      {
-         goto bad_password;
-      }
+   pgagroal_base64_decode(base64_server_signature, sasl_final->length - 11,
+                          (void**)&server_signature_received, &server_signature_received_length);
+
+   if (server_signature(password_prep, salt, salt_length, iteration,
+                        NULL, 0,
+                        client_first_message_bare, sasl_response->length - 26,
+                        server_first_message, sasl_continue->length - 9,
+                        &wo_proof[0], strlen(wo_proof),
+                        &server_signature_calc, &server_signature_calc_length))
+   {
+      goto error;
+   }
+
+   if (server_signature_calc_length != server_signature_received_length ||
+       memcmp(server_signature_received, server_signature_calc, server_signature_calc_length) != 0)
+   {
+      goto bad_password;
    }
 
    /* Cleanup */

--- a/test/testcases/test_message_complete.c
+++ b/test/testcases/test_message_complete.c
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) 2026 The pgagroal community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include <pgagroal.h>
+#include <message.h>
+#include <utils.h>
+#include <mctf.h>
+
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/*
+ * Regression tests for issue #834: an AuthenticationSASLContinue split across
+ * multiple network segments was parsed after the first read(), so
+ * sasl_continue->length - 9 underflowed (size_t) and crashed pgagroal-cli.
+ *
+ * pgagroal_read_complete_message() must keep reading until the byte count
+ * declared in the message header has arrived, and must reject a header whose
+ * declared length is malformed.
+ */
+
+/* AuthenticationSASLContinue: 'R' + int32 length + int32 11 + SCRAM payload */
+static ssize_t
+build_sasl_continue(char* buffer, size_t size)
+{
+   const char* payload = "r=clientnonceservernonce,s=c2FsdA==,i=4096";
+   size_t total = 1 + 4 + 4 + strlen(payload);
+
+   if (size < total)
+   {
+      return -1;
+   }
+
+   pgagroal_write_byte(buffer, 'R');
+   pgagroal_write_int32(buffer + 1, (int32_t)(total - 1));
+   pgagroal_write_int32(buffer + 5, 11);
+   memcpy(buffer + 9, payload, strlen(payload));
+
+   return (ssize_t)total;
+}
+
+/* Baseline: a message arriving in a single segment is returned as-is. */
+MCTF_TEST(test_complete_message_single_segment)
+{
+   int sv[2] = {-1, -1};
+   char buffer[128];
+   ssize_t total;
+   int status;
+   struct message* msg = NULL;
+
+   total = build_sasl_continue(buffer, sizeof(buffer));
+   MCTF_ASSERT(total > 0, cleanup, "failed to build test message");
+
+   MCTF_ASSERT_INT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0, cleanup, "socketpair failed");
+
+   MCTF_ASSERT(write(sv[1], buffer, total) == total, cleanup, "write failed");
+
+   status = pgagroal_read_complete_message(NULL, sv[0], &msg);
+
+   MCTF_ASSERT_INT_EQ(status, MESSAGE_STATUS_OK, cleanup, "single segment should succeed");
+   MCTF_ASSERT(msg != NULL, cleanup, "message should be returned");
+   MCTF_ASSERT(msg->kind == 'R', cleanup, "kind should be R");
+   MCTF_ASSERT_INT_EQ((int)msg->length, (int)total, cleanup, "length should match the declared length");
+
+cleanup:
+   if (sv[0] >= 0)
+   {
+      close(sv[0]);
+   }
+   if (sv[1] >= 0)
+   {
+      close(sv[1]);
+   }
+   MCTF_FINISH();
+}
+
+/* #834: a message split across segments must be assembled before parsing. */
+MCTF_TEST(test_complete_message_split_segments)
+{
+   int sv[2] = {-1, -1};
+   char buffer[128];
+   ssize_t total;
+   int status;
+   pid_t pid = -1;
+   struct message* msg = NULL;
+
+   total = build_sasl_continue(buffer, sizeof(buffer));
+   MCTF_ASSERT(total > 0, cleanup, "failed to build test message");
+
+   MCTF_ASSERT_INT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0, cleanup, "socketpair failed");
+
+   pid = fork();
+   MCTF_ASSERT(pid >= 0, cleanup, "fork failed");
+
+   if (pid == 0)
+   {
+      /* writer: 3 bytes (shorter than the 5 byte header), pause, 4 more
+       * bytes, pause, the rest -- forces partial reads on the reader */
+      close(sv[0]);
+      write(sv[1], buffer, 3);
+      usleep(50 * 1000);
+      write(sv[1], buffer + 3, 4);
+      usleep(50 * 1000);
+      write(sv[1], buffer + 7, total - 7);
+      close(sv[1]);
+      _exit(0);
+   }
+
+   close(sv[1]);
+   sv[1] = -1;
+
+   status = pgagroal_read_complete_message(NULL, sv[0], &msg);
+
+   MCTF_ASSERT_INT_EQ(status, MESSAGE_STATUS_OK, cleanup, "split message should be assembled");
+   MCTF_ASSERT(msg != NULL, cleanup, "message should be returned");
+   MCTF_ASSERT(msg->kind == 'R', cleanup, "kind should be R");
+   MCTF_ASSERT_INT_EQ((int)msg->length, (int)total, cleanup, "all declared bytes should have been read");
+
+cleanup:
+   if (pid > 0)
+   {
+      waitpid(pid, NULL, 0);
+   }
+   if (sv[0] >= 0)
+   {
+      close(sv[0]);
+   }
+   if (sv[1] >= 0)
+   {
+      close(sv[1]);
+   }
+   MCTF_FINISH();
+}
+
+/* A peer that disappears mid-message is an error, not a partial message. */
+MCTF_TEST(test_complete_message_truncated_by_close)
+{
+   int sv[2] = {-1, -1};
+   char buffer[128];
+   ssize_t total;
+   int status;
+   struct message* msg = NULL;
+
+   total = build_sasl_continue(buffer, sizeof(buffer));
+   MCTF_ASSERT(total > 0, cleanup, "failed to build test message");
+
+   MCTF_ASSERT_INT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0, cleanup, "socketpair failed");
+
+   /* half the message, then close */
+   MCTF_ASSERT(write(sv[1], buffer, total / 2) == total / 2, cleanup, "write failed");
+   close(sv[1]);
+   sv[1] = -1;
+
+   status = pgagroal_read_complete_message(NULL, sv[0], &msg);
+
+   MCTF_ASSERT(status != MESSAGE_STATUS_OK, cleanup, "truncated message must not be returned as complete");
+   MCTF_ASSERT(msg == NULL, cleanup, "no message should be returned");
+
+cleanup:
+   if (sv[0] >= 0)
+   {
+      close(sv[0]);
+   }
+   if (sv[1] >= 0)
+   {
+      close(sv[1]);
+   }
+   MCTF_FINISH();
+}
+
+/* A header whose declared length cannot be valid is rejected. */
+MCTF_TEST(test_complete_message_invalid_declared_length)
+{
+   int sv[2] = {-1, -1};
+   char buffer[8];
+   int status;
+   struct message* msg = NULL;
+
+   MCTF_ASSERT_INT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0, cleanup, "socketpair failed");
+
+   /* 'R' declaring a length of 3: less than the length field itself */
+   pgagroal_write_byte(buffer, 'R');
+   pgagroal_write_int32(buffer + 1, 3);
+
+   MCTF_ASSERT(write(sv[1], buffer, 5) == 5, cleanup, "write failed");
+
+   status = pgagroal_read_complete_message(NULL, sv[0], &msg);
+
+   MCTF_ASSERT_INT_EQ(status, MESSAGE_STATUS_ERROR, cleanup, "invalid declared length must be an error");
+   MCTF_ASSERT(msg == NULL, cleanup, "no message should be returned");
+
+cleanup:
+   if (sv[0] >= 0)
+   {
+      close(sv[0]);
+   }
+   if (sv[1] >= 0)
+   {
+      close(sv[1]);
+   }
+   MCTF_FINISH();
+}


### PR DESCRIPTION
## Problem

`pgagroal-cli` segfaults when a SCRAM message arrives split across network segments (#834). `read_message()` returns whatever a single `read()` yields, so the parser can see a partial `AuthenticationSASLContinue`; `sasl_continue->length - 9` then underflows (`size_t`) and the huge value reaches `get_scram_attribute()`, which crashes in `calloc()`/`memcpy()`. The same single-read assumption exists in every SCRAM exchange, and a message missing an expected attribute additionally leads to `strlen(NULL)`.

## Fix

Per the direction in the issue — keep loading until the message is complete, and bound-check before the offset arithmetic:

- New `pgagroal_read_complete_message()` in `message.c`: reads until the byte count declared in the message header (kind + int32 length) has arrived; a declared length below 4 bytes or beyond the parse buffer is rejected as an error.
- The SCRAM exchanges in `pgagroal_remote_management_scram_sha256()` (the reported path), `server_scram256()`, and the auth_query SCRAM flow now use it for the SASL continue/final reads.
- Every SCRAM parse site guards the message length before the `- 9` / `- 11` / `- 26` / `- 5` arithmetic and checks the extracted attributes for NULL, so a short or malformed message fails authentication cleanly instead of crashing. This includes the daemon-side parsing of client-supplied SCRAM messages.
- While there: `server_scram256()` did not check the read status before using the message, and the (currently unreferenced) `pgagroal_scram_client_authenticate()` ran its server-signature verification only when `pgagroal_extract_message()` failed — with a NULL `sasl_final`. Both aligned with the conventions used at the other sites.

## Tests

`test/testcases/test_message_complete.c` (MCTF, module `message_complete`) covers: a single-segment message, the #834 case of a message split across three segments with delays, a peer closing mid-message, and an invalid declared length. All four pass; the split-segment case fails without the new read behaviour.

`art` and `utf8` module failures observed locally are pre-existing on master (verified against a clean checkout) and unrelated.

close #834