### PR TITLE
[#946]Fix pgagroal-cli failure in transaction mode when clients are c…

### DIFF
--- a/src/libpgagroal/pipeline_transaction.c
+++ b/src/libpgagroal/pipeline_transaction.c
@@ -120,7 +120,7 @@ transaction_start(struct event_loop* loop, struct worker_io* w)
    deallocate = false;
 
    memset(&p, 0, sizeof(p));
-   pgagroal_snprintf(&p[0], sizeof(p), MAIN_UDS);
+   pgagroal_snprintf(&p[0], sizeof(p), ".s.pgagroal.%d", (int)getpid());
 
    if (pgagroal_bind_unix_socket(config->unix_socket_dir, &p[0], &unix_socket))
    {
@@ -587,7 +587,7 @@ shutdown_mgt(struct event_loop* loop __attribute__((unused)))
    config = (struct main_configuration*)shmem;
 
    memset(&p, 0, sizeof(p));
-   pgagroal_snprintf(&p[0], sizeof(p), MAIN_UDS);
+   pgagroal_snprintf(&p[0], sizeof(p), ".s.pgagroal.%d", (int)getpid());
 
    pgagroal_io_stop(&io_mgt);
    pgagroal_disconnect(unix_socket);

--- a/src/libpgagroal/pipeline_transaction.c
+++ b/src/libpgagroal/pipeline_transaction.c
@@ -120,6 +120,7 @@ transaction_start(struct event_loop* loop, struct worker_io* w)
    deallocate = false;
 
    memset(&p, 0, sizeof(p));
+   /* Use a per-worker socket, not MAIN_UDS: binding MAIN_UDS here would collide with the main management socket and reset pgagroal-cli once a client is attached */
    pgagroal_snprintf(&p[0], sizeof(p), ".s.pgagroal.%d", (int)getpid());
 
    if (pgagroal_bind_unix_socket(config->unix_socket_dir, &p[0], &unix_socket))
@@ -587,6 +588,7 @@ shutdown_mgt(struct event_loop* loop __attribute__((unused)))
    config = (struct main_configuration*)shmem;
 
    memset(&p, 0, sizeof(p));
+   /* Must match the per-worker socket bound in transaction_start, not MAIN_UDS, so cleanup removes the right socket */
    pgagroal_snprintf(&p[0], sizeof(p), ".s.pgagroal.%d", (int)getpid());
 
    pgagroal_io_stop(&io_mgt);

--- a/test/check.sh
+++ b/test/check.sh
@@ -432,12 +432,16 @@ export_pgagroal_test_variables() {
 
   echo "export PGPASSWORD=$PG_USER_PASSWORD"
   export PGPASSWORD=$PG_USER_PASSWORD
+
+  echo "export PGAGROAL_TEST_BIN=$EXECUTABLE_DIRECTORY"
+  export PGAGROAL_TEST_BIN=$EXECUTABLE_DIRECTORY
 }
 
 unset_pgagroal_test_variables() {
   unset PGAGROAL_TEST_BASE_DIR
   unset PGAGROAL_TEST_CONF
   unset PGPASSWORD
+  unset PGAGROAL_TEST_BIN
   unset LLVM_PROFILE_FILE
   unset CC
 }

--- a/test/include/tsclient.h
+++ b/test/include/tsclient.h
@@ -119,6 +119,31 @@ pgagroal_tsclient_execute_concurrent_holds(char* user, char* database, int clien
 int
 pgagroal_tsclient_limit_backend_peak(char* user, char* database, int client_count, int hold_seconds);
 
+/**
+* Run a pgagroal-cli management command against the running test instance,
+ * using the testsuite configuration so the CLI targets the same management
+ * endpoint the instance listens on.
+ * @param args the pgagroal-cli arguments (e.g. "status")
+ * @return 0 if pgagroal-cli exited successfully, otherwise 1
+ */
+int
+pgagroal_tsclient_execute_cli(char* args);
+
+/**
+ * Keep one client connected (BEGIN; SELECT pg_sleep(hold_seconds); COMMIT;) and
+ * run a pgagroal-cli management command while it is connected. Regression
+ * harness for issue #946: in pipeline = transaction the CLI was reset by a
+ * worker that had bound the management socket. Fails if the held client did not
+ * run or the CLI did not succeed.
+ * @param user name of the user
+ * @param database name of the database
+ * @param cli_args the pgagroal-cli arguments to run during the hold (e.g. "status")
+ * @param hold_seconds duration of the pg_sleep() hold (coerced to >= 2)
+ * @return 0 if the CLI succeeded while the client was connected, otherwise 1
+ */
+int
+pgagroal_tsclient_cli_during_hold(char* user, char* database, char* cli_args, int hold_seconds);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/libpgagroaltest/tsclient.c
+++ b/test/libpgagroaltest/tsclient.c
@@ -46,6 +46,7 @@
 #include <time.h>
 #include <sys/mman.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 char project_directory[BUFFER_SIZE];
@@ -710,4 +711,95 @@ get_log_file_path()
    memcpy(log_file_path + project_directory_length, PGBENCH_LOG_FILE_TRAIL, log_trail_length);
 
    return log_file_path;
+}
+
+int
+pgagroal_tsclient_execute_cli(char* args)
+{
+   char* configuration_path = NULL;
+   char* cmd = NULL;
+   char* conf = NULL;
+   char* bin_dir = NULL;
+   int ret;
+
+   /* Target the running instance's own config (exported by the test harness) so
+    * the CLI reaches the same management endpoint; fall back to the tsclient
+    * configuration path. */
+   conf = getenv("PGAGROAL_TEST_CONF");
+   if (conf == NULL)
+   {
+      configuration_path = get_configuration_path();
+      conf = configuration_path;
+   }
+   if (conf == NULL)
+   {
+      return 1;
+   }
+
+   /* pgagroal-cli is not installed on PATH during tests; the harness exports its
+    * directory (PGAGROAL_TEST_BIN). */
+   bin_dir = getenv("PGAGROAL_TEST_BIN");
+
+   if (bin_dir != NULL)
+   {
+      cmd = pgagroal_append(cmd, bin_dir);
+      cmd = pgagroal_append_char(cmd, '/');
+   }
+   cmd = pgagroal_append(cmd, "pgagroal-cli -c ");
+   cmd = pgagroal_append(cmd, conf);
+   cmd = pgagroal_append_char(cmd, ' ');
+   cmd = pgagroal_append(cmd, args);
+
+   ret = system(cmd);
+
+   free(cmd);
+   free(configuration_path);
+
+   return (ret == 0) ? 0 : 1;
+}
+
+int
+pgagroal_tsclient_cli_during_hold(char* user, char* database, char* cli_args, int hold_seconds)
+{
+   pid_t hold;
+   int cli_rc;
+   int status;
+
+   if (hold_seconds < 2)
+   {
+      hold_seconds = 3;
+   }
+
+   /* Hold one client connected in a child process so a transaction worker is
+    * live while the CLI runs, reusing the existing hold machinery
+    * (BEGIN; SELECT pg_sleep(n); COMMIT;). */
+   hold = fork();
+   if (hold < 0)
+   {
+      return 1;
+   }
+   if (hold == 0)
+   {
+      int rc = pgagroal_tsclient_execute_concurrent_holds(user, database, 1, hold_seconds);
+      _exit(rc == 0 ? 0 : 1);
+   }
+
+   /* Let the held client connect, then run the management command while it is
+    * still connected. */
+   sleep(1);
+   cli_rc = pgagroal_tsclient_execute_cli(cli_args);
+
+   if (waitpid(hold, &status, 0) < 0)
+   {
+      return 1;
+   }
+
+   /* A false pass is worse than a failure: if the held client never ran, the
+    * CLI would trivially succeed. Require both the hold and the CLI to succeed. */
+   if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+   {
+      return 1;
+   }
+
+   return cli_rc;
 }

--- a/test/testcases/test_cli_transaction.c
+++ b/test/testcases/test_cli_transaction.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 The pgagroal community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <pgagroal.h>
+
+#include <tsclient.h>
+#include <mctf.h>
+
+/*
+ * Regression test for issue #946: in pipeline = transaction, a pgagroal-cli
+ * management command failed with "Connection reset by peer" whenever a client
+ * was connected, because the transaction worker bound MAIN_UDS and stole the
+ * management socket (introduced by #824 / 9dd22c7, fixed in #947).
+ *
+ * The test keeps one client connected through a held transaction and runs a
+ * `pgagroal-cli status` while it is connected; the command must succeed. This
+ * runs against every test configuration; under the transaction-pipeline
+ * configs (test/conf/01, test/conf/02) it exercises the regression, and under
+ * the session/performance configs it is a benign smoke check.
+ */
+MCTF_TEST(test_pgagroal_cli_transaction_client_connected)
+{
+   int rc = 0;
+
+   rc = pgagroal_tsclient_cli_during_hold(user, database, "status", 3);
+   MCTF_ASSERT(rc == 0, cleanup,
+               "pgagroal-cli failed while a client was connected (transaction-mode #946 regression)");
+cleanup:
+   MCTF_FINISH();
+}


### PR DESCRIPTION
 Summary

  Revert the transaction worker socket change from commit 9dd22c7 (#824 (https://github.com/pgagroal/pgagroal/issues/824)) that switched workers from .s.pgagroal.<pid> to MAIN_UDS. That caused workers to steal the CLI management socket `(.s.pgagrshooal.<port>)`, breaking pgagroal-cli with Connection reset by peer when clients are connected in transaction mode.

  Restore per-worker UDS in pipeline_transaction.c; keep the #824 port suffix in network.c.

closes #946 