### PR TITLE
[#939] Fix Clang warnings in pool saturation test and MCTF_SKIP

### DIFF
--- a/test/include/mctf.h
+++ b/test/include/mctf.h
@@ -344,20 +344,17 @@ mctf_format_error(const char* format, ...);
    while (0)
 
 /* Skip test macro */
-#define MCTF_SKIP(...)                                 \
-   do                                                  \
-   {                                                   \
-      mctf_errno = MCTF_CODE_SKIPPED;                  \
-      if (__VA_ARGS__)                                 \
-      {                                                \
-         mctf_errmsg = mctf_format_error(__VA_ARGS__); \
-      }                                                \
-      else                                             \
-      {                                                \
-         mctf_errmsg = strdup("Test skipped");         \
-      }                                                \
-      return MCTF_CODE_SKIPPED;                        \
-   }                                                   \
+#define MCTF_SKIP(...)                              \
+   do                                               \
+   {                                                \
+      mctf_errno = MCTF_CODE_SKIPPED;               \
+      mctf_errmsg = mctf_format_error(__VA_ARGS__); \
+      if (mctf_errmsg == NULL)                      \
+      {                                             \
+         mctf_errmsg = strdup("Test skipped");      \
+      }                                             \
+      return MCTF_CODE_SKIPPED;                     \
+   }                                                \
    while (0)
 
 /* Finish test macro */

--- a/test/testcases/test_pool_saturation.c
+++ b/test/testcases/test_pool_saturation.c
@@ -73,7 +73,7 @@ cleanup:
  * succeed.
  *
  * Parameters are derived from the live configuration so the test is meaningful
- * against every test/conf/* profile exercised by run-configs. Configurations
+ * against every test/conf profile exercised by run-configs. Configurations
  * whose blocking_timeout is too small to absorb one hold cycle are skipped:
  * there the waiters are expected to time out regardless of #875, so the test
  * could not isolate the regression.


### PR DESCRIPTION
Clears the two Clang warnings reported in #939.

- **`test_pool_saturation.c`** - a doc comment contained `test/conf/*`; the `/*` trips `-Wcomment` ("'/*' within block comment"). Reworded to drop the glob.
- **`MCTF_SKIP()`** (`test/include/mctf.h`) - `if (__VA_ARGS__)` evaluates the format string plus its arguments as a comma expression, so a call with arguments (e.g. `MCTF_SKIP("... %d ...", n)`) discards the format string as the left operand -> `-Wunused-value`. Now always formats via `mctf_format_error()` - matching how the `MCTF_ASSERT_*` macros already use it - and falls back to a default message if it returns `NULL`. All current callers pass a format string, and `MCTF_SKIP()` with no argument was already a syntax error, so behaviour is unchanged; the skip message is still formatted correctly.

Clang build is warning-free after the change.

close #939