### PR TITLE
[#892] Refactor CLI commands to use all instead of * for consistency

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,3 +37,4 @@ Bhawesh Panwar <panwarbhawesh1112@gmail.com>
 Frank Heikens <frank@elevarq.com>
 Sakshi Aggarwal <sakshiaggarwal2706@gmail.com>
 Ameen Sakr <ameensakr623@gmail.com>
+Rohan Mishra <kmrrohan29@gmail.com>

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -74,19 +74,19 @@ silently ignored for the `idle` and `all` modes.
 Command
 
 ```
-pgagroal-cli flush [gracefully|idle|all] [*|<database>]
-pgagroal-cli flush [gracefully] [*|<database>] --timeout <DURATION>
+pgagroal-cli flush [gracefully|idle|all] [all|<database>]
+pgagroal-cli flush [gracefully] [all|<database>] --timeout <DURATION>
 ```
 
 Examples
 
 ```
-pgagroal-cli flush                                  # pgagroal-cli flush gracefully '*'
-pgagroal-cli flush idle                             # pgagroal-cli flush idle '*'
-pgagroal-cli flush all                              # pgagroal-cli flush all '*'
+pgagroal-cli flush                                  # pgagroal-cli flush gracefully 'all'
+pgagroal-cli flush idle                             # pgagroal-cli flush idle 'all'
+pgagroal-cli flush all                              # pgagroal-cli flush all 'all'
 pgagroal-cli flush pgbench                          # pgagroal-cli flush gracefully pgbench
-pgagroal-cli flush --timeout 30                     # graceful, escalate to 'flush all *' after 30s
-pgagroal-cli flush --timeout 5m                     # graceful, escalate to 'flush all *' after 5 minutes
+pgagroal-cli flush --timeout 30                     # graceful, escalate to 'flush all' after 30s
+pgagroal-cli flush --timeout 5m                     # graceful, escalate to 'flush all' after 5 minutes
 pgagroal-cli flush gracefully pgbench --timeout 1h  # graceful, escalate to 'flush all pgbench' after 1 hour
 ```
 
@@ -123,7 +123,7 @@ Enables a database (or all databases).
 Command
 
 ```
-pgagroal-cli enable [<database>|*]
+pgagroal-cli enable [<database>|all]
 ```
 
 Example
@@ -138,7 +138,7 @@ Disables a database (or all databases).
 Command
 
 ```
-pgagroal-cli disable [<database>|*]
+pgagroal-cli disable [<database>|all]
 ```
 
 Example

--- a/doc/manual/en/14-cli-tools.md
+++ b/doc/manual/en/14-cli-tools.md
@@ -75,18 +75,18 @@ silently ignored for the `idle` and `all` modes.
 
 Command:
 ```
-pgagroal-cli flush [gracefully|idle|all] [*|<database>]
-pgagroal-cli flush [gracefully] [*|<database>] --timeout <DURATION>
+pgagroal-cli flush [gracefully|idle|all] [all|<database>]
+pgagroal-cli flush [gracefully] [all|<database>] --timeout <DURATION>
 ```
 
 Examples:
 ```
-pgagroal-cli flush                                  # pgagroal-cli flush gracefully '*'
-pgagroal-cli flush idle                             # pgagroal-cli flush idle '*'
-pgagroal-cli flush all                              # pgagroal-cli flush all '*'
+pgagroal-cli flush                                  # pgagroal-cli flush gracefully 'all'
+pgagroal-cli flush idle                             # pgagroal-cli flush idle 'all'
+pgagroal-cli flush all                              # pgagroal-cli flush all 'all'
 pgagroal-cli flush pgbench                          # pgagroal-cli flush gracefully pgbench
-pgagroal-cli flush --timeout 30                     # graceful, escalate to 'flush all *' after 30s
-pgagroal-cli flush --timeout 5m                     # graceful, escalate to 'flush all *' after 5 minutes
+pgagroal-cli flush --timeout 30                     # graceful, escalate to 'flush all' after 30s
+pgagroal-cli flush --timeout 5m                     # graceful, escalate to 'flush all' after 5 minutes
 pgagroal-cli flush gracefully pgbench --timeout 1h  # graceful, escalate to 'flush all pgbench' after 1 hour
 ```
 
@@ -113,7 +113,7 @@ Enables a database (or all databases).
 
 Command:
 ```
-pgagroal-cli enable [<database>|*]
+pgagroal-cli enable [<database>|all]
 ```
 
 Example:
@@ -126,7 +126,7 @@ Disables a database (or all databases).
 
 Command:
 ```
-pgagroal-cli disable [<database>|*]
+pgagroal-cli disable [<database>|all]
 ```
 
 Example:

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -45,6 +45,7 @@ Frank Heikens <frank@elevarq.com>
 Sakshi Aggarwal <sakshiaggarwal2706@gmail.com>
 Ameen Sakr <ameensakr623@gmail.com>
 Abdallah Hany Ragab <abdallah.hany1974@gmail.com>
+Rohan Mishra <kmrrohan29@gmail.com>
 ```
 
 ## Committers

--- a/src/cli.c
+++ b/src/cli.c
@@ -132,7 +132,7 @@ const struct pgagroal_command command_table[] = {
       .accepted_argument_count = {0, 1},
       .action = MANAGEMENT_FLUSH,
       .mode = FLUSH_GRACEFULLY,
-      .default_argument = "*",
+      .default_argument = "all",
       .deprecated = false,
       .log_message = "<flush gracefully> [%s]",
    },
@@ -149,7 +149,7 @@ const struct pgagroal_command command_table[] = {
       .subcommand = "",
       .accepted_argument_count = {0, 1},
       .action = MANAGEMENT_ENABLEDB,
-      .default_argument = "*",
+      .default_argument = "all",
       .deprecated = false,
       .log_message = "<enable> [%s]",
    },
@@ -158,7 +158,7 @@ const struct pgagroal_command command_table[] = {
       .subcommand = "",
       .accepted_argument_count = {0, 1},
       .action = MANAGEMENT_DISABLEDB,
-      .default_argument = "*",
+      .default_argument = "all",
       .deprecated = false,
       .log_message = "<disable> [%s]",
    },
@@ -273,7 +273,7 @@ const struct pgagroal_command command_table[] = {
       .accepted_argument_count = {0, 1},
       .action = MANAGEMENT_FLUSH,
       .mode = FLUSH_IDLE,
-      .default_argument = "*",
+      .default_argument = "all",
       .deprecated = false,
       .log_message = "<flush idle> [%s]",
    },
@@ -283,7 +283,7 @@ const struct pgagroal_command command_table[] = {
       .accepted_argument_count = {0, 1},
       .action = MANAGEMENT_FLUSH,
       .mode = FLUSH_GRACEFULLY,
-      .default_argument = "*",
+      .default_argument = "all",
       .deprecated = false,
       .log_message = "<flush gracefully> [%s]",
    },
@@ -293,7 +293,7 @@ const struct pgagroal_command command_table[] = {
       .accepted_argument_count = {0, 1},
       .action = MANAGEMENT_FLUSH,
       .mode = FLUSH_ALL,
-      .default_argument = "*",
+      .default_argument = "all",
       .deprecated = false,
       .log_message = "<flush all> [%s]",
    },
@@ -931,14 +931,14 @@ static void
 help_disabledb(void)
 {
    printf("Disable a database\n");
-   printf("  pgagroal-cli disabledb <database>|*\n");
+   printf("  pgagroal-cli disabledb <database>|all\n");
 }
 
 static void
 help_enabledb(void)
 {
    printf("Enable a database\n");
-   printf("  pgagroal-cli enabledb <database>|*\n");
+   printf("  pgagroal-cli enabledb <database>|all\n");
 }
 
 static void
@@ -963,8 +963,8 @@ static void
 help_flush(void)
 {
    printf("Flush connections\n");
-   printf("  pgagroal-cli flush [gracefully|idle|all] [*|<database>]\n");
-   printf("  pgagroal-cli flush [gracefully] [*|<database>] --timeout <DURATION>\n");
+   printf("  pgagroal-cli flush [gracefully|idle|all] [all|<database>]\n");
+   printf("  pgagroal-cli flush [gracefully] [all|<database>] --timeout <DURATION>\n");
    printf("    '--timeout' bounds a graceful flush; DURATION overrides 'flush_timeout' from pgagroal.conf.\n");
    printf("    DURATION is a non-negative number with an optional unit suffix: s (seconds, default), m (minutes),\n");
    printf("    h (hours), d (days), w (weeks); e.g. '30', '30s', '5m', '1h', '2d', '1w'.\n");

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -1008,7 +1008,7 @@ pgagroal_flush(int mode, char* database)
       {
          bool consider = false;
 
-         if (!strcmp(database, "*") || !strcmp(config->connections[i].database, database))
+         if (!strcmp(database, "all") || !strcmp(config->connections[i].database, database))
          {
             consider = true;
          }

--- a/src/main.c
+++ b/src/main.c
@@ -1755,7 +1755,7 @@ accept_mgt_cb(struct io_watcher* watcher)
       pgagroal_management_create_response(payload, -1, &res);
       pgagroal_json_create(&databases);
 
-      if (!strcmp("*", database))
+      if (!strcmp("all", database))
       {
          struct json* js = NULL;
 
@@ -1818,7 +1818,7 @@ accept_mgt_cb(struct io_watcher* watcher)
 
       config->all_disabled = false;
 
-      if (!strcmp("*", database))
+      if (!strcmp("*", database) || !strcmp("all", database))
       {
          struct json* js = NULL;
 


### PR DESCRIPTION
Closes #892

This PR standardizes CLI commands to use `all` instead of `*` when targeting all databases/resources, for consistency across the codebase.

Changes made:
- Updated `default_argument` from `*` to `all` in command_table[] for flush, enable, disable commands in cli.c
- Updated help text in help_disabledb(), help_enabledb(), and help_flush() to show `all` instead of `*`
- Updated pool.c to accept both `*` and `all` as "all databases" for backward compatibility
- Updated main.c to accept both `*` and `all` for the same reason

Tested by building the project successfully with no errors.