### PR TITLE
[#939]fix clang warnings caused by incorrect MCTF_SKIP macro condition

### DIFF
--- a/test/include/mctf.h
+++ b/test/include/mctf.h
@@ -348,7 +348,7 @@ mctf_format_error(const char* format, ...);
    do                                                  \
    {                                                   \
       mctf_errno = MCTF_CODE_SKIPPED;                  \
-      if (__VA_ARGS__)                                 \
+      if (sizeof(#__VA_ARGS__) > 1)                    \
       {                                                \
          mctf_errmsg = mctf_format_error(__VA_ARGS__); \
       }                                                \

--- a/test/testcases/test_pool_saturation.c
+++ b/test/testcases/test_pool_saturation.c
@@ -73,7 +73,7 @@ cleanup:
  * succeed.
  *
  * Parameters are derived from the live configuration so the test is meaningful
- * against every test/conf/* profile exercised by run-configs. Configurations
+ * against every test/conf profile exercised by run-configs. Configurations
  * whose blocking_timeout is too small to absorb one hold cycle are skipped:
  * there the waiters are expected to time out regardless of #875, so the test
  * could not isolate the regression.


### PR DESCRIPTION
- fixes #939 

resolves the below warnings
```
[ 96%] Building C object test/CMakeFiles/pgagroal_test.dir/testcases/test_startup_validation.c.o
[ 97%] Building C object test/CMakeFiles/pgagroal_test.dir/testcases/test_tls.c.o
[ 98%] Building C object test/CMakeFiles/pgagroal_test.dir/testcases/test_utf8.c.o
/__w/pgagroal/pgagroal/test/testcases/test_pool_saturation.c:76:27: warning: '/*' within block comment [-Wcomment]
   76 |  * against every test/conf/* profile exercised by run-configs. Configurations
      |                           ^
/__w/pgagroal/pgagroal/test/testcases/test_pool_saturation.c:100:17: warning: left operand of comma operator has no effect [-Wunused-value]
  100 |       MCTF_SKIP("max_connections (%d) too large to oversubscribe safely; retry-path test targets small pools",
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/__w/pgagroal/pgagroal/test/include/mctf.h:351:11: note: expanded from macro 'MCTF_SKIP'
  351 |       if (__VA_ARGS__)                                 \
      |           ^~~~~~~~~~~
/__w/pgagroal/pgagroal/test/testcases/test_pool_saturation.c:108:17: warning: left operand of comma operator has no effect [-Wunused-value]
  108 |       MCTF_SKIP("blocking_timeout (%lds) too small to exercise the retry path",
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/__w/pgagroal/pgagroal/test/include/mctf.h:351:11: note: expanded from macro 'MCTF_SKIP'
  351 |       if (__VA_ARGS__)                                 \
      |           ^~~~~~~~~~~
3 warnings generated.
```