### PR TITLE
[#954] Bump Rocky Linux reference image to Rocky 10

### DIFF
--- a/contrib/docker/Dockerfile.rocky10
+++ b/contrib/docker/Dockerfile.rocky10
@@ -24,9 +24,9 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-FROM rockylinux:9 AS builder
+FROM rockylinux/rockylinux:10 AS builder
 
-RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm && \
     dnf -y upgrade && \
     dnf install -y dnf-plugins-core && \
     dnf config-manager --set-enabled crb && \
@@ -69,9 +69,9 @@ RUN cd build && \
     cmake .. -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_INSTALL_RPATH=/usr/local/lib && \
     make install
 
-FROM rockylinux:9
+FROM rockylinux/rockylinux:10
 
-RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm && \
     dnf -y upgrade && \
     dnf install -y dnf-plugins-core && \
     dnf config-manager --set-enabled crb && \

--- a/doc/manual/en/13-docker.md
+++ b/doc/manual/en/13-docker.md
@@ -81,17 +81,17 @@ docker build -t pgagroal:latest -f ./contrib/docker/Dockerfile.alpine .
 podman build -t pgagroal:latest -f ./contrib/docker/Dockerfile.alpine .
 ```
 
-2. **Rocky Linux 9-based image**
+2. **Rocky Linux 10-based image**
 
 **Using Docker**
 ```sh
-docker build -t pgagroal:latest -f ./contrib/docker/Dockerfile.rocky9 .
+docker build -t pgagroal:latest -f ./contrib/docker/Dockerfile.rocky10 .
 ```
 
 **Using Podman**
 
 ```sh
-podman build -t pgagroal:latest -f ./contrib/docker/Dockerfile.rocky9 .
+podman build -t pgagroal:latest -f ./contrib/docker/Dockerfile.rocky10 .
 ```
 
 **Step 4: Run pgagroal as a Docker Container**


### PR DESCRIPTION
Rocky Linux 10 is GA, so the `contrib/docker/` reference image should track it (requested by @jesperpedersen).

This is not a plain tag bump: the Docker Hub official `library/rockylinux` image was discontinued after Rocky 9, so `rockylinux:10` does not exist. Rocky 10 ships under the `rockylinux/rockylinux` namespace, so both stages move to `rockylinux/rockylinux:10`. EPEL is bumped to `epel-release-latest-10`.

Changes:
- Rename `contrib/docker/Dockerfile.rocky9` to `Dockerfile.rocky10`.
- `FROM rockylinux:9` -> `FROM rockylinux/rockylinux:10` (builder + runtime stages).
- EPEL `epel-release-latest-9` -> `epel-release-latest-10` (both stages).
- Update the `docker build` / `podman build` examples in `doc/manual/en/13-docker.md`.

Verified locally: `docker build -f contrib/docker/Dockerfile.rocky10 .` builds on `Rocky Linux 10.2 (Red Quartz)`, all three binaries run, and `ldd` shows every shared library resolves.

The separate CI testing-platform move to Rocky 10 is tracked in #819 and is out of scope here.

close #954
