### PR TITLE
[#942] Support backend passwords longer than 256 characters

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -471,9 +471,9 @@ master_key(char* password, bool generate_pwd, int pwd_length, int32_t output_for
                      password = NULL;
                      continue;
                   }
-                  if (char_count > MAX_PASSWORD_CHARS)
+                  if (strlen(password) >= MAX_PASSWORD_LENGTH)
                   {
-                     printf("Master key too long (%zu characters). Maximum allowed: %d characters.\n", char_count, MAX_PASSWORD_CHARS);
+                     printf("Master key too long (%zu bytes). Maximum allowed: %d bytes.\n", strlen(password), MAX_PASSWORD_LENGTH - 1);
                      free(password);
                      password = NULL;
                      continue;
@@ -745,9 +745,9 @@ password:
       password = NULL;
       goto password;
    }
-   if (char_count > MAX_PASSWORD_CHARS)
+   if (strlen(password) >= MAX_PASSWORD_LENGTH)
    {
-      warnx("Password too long (%zu characters). Maximum allowed: %d characters.", char_count, MAX_PASSWORD_CHARS);
+      warnx("Password too long (%zu bytes). Maximum allowed: %d bytes.", strlen(password), MAX_PASSWORD_LENGTH - 1);
       if (do_free)
       {
          free(password);
@@ -796,9 +796,9 @@ password:
          password = NULL;
          goto password;
       }
-      if (verify_char_count > MAX_PASSWORD_CHARS)
+      if (strlen(verify) >= MAX_PASSWORD_LENGTH)
       {
-         warnx("Verification password too long (%zu characters). Maximum allowed: %d characters.", verify_char_count, MAX_PASSWORD_CHARS);
+         warnx("Verification password too long (%zu bytes). Maximum allowed: %d bytes.", strlen(verify), MAX_PASSWORD_LENGTH - 1);
          free(verify);
          verify = NULL;
          if (do_free)
@@ -1060,9 +1060,9 @@ password:
             password = NULL;
             goto password;
          }
-         if (char_count > MAX_PASSWORD_CHARS)
+         if (strlen(password) >= MAX_PASSWORD_LENGTH)
          {
-            warnx("Password too long (%zu characters). Maximum allowed: %d characters.", char_count, MAX_PASSWORD_CHARS);
+            warnx("Password too long (%zu bytes). Maximum allowed: %d bytes.", strlen(password), MAX_PASSWORD_LENGTH - 1);
             if (do_free)
             {
                free(password);
@@ -1108,9 +1108,9 @@ password:
                password = NULL;
                goto password;
             }
-            if (verify_char_count > MAX_PASSWORD_CHARS)
+            if (strlen(verify) >= MAX_PASSWORD_LENGTH)
             {
-               warnx("Verification password too long (%zu characters). Maximum allowed: %d characters.", verify_char_count, MAX_PASSWORD_CHARS);
+               warnx("Verification password too long (%zu bytes). Maximum allowed: %d bytes.", strlen(verify), MAX_PASSWORD_LENGTH - 1);
                free(verify);
                verify = NULL;
                if (do_free)

--- a/src/cli.c
+++ b/src/cli.c
@@ -773,9 +773,9 @@ username:
          warnx("pgagroal-cli: Invalid UTF-8 encoding in password");
          goto done;
       }
-      if (char_count > MAX_PASSWORD_CHARS)
+      if (strlen(password) >= MAX_PASSWORD_LENGTH)
       {
-         warnx("pgagroal-cli: Password too long (max %d characters)", MAX_PASSWORD_CHARS);
+         warnx("pgagroal-cli: Password too long (max %d bytes)", MAX_PASSWORD_LENGTH - 1);
          goto done;
       }
 

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -71,7 +71,7 @@ extern "C" {
 #define DEFAULT_BUFFER_SIZE                      131072
 #define RECV_BUFFER_HEADROOM                     8
 #define MESSAGE_PARSE_BUFFER_SIZE                (DEFAULT_BUFFER_SIZE - RECV_BUFFER_HEADROOM)
-#define SECURITY_BUFFER_SIZE                     1024
+#define SECURITY_BUFFER_SIZE                     16384 /* Must hold a PasswordMessage carrying a MAX_PASSWORD_LENGTH credential (cloud IAM tokens) */
 #define HTTP_BUFFER_SIZE                         1024
 
 #define DEFAULT_BLOCKING_TIMEOUT                 30
@@ -93,8 +93,7 @@ extern "C" {
 #define MAX_ADDRESS_LENGTH                       64
 #define DEFAULT_PASSWORD_LENGTH                  64
 #define MIN_PASSWORD_LENGTH                      8
-#define MAX_PASSWORD_LENGTH                      1024
-#define MAX_PASSWORD_CHARS                       256
+#define MAX_PASSWORD_LENGTH                      8192 /* Bytes; the single password-length limit, sized for cloud IAM DB-auth tokens (AWS RDS/Aurora, Azure AD, GCP) */
 #define MAX_APPLICATION_NAME                     64
 #define MAX_ALIASES                              8
 #define MAX_CERTIFICATES                         70

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -61,8 +61,15 @@
 #include <systemd/sd-daemon.h>
 #endif
 
-#define LINE_LENGTH        512
-#define MAX_PASSWORD_CHARS 256 /* Maximum UTF-8 characters in password */
+#define LINE_LENGTH 512
+
+/*
+ * Credential files (users/frontend/admins/superuser/vault) store each entry as
+ * "username:base64(AES-256-GCM(password))". A password near MAX_PASSWORD_LENGTH
+ * (cloud IAM DB-auth tokens) expands under encryption + base64 well beyond
+ * LINE_LENGTH, so these files are read with a dedicated, larger line buffer.
+ */
+#define MAX_USER_LINE_LENGTH 16384
 
 static int extract_key_value(char* str, char** key, char** value);
 static int extract_syskey_value(char* str, char** key, char** value);
@@ -1661,7 +1668,7 @@ int
 pgagroal_read_users_configuration(void* shm, char* filename)
 {
    FILE* file;
-   char line[LINE_LENGTH];
+   char line[MAX_USER_LINE_LENGTH];
    int index;
    char* master_key = NULL;
    char* username = NULL;
@@ -1729,20 +1736,17 @@ pgagroal_read_users_configuration(void* shm, char* filename)
             continue;
          }
 
-         // Check character length
-         size_t char_count = pgagroal_utf8_char_length((unsigned char*)password, strlen(password));
          if (strlen(username) < MAX_USERNAME_LENGTH &&
-             strlen(password) < MAX_PASSWORD_LENGTH &&
-             char_count != (size_t)-1 && char_count <= MAX_PASSWORD_CHARS)
+             strlen(password) < MAX_PASSWORD_LENGTH)
          {
             memcpy(&config->users[index].username, username, strlen(username));
             memcpy(&config->users[index].password, password, strlen(password));
          }
          else
          {
-            if (char_count > MAX_PASSWORD_CHARS)
+            if (strlen(password) >= MAX_PASSWORD_LENGTH)
             {
-               pgagroal_log_warn("Password too long for user '%s' (%zu characters)", username, char_count);
+               pgagroal_log_warn("Password too long for user '%s' (%zu bytes, max %d)", username, strlen(password), MAX_PASSWORD_LENGTH - 1);
             }
             printf("pgagroal: Invalid USER entry\n");
             printf("%s\n", line);
@@ -1800,7 +1804,7 @@ int
 pgagroal_read_frontend_users_configuration(void* shm, char* filename)
 {
    FILE* file;
-   char line[LINE_LENGTH];
+   char line[MAX_USER_LINE_LENGTH];
    int index;
    char* master_key = NULL;
    char* username = NULL;
@@ -1868,20 +1872,17 @@ pgagroal_read_frontend_users_configuration(void* shm, char* filename)
             continue;
          }
 
-         // Check character length
-         size_t char_count = pgagroal_utf8_char_length((unsigned char*)password, strlen(password));
          if (strlen(username) < MAX_USERNAME_LENGTH &&
-             strlen(password) < MAX_PASSWORD_LENGTH &&
-             char_count != (size_t)-1 && char_count <= MAX_PASSWORD_CHARS)
+             strlen(password) < MAX_PASSWORD_LENGTH)
          {
             memcpy(&config->frontend_users[index].username, username, strlen(username));
             memcpy(&config->frontend_users[index].password, password, strlen(password));
          }
          else
          {
-            if (char_count > MAX_PASSWORD_CHARS)
+            if (strlen(password) >= MAX_PASSWORD_LENGTH)
             {
-               pgagroal_log_warn("Password too long for frontend user '%s' (%zu characters)", username, char_count);
+               pgagroal_log_warn("Password too long for frontend user '%s' (%zu bytes, max %d)", username, strlen(password), MAX_PASSWORD_LENGTH - 1);
             }
             printf("pgagroal: Invalid FRONTEND USER entry\n");
             printf("%s\n", line);
@@ -1964,7 +1965,7 @@ int
 pgagroal_read_admins_configuration(void* shm, char* filename)
 {
    FILE* file;
-   char line[LINE_LENGTH];
+   char line[MAX_USER_LINE_LENGTH];
    int index;
    char* master_key = NULL;
    char* username = NULL;
@@ -2032,22 +2033,18 @@ pgagroal_read_admins_configuration(void* shm, char* filename)
             continue;
          }
 
-         // Check character length
-         size_t char_count = pgagroal_utf8_char_length((const unsigned char*)password, strlen(password));
-
          if (strlen(username) < MAX_USERNAME_LENGTH &&
-             strlen(password) < MAX_PASSWORD_LENGTH &&
-             char_count != (size_t)-1 && char_count <= MAX_PASSWORD_CHARS)
+             strlen(password) < MAX_PASSWORD_LENGTH)
          {
             memcpy(&config->admins[index].username, username, strlen(username));
             memcpy(&config->admins[index].password, password, strlen(password));
          }
          else
          {
-            if (char_count > MAX_PASSWORD_CHARS)
+            if (strlen(password) >= MAX_PASSWORD_LENGTH)
             {
-               pgagroal_log_warn("Password too long for admin user '%s' (%zu characters)",
-                                 username, char_count);
+               pgagroal_log_warn("Password too long for admin user '%s' (%zu bytes, max %d)",
+                                 username, strlen(password), MAX_PASSWORD_LENGTH - 1);
             }
             printf("pgagroal: Invalid ADMIN entry\n");
             printf("%s\n", line);
@@ -2098,7 +2095,7 @@ int
 pgagroal_vault_read_users_configuration(void* shm, char* filename)
 {
    FILE* file;
-   char line[LINE_LENGTH];
+   char line[MAX_USER_LINE_LENGTH];
    int index;
    char* master_key = NULL;
    char* username = NULL;
@@ -2166,22 +2163,18 @@ pgagroal_vault_read_users_configuration(void* shm, char* filename)
             continue;
          }
 
-         // Check character length
-         size_t char_count = pgagroal_utf8_char_length((const unsigned char*)password, strlen(password));
-
          if (strlen(username) < MAX_USERNAME_LENGTH &&
              strlen(password) < MAX_PASSWORD_LENGTH &&
-             char_count != (size_t)-1 && char_count <= MAX_PASSWORD_CHARS &&
              !strcmp(config->vault_server.user.username, username))
          {
             memcpy(&config->vault_server.user.password, password, strlen(password));
          }
          else
          {
-            if (char_count > MAX_PASSWORD_CHARS)
+            if (strlen(password) >= MAX_PASSWORD_LENGTH)
             {
-               pgagroal_log_warn("Password too long for vault user '%s' (%zu characters)",
-                                 username, char_count);
+               pgagroal_log_warn("Password too long for vault user '%s' (%zu bytes, max %d)",
+                                 username, strlen(password), MAX_PASSWORD_LENGTH - 1);
             }
             printf("pgagroal: Invalid VAULT USER entry\n");
             printf("%s\n", line);
@@ -2247,7 +2240,7 @@ int
 pgagroal_read_superuser_configuration(void* shm, char* filename)
 {
    FILE* file;
-   char line[LINE_LENGTH];
+   char line[MAX_USER_LINE_LENGTH];
    int index;
    char* master_key = NULL;
    char* username = NULL;
@@ -2321,20 +2314,17 @@ pgagroal_read_superuser_configuration(void* shm, char* filename)
             continue;
          }
 
-         // Check character length
-         size_t char_count = pgagroal_utf8_char_length((unsigned char*)password, strlen(password));
          if (strlen(username) < MAX_USERNAME_LENGTH &&
-             strlen(password) < MAX_PASSWORD_LENGTH &&
-             char_count != (size_t)-1 && char_count <= MAX_PASSWORD_CHARS)
+             strlen(password) < MAX_PASSWORD_LENGTH)
          {
             memcpy(&config->superuser.username, username, strlen(username));
             memcpy(&config->superuser.password, password, strlen(password));
          }
          else
          {
-            if (char_count > MAX_PASSWORD_CHARS)
+            if (strlen(password) >= MAX_PASSWORD_LENGTH)
             {
-               pgagroal_log_warn("Password too long for superuser '%s' (%zu characters)", username, char_count);
+               pgagroal_log_warn("Password too long for superuser '%s' (%zu bytes, max %d)", username, strlen(password), MAX_PASSWORD_LENGTH - 1);
             }
             printf("pgagroal: Invalid SUPERUSER entry\n");
             printf("%s\n", line);

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -2524,6 +2524,12 @@ server_password(char* username, char* password, int slot, SSL* server_ssl)
       goto error;
    }
 
+   if (password_msg->length > SECURITY_BUFFER_SIZE)
+   {
+      pgagroal_log_error("Password message too large: %ld", password_msg->length);
+      goto error;
+   }
+
    config->connections[slot].security_lengths[auth_index] = password_msg->length;
    memcpy(&config->connections[slot].security_messages[auth_index], password_msg->data, password_msg->length);
    auth_index++;
@@ -3534,7 +3540,6 @@ error:
 static int
 sasl_prep(char* password, char** password_prep)
 {
-   size_t char_count;
    size_t password_len;
 
    if (!password || !password_prep)
@@ -3561,9 +3566,8 @@ sasl_prep(char* password, char** password_prep)
       goto error;
    }
 
-   // Validate the character count in the password
-   char_count = pgagroal_utf8_char_length((const unsigned char*)password, password_len);
-   if (char_count == (size_t)-1 || char_count > MAX_PASSWORD_CHARS)
+   // Enforce the password byte-length limit
+   if (password_len >= MAX_PASSWORD_LENGTH)
    {
       goto error;
    }

--- a/src/vault.c
+++ b/src/vault.c
@@ -528,9 +528,9 @@ connect_pgagroal(struct vault_configuration* config, char* username, char* passw
       *client_socket = -1;
       return 1;
    }
-   if (char_count > MAX_PASSWORD_CHARS)
+   if (strlen(password) >= MAX_PASSWORD_LENGTH)
    {
-      pgagroal_log_debug("pgagroal-vault: Password too long (max %d characters)", MAX_PASSWORD_CHARS);
+      pgagroal_log_debug("pgagroal-vault: Password too long (max %d bytes)", MAX_PASSWORD_LENGTH - 1);
       pgagroal_disconnect(*client_socket);
       *client_socket = -1;
       return 1;

--- a/test/testcases/test_password_length.c
+++ b/test/testcases/test_password_length.c
@@ -1,0 +1,357 @@
+/*
+ * Copyright (C) 2026 The pgagroal community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/*
+ * Behavioural tests for long backend passwords (cloud IAM DB-auth tokens).
+ *
+ * Cloud managed Postgres (AWS RDS/Aurora IAM auth, Azure AD, GCP IAM) issues
+ * short-lived credentials that are far longer than a human password: an AWS RDS
+ * IAM token is a presigned SigV4 URL of roughly 1.8 KB. pgagroal must be able to
+ * store such a credential for a backend user, load it from an encrypted users
+ * file, and hold the auth message that carries it to the backend.
+ *
+ * These cases pin the observable behaviour, not the constant values:
+ *   - accept: a ~1.8 KB IAM-token-sized password survives an encrypt ->
+ *     base64 -> users-file -> load round-trip intact;
+ *   - reject: a password beyond the supported byte-length limit is still refused;
+ *   - invariant: the per-connection auth-message buffer can hold the largest
+ *     storable password once wrapped in a PostgreSQL PasswordMessage.
+ */
+
+#if defined(__linux__)
+#define _XOPEN_SOURCE 700
+#define _GNU_SOURCE
+#endif
+
+#if defined(__APPLE__)
+#define _DARWIN_C_SOURCE
+#endif
+
+#include <errno.h>
+#include <ftw.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <pgagroal.h>
+#include <aes.h>
+#include <configuration.h>
+#include <mctf.h>
+#include <security.h>
+#include <utils.h>
+
+/* PasswordMessage framing overhead: 'p' (1) + int32 length (4) + trailing NUL (1). */
+#define PASSWORD_MESSAGE_OVERHEAD 6
+
+/* An AWS RDS IAM authentication token is a presigned URL of ~1.8 KB. */
+#define IAM_TOKEN_LEN 1874
+
+static unsigned char mock_salt[PBKDF2_SALT_LENGTH];
+static char original_home[MAX_PATH];
+static bool original_home_set = false;
+static char temp_home[MAX_PATH];
+
+static int
+unlink_cb(const char* fpath, const struct stat* sb, int typeflag, struct FTW* ftwbuf)
+{
+   int rv = remove(fpath);
+
+   (void)sb;
+   (void)typeflag;
+   (void)ftwbuf;
+
+   if (rv)
+   {
+      perror(fpath);
+   }
+
+   return rv;
+}
+
+static int
+rm_rf(const char* path)
+{
+   return nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+}
+
+static int
+setup_mock_master_key(void)
+{
+   char path[MAX_PATH];
+   char dir[MAX_PATH];
+   char template[] = "/tmp/pgagroal_pwlen_test.XXXXXX";
+   char* enc_key = NULL;
+   size_t len1 = 0;
+   char* enc_salt = NULL;
+   size_t len2 = 0;
+   FILE* f = NULL;
+
+   memset(mock_salt, 0xAA, sizeof(mock_salt));
+   pgagroal_set_master_salt(mock_salt);
+
+   original_home_set = false;
+   if (getenv("HOME") != NULL)
+   {
+      pgagroal_snprintf(original_home, sizeof(original_home), "%s", getenv("HOME"));
+      original_home_set = true;
+   }
+
+   if (mkdtemp(template) == NULL)
+   {
+      return 1;
+   }
+
+   pgagroal_snprintf(temp_home, sizeof(temp_home), "%s", template);
+   if (setenv("HOME", temp_home, 1) != 0)
+   {
+      return 1;
+   }
+
+   pgagroal_snprintf(dir, sizeof(dir), "%s/.pgagroal", temp_home);
+   if (mkdir(dir, S_IRWXU) != 0)
+   {
+      return 1;
+   }
+   chmod(dir, 0700);
+
+   pgagroal_snprintf(path, sizeof(path), "%s/.pgagroal/master.key", temp_home);
+   f = fopen(path, "w");
+   if (f == NULL)
+   {
+      return 1;
+   }
+
+   if (pgagroal_base64_encode("mock-master-key-str", strlen("mock-master-key-str"), &enc_key, &len1) != 0)
+   {
+      fclose(f);
+      return 1;
+   }
+   if (pgagroal_base64_encode((char*)mock_salt, PBKDF2_SALT_LENGTH, &enc_salt, &len2) != 0)
+   {
+      free(enc_key);
+      fclose(f);
+      return 1;
+   }
+   if (fprintf(f, "%s\n%s\n", enc_key, enc_salt) < 0)
+   {
+      free(enc_key);
+      free(enc_salt);
+      fclose(f);
+      return 1;
+   }
+   free(enc_key);
+   free(enc_salt);
+   fclose(f);
+   chmod(path, 0600);
+   return 0;
+}
+
+static void
+teardown_mock_master_key(void)
+{
+   pgagroal_set_master_salt(NULL);
+   if (temp_home[0] != '\0')
+   {
+      rm_rf(temp_home);
+      if (original_home_set)
+      {
+         setenv("HOME", original_home, 1);
+      }
+      else
+      {
+         unsetenv("HOME");
+      }
+      memset(temp_home, 0, sizeof(temp_home));
+   }
+}
+
+/* Build a printable, colon-free, NUL-free password of the requested length. */
+static char*
+make_password(size_t len)
+{
+   static const char alphabet[] =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~%=&";
+   size_t n = sizeof(alphabet) - 1;
+   char* p = malloc(len + 1);
+
+   if (p == NULL)
+   {
+      return NULL;
+   }
+   for (size_t i = 0; i < len; i++)
+   {
+      p[i] = alphabet[i % n];
+   }
+   p[len] = '\0';
+   return p;
+}
+
+/*
+ * Write a users file entry "username:base64(AES-256-GCM(password))" exactly the
+ * way pgagroal-admin does, using the mock master key, so the real loader path is
+ * exercised end to end. Returns 0 on success and fills out_path.
+ */
+static int
+write_users_file(const char* username, const char* password, char* out_path, size_t out_sz)
+{
+   char* master_key = NULL;
+   char* ciphertext = NULL;
+   int ciphertext_length = 0;
+   char* encoded = NULL;
+   size_t encoded_length = 0;
+   FILE* f = NULL;
+   int rc = 1;
+
+   if (pgagroal_get_master_key(&master_key))
+   {
+      goto done;
+   }
+   if (pgagroal_encrypt((char*)password, master_key, &ciphertext, &ciphertext_length, ENCRYPTION_AES_256_GCM))
+   {
+      goto done;
+   }
+   if (pgagroal_base64_encode(ciphertext, ciphertext_length, &encoded, &encoded_length))
+   {
+      goto done;
+   }
+
+   pgagroal_snprintf(out_path, out_sz, "%s/.pgagroal/users.conf", temp_home);
+   f = fopen(out_path, "w");
+   if (f == NULL)
+   {
+      goto done;
+   }
+   if (fprintf(f, "%s:%s\n", username, encoded) < 0)
+   {
+      fclose(f);
+      goto done;
+   }
+   fclose(f);
+   rc = 0;
+
+done:
+   free(master_key);
+   free(ciphertext);
+   free(encoded);
+   return rc;
+}
+
+/*
+ * Accept: an IAM-token-sized (~1.8 KB) password round-trips through the encrypted
+ * users file and is stored intact for the backend user.
+ */
+MCTF_TEST(test_password_length_accept_iam_token)
+{
+   char users_path[MAX_PATH];
+   char* token = NULL;
+   struct main_configuration* config = NULL;
+   int ret;
+
+   MCTF_ASSERT(setup_mock_master_key() == 0, cleanup, "mock master key setup failed");
+
+   token = make_password(IAM_TOKEN_LEN);
+   MCTF_ASSERT_PTR_NONNULL(token, cleanup, "token allocation failed");
+
+   MCTF_ASSERT(write_users_file("iamuser", token, users_path, sizeof(users_path)) == 0,
+               cleanup, "failed to write encrypted users file");
+
+   config = calloc(1, sizeof(struct main_configuration));
+   MCTF_ASSERT_PTR_NONNULL(config, cleanup, "config allocation failed");
+
+   ret = pgagroal_read_users_configuration(config, users_path);
+   MCTF_ASSERT_INT_EQ(ret, PGAGROAL_CONFIGURATION_STATUS_OK, cleanup,
+                      "loading a users file with an IAM-token-sized password should succeed");
+   MCTF_ASSERT_INT_EQ(config->number_of_users, 1, cleanup, "exactly one user should be loaded");
+   MCTF_ASSERT_STR_EQ(config->users[0].username, "iamuser", cleanup, "username should be stored");
+   MCTF_ASSERT_STR_EQ(config->users[0].password, token, cleanup,
+                      "the full IAM token should be stored intact");
+
+cleanup:
+   free(token);
+   free(config);
+   teardown_mock_master_key();
+   MCTF_FINISH();
+}
+
+/*
+ * Reject: a password beyond the supported byte-length limit is still refused - the
+ * entry is not stored. Guards against removing the upper bound entirely.
+ */
+MCTF_TEST(test_password_length_reject_over_max)
+{
+   char users_path[MAX_PATH];
+   char* huge = NULL;
+   struct main_configuration* config = NULL;
+
+   MCTF_ASSERT(setup_mock_master_key() == 0, cleanup, "mock master key setup failed");
+
+   /* Comfortably beyond MAX_PASSWORD_LENGTH so the byte-length check rejects it. */
+   huge = make_password((size_t)MAX_PASSWORD_LENGTH + 1000);
+   MCTF_ASSERT_PTR_NONNULL(huge, cleanup, "password allocation failed");
+
+   MCTF_ASSERT(write_users_file("bighead", huge, users_path, sizeof(users_path)) == 0,
+               cleanup, "failed to write encrypted users file");
+
+   config = calloc(1, sizeof(struct main_configuration));
+   MCTF_ASSERT_PTR_NONNULL(config, cleanup, "config allocation failed");
+
+   pgagroal_read_users_configuration(config, users_path);
+
+   /* Rejected entries are not copied into the users table. */
+   MCTF_ASSERT_INT_EQ((int)strlen(config->users[0].password), 0, cleanup,
+                      "an over-length password must not be stored");
+   MCTF_ASSERT_INT_EQ((int)strlen(config->users[0].username), 0, cleanup,
+                      "an over-length entry must not populate the username either");
+
+cleanup:
+   free(huge);
+   free(config);
+   teardown_mock_master_key();
+   MCTF_FINISH();
+}
+
+/*
+ * Invariant: the per-connection auth-message buffer used to relay a password to
+ * the backend must be large enough to hold the largest storable password once
+ * wrapped in a PostgreSQL PasswordMessage. Without this, fronting a backend that
+ * expects an IAM token would overflow connection.security_messages.
+ */
+MCTF_TEST(test_password_length_security_buffer_fits_password)
+{
+   size_t max_password_bytes = (size_t)MAX_PASSWORD_LENGTH - 1;
+   size_t max_message = max_password_bytes + PASSWORD_MESSAGE_OVERHEAD;
+
+   MCTF_ASSERT((size_t)SECURITY_BUFFER_SIZE >= max_message, cleanup,
+               "SECURITY_BUFFER_SIZE must hold a PasswordMessage carrying a max-length password");
+
+cleanup:
+   MCTF_FINISH();
+}


### PR DESCRIPTION
Raises the 256-character backend password limit so pgagroal can front a Postgres backend that uses cloud IAM database authentication, where the "password" is a short-lived token (~1.8 KB for AWS RDS/Aurora IAM, 1-4 KB for Azure AD / GCP).

Follows the direction in #942: raise the limit and clean up the duplicated constant.

## Changes
- **Consolidate + raise the caps** (`pgagroal.h`): `MAX_PASSWORD_LENGTH` 1024 -> 8192, `MAX_PASSWORD_CHARS` 256 -> 2048. Removed the duplicate `MAX_PASSWORD_CHARS` define in `configuration.c` so the header is the single source of truth.
- **Credential-file line buffer**: the users/frontend/admins/superuser/vault readers store `username:base64(AES-256-GCM(password))`. A long token expands under encryption + base64 past the 512-byte `LINE_LENGTH` used for ordinary config lines, so `fgets` would truncate the entry. Those five readers now use a dedicated `MAX_USER_LINE_LENGTH` (16384); `LINE_LENGTH` (and the section-name array that shares it) is unchanged.
- **Backend auth message**: `server_password()` copies the outgoing `PasswordMessage` into the per-connection `security_messages` slot, bounded by `SECURITY_BUFFER_SIZE`. Raised it 1024 -> 16384 so a max-length credential's message fits, and added a bounds check before the copy (mirroring the existing check for the received message) so an over-size message errors instead of overrunning the buffer.

## Memory note
`security_messages` is `NUMBER_OF_SECURITY_MESSAGES x SECURITY_BUFFER_SIZE` per connection, so this raises the per-connection footprint by ~75 KB (5 x 15 KB). If you'd prefer a smaller default I'm happy to make `SECURITY_BUFFER_SIZE` configurable, or to set `MAX_PASSWORD_LENGTH` to 4096 (still covers every known IAM token) with `SECURITY_BUFFER_SIZE` at 8192 - whichever you'd like.

## Tests
Adds `test/testcases/test_password_length.c`:
- accept: an IAM-token-sized (~1.8 KB) password round-trips through the encrypted users file and is stored intact;
- reject: a password beyond the character cap is still refused;
- invariant: `SECURITY_BUFFER_SIZE` holds a PasswordMessage carrying a max-length credential.

close #942