### PR TITLE
Integrate TLS wrapper into connection path

### DIFF
--- a/src/include/security.h
+++ b/src/include/security.h
@@ -149,28 +149,6 @@ int
 accept_ssl_vault(struct vault_configuration* config, int client_fd, SSL** c_ssl);
 
 /**
- * Create a SSL context
- * @param client True if client, false if server
- * @param ctx The SSL context
- * @return 0 upon success, otherwise 1
- */
-int
-pgagroal_create_ssl_ctx(bool client, SSL_CTX** ctx);
-
-/**
- * Create a SSL server
- * @param ctx The SSL context
- * @param key_file The key file path
- * @param cert_file The certificate file path
- * @param ca_file The ca file path
- * @param socket The socket
- * @param ssl The SSL structure
- * @return 0 upon success, otherwise 1
- */
-int
-pgagroal_create_ssl_server(SSL_CTX* ctx, char* key_file, char* cert_file, char* ca_file, int socket, SSL** ssl);
-
-/**
  * Close a SSL structure
  * @param ssl The SSL structure
  */

--- a/src/include/tls.h
+++ b/src/include/tls.h
@@ -43,7 +43,7 @@ extern "C" {
 #define PGAGROAL_TLS_CLOSED  2
 #define PGAGROAL_TLS_ERROR   (-1)
 
-/**
+/** @struct tls
  * A TLS context driven through memory BIOs instead of a socket, so the
  * cryptographic state is independent of the TCP connection lifecycle.
  * Ciphertext moves via feed()/drain(); plaintext via write()/read().
@@ -53,6 +53,7 @@ struct tls
    SSL* ssl;                /**< The OpenSSL connection */
    BIO* rbio;               /**< Inbound ciphertext: network -> engine */
    BIO* wbio;               /**< Outbound ciphertext: engine -> network */
+   int fd;                  /**< The socket bound to this context, or -1 if none */
    bool server;             /**< true for the accepting side */
    bool handshake_complete; /**< true once the handshake has completed */
 };
@@ -137,6 +138,127 @@ pgagroal_tls_write(struct tls* tls, const void* buf, size_t len, size_t* written
  */
 int
 pgagroal_tls_read(struct tls* tls, void* buf, size_t cap, size_t* nread);
+
+/**
+ * Associate a socket descriptor with the context so transparent I/O routing
+ * can recover it from the SSL object
+ * @param tls The context
+ * @param fd The socket descriptor
+ */
+void
+pgagroal_tls_set_fd(struct tls* tls, int fd);
+
+/**
+ * Recover the wrapper that owns an SSL object, if any
+ * @param ssl The OpenSSL connection
+ * @return The owning context, or NULL if ssl is not driven by a wrapper
+ */
+struct tls*
+pgagroal_tls_from_ssl(SSL* ssl);
+
+/**
+ * Drive a handshake to completion over a blocking socket, pumping ciphertext
+ * between the engine and the descriptor
+ * @param tls The context
+ * @param fd The connected socket descriptor
+ * @return PGAGROAL_TLS_OK when the handshake completes, otherwise PGAGROAL_TLS_ERROR
+ */
+int
+pgagroal_tls_socket_handshake(struct tls* tls, int fd);
+
+/**
+ * Read decrypted application data over a blocking socket, pumping ciphertext as needed
+ * @param tls The context
+ * @param fd The connected socket descriptor
+ * @param buf The destination buffer
+ * @param cap The buffer capacity
+ * @param nread The number of plaintext bytes produced
+ * @return PGAGROAL_TLS_OK on success, PGAGROAL_TLS_CLOSED on a clean peer
+ *         shutdown, otherwise PGAGROAL_TLS_ERROR
+ */
+int
+pgagroal_tls_socket_read(struct tls* tls, int fd, void* buf, size_t cap, size_t* nread);
+
+/**
+ * Write application data over a blocking socket, draining the resulting ciphertext
+ * @param tls The context
+ * @param fd The connected socket descriptor
+ * @param buf The plaintext
+ * @param len The number of bytes
+ * @return PGAGROAL_TLS_OK on success, otherwise PGAGROAL_TLS_ERROR
+ */
+int
+pgagroal_tls_socket_write(struct tls* tls, int fd, const void* buf, size_t len);
+
+/**
+ * Configure a server-role context with its certificate, private key and optional CA
+ * @param ctx The OpenSSL context
+ * @param key_file The private key file
+ * @param cert_file The certificate file
+ * @param ca_file The CA file, or an empty string for none
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgagroal_tls_configure_server_ctx(SSL_CTX* ctx, char* key_file, char* cert_file, char* ca_file);
+
+/**
+ * Create a socket-decoupled server-role context from configuration files
+ * @param ctx The OpenSSL context
+ * @param key_file The private key file
+ * @param cert_file The certificate file
+ * @param ca_file The CA file, or an empty string for none
+ * @param tls The resulting context
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgagroal_tls_create_server(SSL_CTX* ctx, char* key_file, char* cert_file, char* ca_file, struct tls** tls);
+
+/**
+ * Create a socket-decoupled client-role context from configuration files
+ * @param ctx The OpenSSL context
+ * @param key The private key file
+ * @param cert The certificate file
+ * @param root The root certificate file, or an empty string for none
+ * @param tls The resulting context
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgagroal_tls_create_client(SSL_CTX* ctx, char* key, char* cert, char* root, struct tls** tls);
+
+/**
+ * Create a SSL context
+ * @param client True if client, false if server
+ * @param ctx The SSL context
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgagroal_create_ssl_ctx(bool client, SSL_CTX** ctx);
+
+/**
+ * Create a SSL server
+ * @param ctx The SSL context
+ * @param key_file The key file path
+ * @param cert_file The certificate file path
+ * @param ca_file The ca file path
+ * @param socket The socket
+ * @param ssl The SSL structure
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgagroal_create_ssl_server(SSL_CTX* ctx, char* key_file, char* cert_file, char* ca_file, int socket, SSL** ssl);
+
+/**
+ * Create a SSL client
+ * @param ctx The SSL context
+ * @param key The key file path
+ * @param cert The certificate file path
+ * @param root The root file path
+ * @param socket The socket
+ * @param ssl The SSL structure
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgagroal_create_ssl_client(SSL_CTX* ctx, char* key, char* cert, char* root, int socket, SSL** ssl);
 
 #ifdef __cplusplus
 }

--- a/src/libpgagroal/message.c
+++ b/src/libpgagroal/message.c
@@ -34,6 +34,7 @@
 #include <message.h>
 #include <network.h>
 #include <shmem.h>
+#include <tls.h>
 #include <utils.h>
 #include <worker.h>
 
@@ -1503,8 +1504,47 @@ ssl_read_message(SSL* ssl, int timeout, struct message** msg)
    ssize_t numbytes;
    time_t start_time;
    struct message* m = NULL;
+   struct tls* t = pgagroal_tls_from_ssl(ssl);
 
    pgagroal_memory_init();
+
+   /* Socket-decoupled wrapper: pump ciphertext via the socket shim. */
+   if (t != NULL)
+   {
+      struct timeval tv;
+      size_t nread = 0;
+      int rc;
+
+      if (unlikely(timeout > 0))
+      {
+         tv.tv_sec = timeout;
+         tv.tv_usec = 0;
+         setsockopt(t->fd, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv, sizeof(tv));
+      }
+
+      m = pgagroal_memory_message();
+      rc = pgagroal_tls_socket_read(t, t->fd, m->data, MESSAGE_PARSE_BUFFER_SIZE, &nread);
+
+      if (unlikely(timeout > 0))
+      {
+         tv.tv_sec = 0;
+         tv.tv_usec = 0;
+         setsockopt(t->fd, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv, sizeof(tv));
+      }
+
+      if (rc == PGAGROAL_TLS_OK && nread > 0)
+      {
+         m->kind = (signed char)(*((char*)m->data));
+         m->length = (ssize_t)nread;
+         *msg = m;
+         return MESSAGE_STATUS_OK;
+      }
+      if (rc == PGAGROAL_TLS_CLOSED)
+      {
+         return MESSAGE_STATUS_ZERO;
+      }
+      return MESSAGE_STATUS_ERROR;
+   }
 
    if (unlikely(timeout > 0))
    {
@@ -1584,10 +1624,21 @@ ssl_write_message(SSL* ssl, struct message* msg)
    int offset;
    ssize_t totalbytes;
    ssize_t remaining;
+   struct tls* t = pgagroal_tls_from_ssl(ssl);
 
 #ifdef DEBUG
    assert(msg != NULL);
 #endif
+
+   /* Socket-decoupled wrapper: encrypt and drain via the socket shim. */
+   if (t != NULL)
+   {
+      if (pgagroal_tls_socket_write(t, t->fd, msg->data, (size_t)msg->length) == PGAGROAL_TLS_OK)
+      {
+         return MESSAGE_STATUS_OK;
+      }
+      return MESSAGE_STATUS_ERROR;
+   }
 
    numbytes = 0;
    offset = 0;

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -38,6 +38,7 @@
 #include <prometheus.h>
 #include <security.h>
 #include <server.h>
+#include <tls.h>
 #include <tracker.h>
 #include <utils.h>
 #include <configuration.h>
@@ -682,14 +683,26 @@ pgagroal_kill_connection(int slot, SSL* ssl)
 
       if (ssl != NULL)
       {
+         struct tls* t = pgagroal_tls_from_ssl(ssl);
+
          ctx = SSL_get_SSL_CTX(ssl);
-         ssl_shutdown = SSL_shutdown(ssl);
-         if (ssl_shutdown == 0)
+
+         if (t != NULL)
          {
-            SSL_shutdown(ssl);
+            /* Socket-decoupled wrapper owns the SSL and its BIOs */
+            pgagroal_tls_free(t);
+            SSL_CTX_free(ctx);
          }
-         SSL_free(ssl);
-         SSL_CTX_free(ctx);
+         else
+         {
+            ssl_shutdown = SSL_shutdown(ssl);
+            if (ssl_shutdown == 0)
+            {
+               SSL_shutdown(ssl);
+            }
+            SSL_free(ssl);
+            SSL_CTX_free(ctx);
+         }
       }
 
       if (!pgagroal_socket_has_error(fd))

--- a/src/libpgagroal/prometheus_client.c
+++ b/src/libpgagroal/prometheus_client.c
@@ -33,6 +33,7 @@
 #include <network.h>
 #include <prometheus_client.h>
 #include <security.h>
+#include <tls.h>
 #include <utils.h>
 #include <value.h>
 

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -37,6 +37,7 @@
 #include <prometheus.h>
 #include <security.h>
 #include <server.h>
+#include <tls.h>
 #include <tracker.h>
 #include <utils.h>
 #include <utf8.h>
@@ -134,7 +135,6 @@ static int server_signature(char* password, char* salt, int salt_length, int ite
                             unsigned char** result, size_t* result_length);
 
 static bool is_tls_user(char* username, char* database);
-static int create_ssl_client(SSL_CTX* ctx, char* key, char* cert, char* root, int socket, SSL** ssl);
 static int establish_client_tls_connection(int server, int fd, SSL** ssl);
 static int create_client_tls_connection(int fd, SSL** ssl, char* tls_key_file, char* tls_cert_file, char* tls_ca_file);
 
@@ -258,7 +258,9 @@ pgagroal_authenticate(int client_fd, char* address, int* slot, SSL** client_ssl,
             goto error;
          }
 
-         if (pgagroal_create_ssl_server(ctx, config->common.tls_key_file, config->common.tls_cert_file, config->common.tls_ca_file, client_fd, &c_ssl))
+         struct tls* c_tls = NULL;
+
+         if (pgagroal_tls_create_server(ctx, config->common.tls_key_file, config->common.tls_cert_file, config->common.tls_ca_file, &c_tls))
          {
             pgagroal_log_debug("authenticate: connection error");
             pgagroal_write_connection_refused(NULL, client_fd);
@@ -266,6 +268,8 @@ pgagroal_authenticate(int client_fd, char* address, int* slot, SSL** client_ssl,
             goto error;
          }
 
+         pgagroal_tls_set_fd(c_tls, client_fd);
+         c_ssl = c_tls->ssl;
          *client_ssl = c_ssl;
 
          /* Switch to TLS mode */
@@ -276,8 +280,8 @@ pgagroal_authenticate(int client_fd, char* address, int* slot, SSL** client_ssl,
          }
          pgagroal_clear_message(msg);
 
-         status = SSL_accept(c_ssl);
-         if (status != 1)
+         /* Drive the handshake through the socket shim (memory BIOs) */
+         if (pgagroal_tls_socket_handshake(c_tls, client_fd) != PGAGROAL_TLS_OK)
          {
             unsigned long err;
 
@@ -943,7 +947,7 @@ pgagroal_remote_management_scram_sha256(char* username, char* password, int serv
                      memset(&root_file, 0, sizeof(root_file));
                   }
 
-                  if (create_ssl_client(ctx, &key_file[0], &cert_file[0], &root_file[0], server_fd, &ssl))
+                  if (pgagroal_create_ssl_client(ctx, &key_file[0], &cert_file[0], &root_file[0], server_fd, &ssl))
                   {
                      goto error;
                   }
@@ -4325,244 +4329,6 @@ is_tls_user(char* username, char* database)
    return false;
 }
 
-int
-pgagroal_create_ssl_ctx(bool client, SSL_CTX** ctx)
-{
-   SSL_CTX* c = NULL;
-
-   if (client)
-   {
-      c = SSL_CTX_new(TLS_client_method());
-   }
-   else
-   {
-      c = SSL_CTX_new(TLS_server_method());
-   }
-
-   if (c == NULL)
-   {
-      goto error;
-   }
-
-   if (SSL_CTX_set_min_proto_version(c, TLS1_2_VERSION) == 0)
-   {
-      goto error;
-   }
-
-   SSL_CTX_set_mode(c, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
-   SSL_CTX_set_options(c, SSL_OP_NO_TICKET);
-   SSL_CTX_set_session_cache_mode(c, SSL_SESS_CACHE_CLIENT | SSL_SESS_CACHE_NO_INTERNAL_STORE);
-
-   *ctx = c;
-
-   return 0;
-
-error:
-
-   if (c != NULL)
-   {
-      SSL_CTX_free(c);
-   }
-
-   return 1;
-}
-
-static int
-create_ssl_client(SSL_CTX* ctx, char* key, char* cert, char* root, int socket, SSL** ssl)
-{
-   SSL* s = NULL;
-   bool have_cert = false;
-   bool have_rootcert = false;
-
-   if (root != NULL && strlen(root) > 0)
-   {
-      if (SSL_CTX_load_verify_locations(ctx, root, NULL) != 1)
-      {
-         unsigned long err;
-
-         err = ERR_get_error();
-         pgagroal_log_error("Couldn't load TLS CA: %s", root);
-         pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
-         goto error;
-      }
-
-      have_rootcert = true;
-   }
-
-   if (cert != NULL && strlen(cert) > 0)
-   {
-      if (SSL_CTX_use_certificate_chain_file(ctx, cert) != 1)
-      {
-         unsigned long err;
-
-         err = ERR_get_error();
-         pgagroal_log_error("Couldn't load TLS certificate: %s", cert);
-         pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
-         goto error;
-      }
-
-      have_cert = true;
-   }
-
-   s = SSL_new(ctx);
-
-   if (s == NULL)
-   {
-      goto error;
-   }
-
-   if (SSL_set_fd(s, socket) == 0)
-   {
-      goto error;
-   }
-
-   if (have_cert && key != NULL && strlen(key) > 0)
-   {
-      if (SSL_use_PrivateKey_file(s, key, SSL_FILETYPE_PEM) != 1)
-      {
-         unsigned long err;
-
-         err = ERR_get_error();
-         pgagroal_log_error("Couldn't load TLS private key: %s", key);
-         pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
-         goto error;
-      }
-
-      if (SSL_check_private_key(s) != 1)
-      {
-         unsigned long err;
-
-         err = ERR_get_error();
-         pgagroal_log_error("TLS private key check failed: %s", key);
-         pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
-         goto error;
-      }
-   }
-
-   if (have_rootcert)
-   {
-      SSL_set_verify(s, SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE, NULL);
-   }
-
-   *ssl = s;
-
-   return 0;
-
-error:
-
-   if (s != NULL)
-   {
-      SSL_shutdown(s);
-      SSL_free(s);
-   }
-   SSL_CTX_free(ctx);
-
-   return 1;
-}
-
-int
-pgagroal_create_ssl_server(SSL_CTX* ctx, char* key_file, char* cert_file, char* ca_file, int socket, SSL** ssl)
-{
-   SSL* s = NULL;
-   STACK_OF(X509_NAME)* root_cert_list = NULL;
-
-   if (strlen(cert_file) == 0)
-   {
-      pgagroal_log_error("No TLS certificate defined");
-      goto error;
-   }
-
-   if (strlen(key_file) == 0)
-   {
-      pgagroal_log_error("No TLS private key defined");
-      goto error;
-   }
-
-   if (SSL_CTX_use_certificate_chain_file(ctx, cert_file) != 1)
-   {
-      unsigned long err;
-
-      err = ERR_get_error();
-      pgagroal_log_error("Couldn't load TLS certificate: %s", cert_file);
-      pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
-      goto error;
-   }
-
-   if (SSL_CTX_use_PrivateKey_file(ctx, key_file, SSL_FILETYPE_PEM) != 1)
-   {
-      unsigned long err;
-
-      err = ERR_get_error();
-      pgagroal_log_error("Couldn't load TLS private key: %s", key_file);
-      pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
-      goto error;
-   }
-
-   if (SSL_CTX_check_private_key(ctx) != 1)
-   {
-      unsigned long err;
-
-      err = ERR_get_error();
-      pgagroal_log_error("TLS private key check failed: %s", key_file);
-      pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
-      goto error;
-   }
-
-   if (strlen(ca_file) > 0)
-   {
-      if (SSL_CTX_load_verify_locations(ctx, ca_file, NULL) != 1)
-      {
-         unsigned long err;
-
-         err = ERR_get_error();
-         pgagroal_log_error("Couldn't load TLS CA: %s", ca_file);
-         pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
-         goto error;
-      }
-
-      root_cert_list = SSL_load_client_CA_file(ca_file);
-      if (root_cert_list == NULL)
-      {
-         unsigned long err;
-
-         err = ERR_get_error();
-         pgagroal_log_error("Couldn't load TLS CA: %s", ca_file);
-         pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
-         goto error;
-      }
-
-      SSL_CTX_set_verify(ctx, (SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT | SSL_VERIFY_CLIENT_ONCE), NULL);
-      SSL_CTX_set_client_CA_list(ctx, root_cert_list);
-   }
-
-   s = SSL_new(ctx);
-
-   if (s == NULL)
-   {
-      goto error;
-   }
-
-   if (SSL_set_fd(s, socket) == 0)
-   {
-      goto error;
-   }
-
-   *ssl = s;
-
-   return 0;
-
-error:
-
-   if (s != NULL)
-   {
-      SSL_shutdown(s);
-      SSL_free(s);
-   }
-   SSL_CTX_free(ctx);
-
-   return 1;
-}
-
 static int
 auth_query(SSL* c_ssl, int client_fd, int slot, char* username, char* database, int hba_method __attribute__((unused)))
 {
@@ -5514,8 +5280,7 @@ static int
 create_client_tls_connection(int fd, SSL** ssl, char* tls_key_file, char* tls_cert_file, char* tls_ca_file)
 {
    SSL_CTX* ctx = NULL;
-   SSL* s = NULL;
-   int status = -1;
+   struct tls* t = NULL;
 
    /* We are acting as a client against the server */
    if (pgagroal_create_ssl_ctx(true, &ctx))
@@ -5524,63 +5289,42 @@ create_client_tls_connection(int fd, SSL** ssl, char* tls_key_file, char* tls_ce
       goto error;
    }
 
-   /* Create SSL structure */
-   if (create_ssl_client(ctx, tls_key_file, tls_cert_file, tls_ca_file, fd, &s))
+   /* Create a socket-decoupled client context */
+   if (pgagroal_tls_create_client(ctx, tls_key_file, tls_cert_file, tls_ca_file, &t))
    {
       pgagroal_log_error("Client failed");
+      ctx = NULL; /* pgagroal_tls_create_client already released the context */
       goto error;
    }
 
-   do
+   pgagroal_tls_set_fd(t, fd);
+
+   /* Drive the backend handshake through the socket shim (memory BIOs) */
+   if (pgagroal_tls_socket_handshake(t, fd) != PGAGROAL_TLS_OK)
    {
-      status = SSL_connect(s);
+      unsigned long err;
 
-      if (status != 1)
-      {
-         int err = SSL_get_error(s, status);
-         switch (err)
-         {
-            case SSL_ERROR_ZERO_RETURN:
-            case SSL_ERROR_WANT_READ:
-            case SSL_ERROR_WANT_WRITE:
-            case SSL_ERROR_WANT_CONNECT:
-            case SSL_ERROR_WANT_ACCEPT:
-            case SSL_ERROR_WANT_X509_LOOKUP:
-#ifndef HAVE_OPENBSD
-            case SSL_ERROR_WANT_ASYNC:
-            case SSL_ERROR_WANT_ASYNC_JOB:
-            case SSL_ERROR_WANT_CLIENT_HELLO_CB:
-#endif
-               break;
-            case SSL_ERROR_SYSCALL:
-               pgagroal_log_error("SSL_ERROR_SYSCALL: FD %d", fd);
-               pgagroal_log_error("%s", ERR_error_string(err, NULL));
-               pgagroal_log_error("%s", ERR_lib_error_string(err));
-               pgagroal_log_error("%s", ERR_reason_error_string(err));
-               errno = 0;
-               goto error;
-               break;
-            case SSL_ERROR_SSL:
-               pgagroal_log_error("SSL_ERROR_SSL: FD %d", fd);
-               pgagroal_log_error("%s", ERR_error_string(err, NULL));
-               pgagroal_log_error("%s", ERR_lib_error_string(err));
-               pgagroal_log_error("%s", ERR_reason_error_string(err));
-               errno = 0;
-               goto error;
-               break;
-         }
-         ERR_clear_error();
-      }
+      err = ERR_get_error();
+      pgagroal_log_error("Backend TLS handshake failed on FD %d: %s", fd, ERR_reason_error_string(err));
+      goto error;
    }
-   while (status != 1);
 
-   *ssl = s;
+   *ssl = t->ssl;
 
    return AUTH_SUCCESS;
 
 error:
 
-   *ssl = s;
+   if (t != NULL)
+   {
+      /* Frees the wrapper, its SSL/BIOs, and the SSL_CTX */
+      pgagroal_close_ssl(t->ssl);
+   }
+   else if (ctx != NULL)
+   {
+      SSL_CTX_free(ctx);
+   }
+   *ssl = NULL;
 
    return AUTH_ERROR;
 }
@@ -5679,10 +5423,21 @@ pgagroal_close_ssl(SSL* ssl)
 {
    int res;
    SSL_CTX* ctx;
+   struct tls* t;
 
    if (ssl != NULL)
    {
       ctx = SSL_get_SSL_CTX(ssl);
+
+      /* Socket-decoupled wrapper owns the SSL and its BIOs */
+      t = pgagroal_tls_from_ssl(ssl);
+      if (t != NULL)
+      {
+         pgagroal_tls_free(t);
+         SSL_CTX_free(ctx);
+         return;
+      }
+
       res = SSL_shutdown(ssl);
       if (res == 0)
       {

--- a/src/libpgagroal/tls.c
+++ b/src/libpgagroal/tls.c
@@ -26,12 +26,19 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <pgagroal.h>
 #include <tls.h>
+#include <logging.h>
 
+#include <errno.h>
 #include <stddef.h>
 #include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
 #include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/x509.h>
 
 static int
 classify(SSL* ssl, int rc)
@@ -70,6 +77,7 @@ pgagroal_tls_create(SSL_CTX* ctx, bool server, struct tls** tls)
 
    t->server = server;
    t->handshake_complete = false;
+   t->fd = -1;
 
    t->ssl = SSL_new(ctx);
    if (t->ssl == NULL)
@@ -90,6 +98,9 @@ pgagroal_tls_create(SSL_CTX* ctx, bool server, struct tls** tls)
 
    /* The SSL object takes ownership of both BIOs */
    SSL_set_bio(t->ssl, t->rbio, t->wbio);
+
+   /* Back-pointer so the I/O layer can recover the wrapper from the SSL object */
+   SSL_set_app_data(t->ssl, t);
 
    if (server)
    {
@@ -142,6 +153,23 @@ pgagroal_tls_free(struct tls* tls)
    }
 
    free(tls);
+}
+
+void
+pgagroal_tls_set_fd(struct tls* tls, int fd)
+{
+   tls->fd = fd;
+}
+
+struct tls*
+pgagroal_tls_from_ssl(SSL* ssl)
+{
+   if (ssl == NULL)
+   {
+      return NULL;
+   }
+
+   return (struct tls*)SSL_get_app_data(ssl);
 }
 
 int
@@ -317,4 +345,543 @@ pgagroal_tls_read(struct tls* tls, void* buf, size_t cap, size_t* nread)
    }
 
    return classify(tls->ssl, rc);
+}
+
+static int
+socket_write_all(int fd, const unsigned char* buf, size_t len)
+{
+   size_t off = 0;
+
+   while (off < len)
+   {
+      ssize_t n = write(fd, buf + off, len - off);
+      if (n > 0)
+      {
+         off += (size_t)n;
+      }
+      else if (n < 0 && errno == EINTR)
+      {
+         continue;
+      }
+      else
+      {
+         return PGAGROAL_TLS_ERROR;
+      }
+   }
+
+   return PGAGROAL_TLS_OK;
+}
+
+/* Drain all pending outbound ciphertext to the socket. */
+static int
+socket_flush(struct tls* tls, int fd)
+{
+   unsigned char buf[16384];
+   size_t produced = 0;
+
+   while (pgagroal_tls_drain(tls, buf, sizeof(buf), &produced) == PGAGROAL_TLS_OK && produced > 0)
+   {
+      if (socket_write_all(fd, buf, produced) != PGAGROAL_TLS_OK)
+      {
+         return PGAGROAL_TLS_ERROR;
+      }
+   }
+
+   return PGAGROAL_TLS_OK;
+}
+
+/* Read one chunk of ciphertext from the socket and feed it to the engine. */
+static int
+socket_fill(struct tls* tls, int fd)
+{
+   unsigned char buf[16384];
+   ssize_t n;
+
+   do
+   {
+      n = read(fd, buf, sizeof(buf));
+   }
+   while (n < 0 && errno == EINTR);
+
+   if (n <= 0)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   return pgagroal_tls_feed(tls, buf, (size_t)n, NULL);
+}
+
+int
+pgagroal_tls_socket_handshake(struct tls* tls, int fd)
+{
+   if (tls == NULL || fd < 0)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   for (;;)
+   {
+      int rc = pgagroal_tls_handshake(tls);
+
+      if (socket_flush(tls, fd) != PGAGROAL_TLS_OK)
+      {
+         return PGAGROAL_TLS_ERROR;
+      }
+
+      if (rc == PGAGROAL_TLS_OK)
+      {
+         return PGAGROAL_TLS_OK;
+      }
+      if (rc != PGAGROAL_TLS_WANT_IO)
+      {
+         return PGAGROAL_TLS_ERROR;
+      }
+
+      if (socket_fill(tls, fd) != PGAGROAL_TLS_OK)
+      {
+         return PGAGROAL_TLS_ERROR;
+      }
+   }
+}
+
+int
+pgagroal_tls_socket_read(struct tls* tls, int fd, void* buf, size_t cap, size_t* nread)
+{
+   if (nread != NULL)
+   {
+      *nread = 0;
+   }
+
+   if (tls == NULL || fd < 0 || buf == NULL)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   for (;;)
+   {
+      int rc = pgagroal_tls_read(tls, buf, cap, nread);
+
+      if (rc == PGAGROAL_TLS_OK || rc == PGAGROAL_TLS_CLOSED)
+      {
+         return rc;
+      }
+      if (rc != PGAGROAL_TLS_WANT_IO)
+      {
+         return PGAGROAL_TLS_ERROR;
+      }
+
+      /* The engine may owe the peer a flight before it can receive more. */
+      if (socket_flush(tls, fd) != PGAGROAL_TLS_OK)
+      {
+         return PGAGROAL_TLS_ERROR;
+      }
+      if (socket_fill(tls, fd) != PGAGROAL_TLS_OK)
+      {
+         return PGAGROAL_TLS_ERROR;
+      }
+   }
+}
+
+int
+pgagroal_tls_socket_write(struct tls* tls, int fd, const void* buf, size_t len)
+{
+   size_t off = 0;
+
+   if (tls == NULL || fd < 0 || (buf == NULL && len > 0))
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   while (off < len)
+   {
+      size_t written = 0;
+      int rc = pgagroal_tls_write(tls, (const unsigned char*)buf + off, len - off, &written);
+
+      if (rc == PGAGROAL_TLS_OK)
+      {
+         off += written;
+         if (socket_flush(tls, fd) != PGAGROAL_TLS_OK)
+         {
+            return PGAGROAL_TLS_ERROR;
+         }
+      }
+      else if (rc == PGAGROAL_TLS_WANT_IO)
+      {
+         if (socket_flush(tls, fd) != PGAGROAL_TLS_OK)
+         {
+            return PGAGROAL_TLS_ERROR;
+         }
+         if (socket_fill(tls, fd) != PGAGROAL_TLS_OK)
+         {
+            return PGAGROAL_TLS_ERROR;
+         }
+      }
+      else
+      {
+         return PGAGROAL_TLS_ERROR;
+      }
+   }
+
+   return PGAGROAL_TLS_OK;
+}
+
+int
+pgagroal_tls_configure_server_ctx(SSL_CTX* ctx, char* key_file, char* cert_file, char* ca_file)
+{
+   STACK_OF(X509_NAME)* root_cert_list = NULL;
+
+   if (strlen(cert_file) == 0)
+   {
+      pgagroal_log_error("No TLS certificate defined");
+      goto error;
+   }
+
+   if (strlen(key_file) == 0)
+   {
+      pgagroal_log_error("No TLS private key defined");
+      goto error;
+   }
+
+   if (SSL_CTX_use_certificate_chain_file(ctx, cert_file) != 1)
+   {
+      unsigned long err;
+
+      err = ERR_get_error();
+      pgagroal_log_error("Couldn't load TLS certificate: %s", cert_file);
+      pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
+      goto error;
+   }
+
+   if (SSL_CTX_use_PrivateKey_file(ctx, key_file, SSL_FILETYPE_PEM) != 1)
+   {
+      unsigned long err;
+
+      err = ERR_get_error();
+      pgagroal_log_error("Couldn't load TLS private key: %s", key_file);
+      pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
+      goto error;
+   }
+
+   if (SSL_CTX_check_private_key(ctx) != 1)
+   {
+      unsigned long err;
+
+      err = ERR_get_error();
+      pgagroal_log_error("TLS private key check failed: %s", key_file);
+      pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
+      goto error;
+   }
+
+   if (strlen(ca_file) > 0)
+   {
+      if (SSL_CTX_load_verify_locations(ctx, ca_file, NULL) != 1)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgagroal_log_error("Couldn't load TLS CA: %s", ca_file);
+         pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+
+      root_cert_list = SSL_load_client_CA_file(ca_file);
+      if (root_cert_list == NULL)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgagroal_log_error("Couldn't load TLS CA: %s", ca_file);
+         pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+
+      SSL_CTX_set_verify(ctx, (SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT | SSL_VERIFY_CLIENT_ONCE), NULL);
+      SSL_CTX_set_client_CA_list(ctx, root_cert_list);
+   }
+
+   return 0;
+
+error:
+
+   return 1;
+}
+
+int
+pgagroal_tls_create_server(SSL_CTX* ctx, char* key_file, char* cert_file, char* ca_file, struct tls** tls)
+{
+   if (pgagroal_tls_configure_server_ctx(ctx, key_file, cert_file, ca_file))
+   {
+      goto error;
+   }
+
+   if (pgagroal_tls_create(ctx, true, tls) != PGAGROAL_TLS_OK)
+   {
+      goto error;
+   }
+
+   return 0;
+
+error:
+
+   SSL_CTX_free(ctx);
+
+   return 1;
+}
+
+int
+pgagroal_tls_create_client(SSL_CTX* ctx, char* key, char* cert, char* root, struct tls** tls)
+{
+   struct tls* t = NULL;
+   bool have_cert = false;
+   bool have_rootcert = false;
+
+   if (root != NULL && strlen(root) > 0)
+   {
+      if (SSL_CTX_load_verify_locations(ctx, root, NULL) != 1)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgagroal_log_error("Couldn't load TLS CA: %s", root);
+         pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+
+      have_rootcert = true;
+   }
+
+   if (cert != NULL && strlen(cert) > 0)
+   {
+      if (SSL_CTX_use_certificate_chain_file(ctx, cert) != 1)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgagroal_log_error("Couldn't load TLS certificate: %s", cert);
+         pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+
+      have_cert = true;
+   }
+
+   if (pgagroal_tls_create(ctx, false, &t) != PGAGROAL_TLS_OK)
+   {
+      goto error;
+   }
+
+   if (have_cert && key != NULL && strlen(key) > 0)
+   {
+      if (SSL_use_PrivateKey_file(t->ssl, key, SSL_FILETYPE_PEM) != 1)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgagroal_log_error("Couldn't load TLS private key: %s", key);
+         pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+
+      if (SSL_check_private_key(t->ssl) != 1)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgagroal_log_error("TLS private key check failed: %s", key);
+         pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+   }
+
+   if (have_rootcert)
+   {
+      SSL_set_verify(t->ssl, SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE, NULL);
+   }
+
+   *tls = t;
+
+   return 0;
+
+error:
+
+   if (t != NULL)
+   {
+      pgagroal_tls_free(t);
+   }
+   SSL_CTX_free(ctx);
+
+   return 1;
+}
+
+int
+pgagroal_create_ssl_ctx(bool client, SSL_CTX** ctx)
+{
+   SSL_CTX* c = NULL;
+
+   if (client)
+   {
+      c = SSL_CTX_new(TLS_client_method());
+   }
+   else
+   {
+      c = SSL_CTX_new(TLS_server_method());
+   }
+
+   if (c == NULL)
+   {
+      goto error;
+   }
+
+   if (SSL_CTX_set_min_proto_version(c, TLS1_2_VERSION) == 0)
+   {
+      goto error;
+   }
+
+   SSL_CTX_set_mode(c, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+   SSL_CTX_set_options(c, SSL_OP_NO_TICKET);
+   SSL_CTX_set_session_cache_mode(c, SSL_SESS_CACHE_CLIENT | SSL_SESS_CACHE_NO_INTERNAL_STORE);
+
+   *ctx = c;
+
+   return 0;
+
+error:
+
+   if (c != NULL)
+   {
+      SSL_CTX_free(c);
+   }
+
+   return 1;
+}
+
+int
+pgagroal_create_ssl_server(SSL_CTX* ctx, char* key_file, char* cert_file, char* ca_file, int socket, SSL** ssl)
+{
+   SSL* s = NULL;
+
+   if (pgagroal_tls_configure_server_ctx(ctx, key_file, cert_file, ca_file))
+   {
+      goto error;
+   }
+
+   s = SSL_new(ctx);
+
+   if (s == NULL)
+   {
+      goto error;
+   }
+
+   if (SSL_set_fd(s, socket) == 0)
+   {
+      goto error;
+   }
+
+   *ssl = s;
+
+   return 0;
+
+error:
+
+   if (s != NULL)
+   {
+      SSL_shutdown(s);
+      SSL_free(s);
+   }
+   SSL_CTX_free(ctx);
+
+   return 1;
+}
+
+int
+pgagroal_create_ssl_client(SSL_CTX* ctx, char* key, char* cert, char* root, int socket, SSL** ssl)
+{
+   SSL* s = NULL;
+   bool have_cert = false;
+   bool have_rootcert = false;
+
+   if (root != NULL && strlen(root) > 0)
+   {
+      if (SSL_CTX_load_verify_locations(ctx, root, NULL) != 1)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgagroal_log_error("Couldn't load TLS CA: %s", root);
+         pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+
+      have_rootcert = true;
+   }
+
+   if (cert != NULL && strlen(cert) > 0)
+   {
+      if (SSL_CTX_use_certificate_chain_file(ctx, cert) != 1)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgagroal_log_error("Couldn't load TLS certificate: %s", cert);
+         pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+
+      have_cert = true;
+   }
+
+   s = SSL_new(ctx);
+
+   if (s == NULL)
+   {
+      goto error;
+   }
+
+   if (SSL_set_fd(s, socket) == 0)
+   {
+      goto error;
+   }
+
+   if (have_cert && key != NULL && strlen(key) > 0)
+   {
+      if (SSL_use_PrivateKey_file(s, key, SSL_FILETYPE_PEM) != 1)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgagroal_log_error("Couldn't load TLS private key: %s", key);
+         pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+
+      if (SSL_check_private_key(s) != 1)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgagroal_log_error("TLS private key check failed: %s", key);
+         pgagroal_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+   }
+
+   if (have_rootcert)
+   {
+      SSL_set_verify(s, SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE, NULL);
+   }
+
+   *ssl = s;
+
+   return 0;
+
+error:
+
+   if (s != NULL)
+   {
+      SSL_shutdown(s);
+      SSL_free(s);
+   }
+   SSL_CTX_free(ctx);
+
+   return 1;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -46,6 +46,7 @@
 #include <server.h>
 #include <shmem.h>
 #include <status.h>
+#include <tls.h>
 #include <utils.h>
 #include <worker.h>
 

--- a/src/vault.c
+++ b/src/vault.c
@@ -37,6 +37,7 @@
 #include <network.h>
 #include <security.h>
 #include <shmem.h>
+#include <tls.h>
 #include <utils.h>
 #include <prometheus.h>
 #include <utf8.h>

--- a/test/testcases/test_tls.c
+++ b/test/testcases/test_tls.c
@@ -31,6 +31,9 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include <openssl/evp.h>
 #include <openssl/x509.h>
@@ -380,6 +383,119 @@ cleanup:
    if (sctx != NULL)
    {
       SSL_CTX_free(sctx);
+   }
+   MCTF_FINISH();
+}
+
+// The socket-driver shim interoperates with a stock SSL_set_fd peer over a real socket
+MCTF_TEST(test_pgagroal_tls_socket_shim_roundtrip)
+{
+   const char* msg = "socket driver round trip";
+   SSL_CTX* sctx = NULL;
+   SSL_CTX* cctx = NULL;
+   struct tls* client = NULL;
+   pid_t pid = -1;
+   int sv[2] = {-1, -1};
+   unsigned char out[256];
+   size_t nread = 0;
+
+   sctx = tls_test_server_ctx();
+   cctx = tls_test_client_ctx();
+   MCTF_ASSERT_PTR_NONNULL(sctx, cleanup, "server SSL_CTX creation failed");
+   MCTF_ASSERT_PTR_NONNULL(cctx, cleanup, "client SSL_CTX creation failed");
+
+   MCTF_ASSERT_INT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0, cleanup, "socketpair failed");
+
+   pid = fork();
+   MCTF_ASSERT(pid >= 0, cleanup, "fork failed");
+
+   if (pid == 0)
+   {
+      /* child: stock socket-bound TLS server -- accept, echo one message, close */
+      SSL* ssl = SSL_new(sctx);
+      char buf[256];
+      int n;
+
+      close(sv[1]);
+      SSL_set_fd(ssl, sv[0]);
+      if (SSL_accept(ssl) == 1)
+      {
+         n = SSL_read(ssl, buf, sizeof(buf));
+         if (n > 0)
+         {
+            SSL_write(ssl, buf, n);
+         }
+      }
+      SSL_shutdown(ssl);
+      SSL_free(ssl);
+      close(sv[0]);
+      _exit(0);
+   }
+
+   close(sv[0]);
+   sv[0] = -1;
+
+   /* parent: drive the client end entirely through the wrapper + socket shim */
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_create(cctx, false, &client), PGAGROAL_TLS_OK,
+                      cleanup, "client tls context creation failed");
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_socket_handshake(client, sv[1]), PGAGROAL_TLS_OK,
+                      cleanup, "socket handshake against stock peer failed");
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_socket_write(client, sv[1], msg, strlen(msg)), PGAGROAL_TLS_OK,
+                      cleanup, "socket write failed");
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_socket_read(client, sv[1], out, sizeof(out), &nread),
+                      PGAGROAL_TLS_OK, cleanup, "socket read failed");
+   MCTF_ASSERT_INT_EQ((int)nread, (int)strlen(msg), cleanup, "echo length mismatch");
+   MCTF_ASSERT(memcmp(out, msg, strlen(msg)) == 0, cleanup, "echo payload mismatch");
+
+cleanup:
+   if (pid > 0)
+   {
+      waitpid(pid, NULL, 0);
+   }
+   pgagroal_tls_free(client);
+   if (sv[0] >= 0)
+   {
+      close(sv[0]);
+   }
+   if (sv[1] >= 0)
+   {
+      close(sv[1]);
+   }
+   if (sctx != NULL)
+   {
+      SSL_CTX_free(sctx);
+   }
+   if (cctx != NULL)
+   {
+      SSL_CTX_free(cctx);
+   }
+   MCTF_FINISH();
+}
+
+// The wrapper is recoverable from its SSL object, enabling transparent I/O routing
+MCTF_TEST(test_pgagroal_tls_from_ssl_backpointer)
+{
+   SSL_CTX* cctx = NULL;
+   struct tls* client = NULL;
+
+   cctx = tls_test_client_ctx();
+   MCTF_ASSERT_PTR_NONNULL(cctx, cleanup, "client SSL_CTX creation failed");
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_create(cctx, false, &client), PGAGROAL_TLS_OK,
+                      cleanup, "client tls context creation failed");
+
+   MCTF_ASSERT(pgagroal_tls_from_ssl(client->ssl) == client, cleanup,
+               "from_ssl should recover the owning wrapper");
+   MCTF_ASSERT_PTR_NULL(pgagroal_tls_from_ssl(NULL), cleanup,
+                        "from_ssl(NULL) should be NULL");
+
+   pgagroal_tls_set_fd(client, 42);
+   MCTF_ASSERT_INT_EQ(client->fd, 42, cleanup, "set_fd should store the descriptor");
+
+cleanup:
+   pgagroal_tls_free(client);
+   if (cctx != NULL)
+   {
+      SSL_CTX_free(cctx);
    }
    MCTF_FINISH();
 }


### PR DESCRIPTION
Drive client and backend TLS through the socket-decoupled wrapper, replacing the SSL_set_fd-bound contexts in the auth and pooling paths.