### PR TITLE
Pool backend TLS 1.3 sessions

### DIFF
--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -115,6 +115,8 @@ extern "C" {
 
 #define NUMBER_OF_SECURITY_MESSAGES    5
 
+#define TLS_CONTEXT_BUFFER_SIZE        256
+
 #define STATE_NOTINIT                  -2
 #define STATE_INIT                     -1
 #define STATE_FREE                     0
@@ -434,6 +436,9 @@ struct connection
    time_t timestamp;       /**< The last used timestamp */
    pid_t pid;              /**< The associated process id */
    int fd;                 /**< The descriptor */
+
+   size_t tls_context_length;                 /**< Length of the parked backend TLS context, 0 if none */
+   char tls_context[TLS_CONTEXT_BUFFER_SIZE]; /**< Serialized backend TLS context for pool resumption */
 } __attribute__((aligned(64)));
 
 /** @struct hba

--- a/src/include/tls.h
+++ b/src/include/tls.h
@@ -35,6 +35,7 @@ extern "C" {
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #include <openssl/ssl.h>
 
@@ -43,6 +44,36 @@ extern "C" {
 #define PGAGROAL_TLS_CLOSED  2
 #define PGAGROAL_TLS_ERROR   (-1)
 
+/* TLS 1.3 AEAD cipher suites for the owned record layer */
+#define PGAGROAL_TLS_AEAD_AES_128_GCM 1
+#define PGAGROAL_TLS_AEAD_AES_256_GCM 2
+
+/* Maximum size of one TLS 1.3 record on the wire (header + 2^14 + expansion) */
+#define PGAGROAL_TLS_RECORD_MAX 16645
+
+/** @struct tls_record_dir
+ * One direction of an owned TLS 1.3 record stream.
+ */
+struct tls_record_dir
+{
+   unsigned char secret[48]; /**< The application traffic secret (<= SHA-384 size) */
+   size_t secret_len;        /**< The secret length (32 for SHA-256, 48 for SHA-384) */
+   unsigned char key[32];    /**< The derived AEAD key */
+   unsigned char iv[12];     /**< The derived AEAD static IV */
+   uint64_t seq;             /**< The record sequence number */
+};
+
+/** @struct tls_record
+ * A socket and process independent TLS 1.3 record context. It is serializable
+ * so it can move between the pool and a worker without re-handshaking the backend.
+ */
+struct tls_record
+{
+   int aead;                    /**< The AEAD suite (PGAGROAL_TLS_AEAD_*) */
+   struct tls_record_dir read;  /**< Records received from the peer */
+   struct tls_record_dir write; /**< Records sent to the peer */
+};
+
 /** @struct tls
  * A TLS context driven through memory BIOs instead of a socket, so the
  * cryptographic state is independent of the TCP connection lifecycle.
@@ -50,12 +81,20 @@ extern "C" {
  */
 struct tls
 {
-   SSL* ssl;                /**< The OpenSSL connection */
-   BIO* rbio;               /**< Inbound ciphertext: network -> engine */
-   BIO* wbio;               /**< Outbound ciphertext: engine -> network */
-   int fd;                  /**< The socket bound to this context, or -1 if none */
-   bool server;             /**< true for the accepting side */
-   bool handshake_complete; /**< true once the handshake has completed */
+   SSL* ssl;                                    /**< The OpenSSL connection */
+   BIO* rbio;                                   /**< Inbound ciphertext: network -> engine */
+   BIO* wbio;                                   /**< Outbound ciphertext: engine -> network */
+   int fd;                                      /**< The socket bound to this context, or -1 if none */
+   bool server;                                 /**< true for the accepting side */
+   bool handshake_complete;                     /**< true once the handshake has completed */
+   unsigned char client_secret[48];             /**< Captured TLS 1.3 client application traffic secret */
+   unsigned char server_secret[48];             /**< Captured TLS 1.3 server application traffic secret */
+   size_t secret_len;                           /**< Length of the captured secrets */
+   int secret_mask;                             /**< 0x1 client + 0x2 server captured */
+   bool owned;                                  /**< true once I/O is driven by our own record layer */
+   struct tls_record record;                    /**< Owned record-layer state (valid when owned) */
+   size_t rbuf_len;                             /**< Bytes buffered for inbound record framing */
+   unsigned char rbuf[PGAGROAL_TLS_RECORD_MAX]; /**< Inbound TLS record framing buffer */
 };
 
 /**
@@ -259,6 +298,87 @@ pgagroal_create_ssl_server(SSL_CTX* ctx, char* key_file, char* cert_file, char* 
  */
 int
 pgagroal_create_ssl_client(SSL_CTX* ctx, char* key, char* cert, char* root, int socket, SSL** ssl);
+
+/**
+ * Harvest the negotiated TLS 1.3 record state (cipher + application traffic
+ * secrets) from a completed handshake into a serializable record context. The
+ * read/write directions are assigned according to the context's role. Requires
+ * TLS 1.3; fails otherwise.
+ * @param tls The context, with a completed handshake
+ * @param record The resulting serializable record context
+ * @return PGAGROAL_TLS_OK upon success, otherwise PGAGROAL_TLS_ERROR
+ */
+int
+pgagroal_tls_harvest(struct tls* tls, struct tls_record* record);
+
+/**
+ * Switch a context to its own serializable record layer after the handshake:
+ * harvest the negotiated TLS 1.3 state, capture any buffered ciphertext, and
+ * route all further socket I/O through our record layer instead of OpenSSL.
+ * Requires TLS 1.3.
+ * @param tls The context, with a completed handshake
+ * @return PGAGROAL_TLS_OK upon success, otherwise PGAGROAL_TLS_ERROR
+ */
+int
+pgagroal_tls_own(struct tls* tls);
+
+/**
+ * Initialize one record direction from its TLS 1.3 application traffic secret
+ * @param dir The direction
+ * @param aead The AEAD suite (PGAGROAL_TLS_AEAD_*)
+ * @param secret The traffic secret
+ * @param secret_len The secret length
+ * @return PGAGROAL_TLS_OK upon success, otherwise PGAGROAL_TLS_ERROR
+ */
+int
+pgagroal_tls_record_dir_init(struct tls_record_dir* dir, int aead, const unsigned char* secret, size_t secret_len);
+
+/**
+ * Seal application plaintext into a TLS 1.3 record (advances the write sequence)
+ * @param record The record context
+ * @param plaintext The plaintext
+ * @param plaintext_len The plaintext length
+ * @param out The destination buffer (>= plaintext_len + 22)
+ * @param cap The buffer capacity
+ * @param out_len The produced record length
+ * @return PGAGROAL_TLS_OK upon success, otherwise PGAGROAL_TLS_ERROR
+ */
+int
+pgagroal_tls_record_seal(struct tls_record* record, const unsigned char* plaintext, size_t plaintext_len, unsigned char* out, size_t cap, size_t* out_len);
+
+/**
+ * Open a TLS 1.3 record into application plaintext (advances the read sequence)
+ * @param record The record context
+ * @param rec The record bytes
+ * @param rec_len The record length
+ * @param out The destination buffer
+ * @param cap The buffer capacity
+ * @param out_len The produced plaintext length
+ * @return PGAGROAL_TLS_OK upon success, otherwise PGAGROAL_TLS_ERROR
+ */
+int
+pgagroal_tls_record_open(struct tls_record* record, const unsigned char* rec, size_t rec_len, unsigned char* out, size_t cap, size_t* out_len);
+
+/**
+ * Serialize a record context to bytes so it can move between processes
+ * @param record The record context
+ * @param buf The destination buffer
+ * @param cap The buffer capacity
+ * @param len The produced length
+ * @return PGAGROAL_TLS_OK upon success, otherwise PGAGROAL_TLS_ERROR
+ */
+int
+pgagroal_tls_record_export(const struct tls_record* record, unsigned char* buf, size_t cap, size_t* len);
+
+/**
+ * Restore a record context from its serialized bytes
+ * @param buf The serialized bytes
+ * @param len The length
+ * @param record The resulting context
+ * @return PGAGROAL_TLS_OK upon success, otherwise PGAGROAL_TLS_ERROR
+ */
+int
+pgagroal_tls_record_import(const unsigned char* buf, size_t len, struct tls_record* record);
 
 #ifdef __cplusplus
 }

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -504,8 +504,15 @@ pgagroal_return_connection(int slot, SSL* ssl, bool transaction_mode)
    signed char in_use;
    signed char age_check;
    int transfer_fd = -1;
+   struct tls* t = NULL;
+   bool tls_owned = false;
 
    config = (struct main_configuration*)shmem;
+
+   /* Park a backend whose record layer we own: its TLS 1.3 state is serializable.
+    * Confined to non-transaction mode -- only use_pooled_connection resumes it. */
+   t = pgagroal_tls_from_ssl(ssl);
+   tls_owned = (t != NULL && t->owned && !transaction_mode);
 
    /* Kill the connection, if it lives longer than max_connection_age */
    if (pgagroal_time_is_valid(config->max_connection_age))
@@ -538,7 +545,7 @@ pgagroal_return_connection(int slot, SSL* ssl, bool transaction_mode)
        (config->connections[slot].has_security != SECURITY_SCRAM256 ||
         (config->connections[slot].has_security == SECURITY_SCRAM256 &&
          (config->authquery || pgagroal_user_known(config->connections[slot].username)))) &&
-       ssl == NULL)
+       (ssl == NULL || tls_owned))
    {
       state = atomic_load(&config->states[slot]);
 
@@ -553,6 +560,25 @@ pgagroal_return_connection(int slot, SSL* ssl, bool transaction_mode)
             {
                goto kill_connection;
             }
+         }
+
+         /* Park the serialized context for a later checkout to resume. Buffered
+          * ciphertext would be lost on worker exit, so only park when rbuf is empty. */
+         if (tls_owned)
+         {
+            if (t->rbuf_len != 0)
+            {
+               pgagroal_log_debug("pgagroal_return_connection: Slot %d cannot park (%zu bytes buffered)", slot, t->rbuf_len);
+               goto kill_connection;
+            }
+            if (pgagroal_tls_record_export(&t->record, (unsigned char*)config->connections[slot].tls_context,
+                                           sizeof(config->connections[slot].tls_context),
+                                           &config->connections[slot].tls_context_length))
+            {
+               pgagroal_log_debug("pgagroal_return_connection: Slot %d TLS context export failed", slot);
+               goto kill_connection;
+            }
+            pgagroal_log_debug("pgagroal_return_connection: Slot %d parked TLS context (%zu bytes)", slot, config->connections[slot].tls_context_length);
          }
 
          pgagroal_tracking_event_slot(TRACKER_RETURN_CONNECTION_SUCCESS, slot);
@@ -757,6 +783,10 @@ pgagroal_kill_connection(int slot, SSL* ssl)
       config->connections[slot].security_lengths[i] = 0;
       memset(&config->connections[slot].security_messages[i], 0, SECURITY_BUFFER_SIZE);
    }
+
+   /* The parked TLS context holds session secrets; cleanse before recycling the slot. */
+   pgagroal_cleanse(config->connections[slot].tls_context, sizeof(config->connections[slot].tls_context));
+   config->connections[slot].tls_context_length = 0;
 
    config->connections[slot].backend_pid = 0;
    config->connections[slot].backend_secret = 0;

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -79,6 +79,7 @@ static int get_auth_type(struct message* msg, int* auth_type);
 static int compare_auth_response(struct message* orig, struct message* response, int auth_type);
 
 static int use_pooled_connection(SSL* c_ssl, int client_fd, int slot, char* username, char* database, int hba_method, SSL** server_ssl);
+static int resume_backend_tls(int slot, SSL** server_ssl);
 static int use_unpooled_connection(struct message* msg, SSL* c_ssl, int client_fd, int slot,
                                    char* username, int hba_method, SSL** server_ssl);
 static int client_trust(SSL* c_ssl, int client_fd, char* username, char* password, int slot);
@@ -1372,8 +1373,60 @@ compare_auth_response(struct message* orig, struct message* response, int auth_t
    return 1;
 }
 
+/* Resume a parked backend TLS context on checkout. The carrier SSL is never
+ * handshaken; only the imported record layer moves traffic. */
 static int
-use_pooled_connection(SSL* c_ssl, int client_fd, int slot, char* username, char* database, int hba_method, SSL** server_ssl __attribute__((unused)))
+resume_backend_tls(int slot, SSL** server_ssl)
+{
+   SSL_CTX* ctx = NULL;
+   struct tls* t = NULL;
+   struct main_configuration* config;
+
+   config = (struct main_configuration*)shmem;
+
+   if (pgagroal_create_ssl_ctx(true, &ctx))
+   {
+      pgagroal_log_error("resume_backend_tls: CTX failed for slot %d", slot);
+      goto error;
+   }
+
+   if (pgagroal_tls_create(ctx, false, &t))
+   {
+      pgagroal_log_error("resume_backend_tls: wrapper failed for slot %d", slot);
+      goto error;
+   }
+
+   if (pgagroal_tls_record_import((const unsigned char*)config->connections[slot].tls_context,
+                                  config->connections[slot].tls_context_length, &t->record))
+   {
+      pgagroal_log_error("resume_backend_tls: context import failed for slot %d", slot);
+      goto error;
+   }
+
+   t->owned = true;
+   pgagroal_tls_set_fd(t, config->connections[slot].fd);
+   *server_ssl = t->ssl;
+
+   pgagroal_log_debug("resume_backend_tls: Slot %d resumed parked TLS context (%zu bytes)", slot, config->connections[slot].tls_context_length);
+
+   return 0;
+
+error:
+
+   if (t != NULL)
+   {
+      pgagroal_close_ssl(t->ssl);
+   }
+   else if (ctx != NULL)
+   {
+      SSL_CTX_free(ctx);
+   }
+
+   return 1;
+}
+
+static int
+use_pooled_connection(SSL* c_ssl, int client_fd, int slot, char* username, char* database, int hba_method, SSL** server_ssl)
 {
    int status = MESSAGE_STATUS_ERROR;
    struct main_configuration* config = NULL;
@@ -1384,6 +1437,16 @@ use_pooled_connection(SSL* c_ssl, int client_fd, int slot, char* username, char*
    database = resolve_database_alias(username, database);
 
    config = (struct main_configuration*)shmem;
+
+   /* Resume the parked backend TLS session, if one was stored on return. Without
+    * this the proxy would speak plaintext into an encrypted backend socket. */
+   if (config->connections[slot].tls_context_length > 0)
+   {
+      if (resume_backend_tls(slot, server_ssl))
+      {
+         goto error;
+      }
+   }
 
    password = get_frontend_password(username);
    if (password == NULL)
@@ -5289,6 +5352,15 @@ create_client_tls_connection(int fd, SSL** ssl, char* tls_key_file, char* tls_ce
       goto error;
    }
 
+   /* The record layer supports only TLS 1.3 AES-GCM; enforce it on the backend so
+    * a session can always be parked and no weaker protocol/cipher is negotiated. */
+   if (SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION) == 0 ||
+       SSL_CTX_set_ciphersuites(ctx, "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384") == 0)
+   {
+      pgagroal_log_error("Backend TLS 1.3 policy failed");
+      goto error;
+   }
+
    /* Create a socket-decoupled client context */
    if (pgagroal_tls_create_client(ctx, tls_key_file, tls_cert_file, tls_ca_file, &t))
    {
@@ -5308,6 +5380,10 @@ create_client_tls_connection(int fd, SSL** ssl, char* tls_key_file, char* tls_ce
       pgagroal_log_error("Backend TLS handshake failed on FD %d: %s", fd, ERR_reason_error_string(err));
       goto error;
    }
+
+   /* Take over the record layer for a parkable TLS 1.3 context. If this fails the
+    * connection stays OpenSSL-backed -- it still works, it just cannot be parked. */
+   pgagroal_tls_own(t);
 
    *ssl = t->ssl;
 

--- a/src/libpgagroal/tls.c
+++ b/src/libpgagroal/tls.c
@@ -32,12 +32,16 @@
 
 #include <errno.h>
 #include <stddef.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
 #include <openssl/bio.h>
+#include <openssl/core_names.h>
 #include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/kdf.h>
 #include <openssl/x509.h>
 
 static int
@@ -54,6 +58,57 @@ classify(SSL* ssl, int rc)
          return PGAGROAL_TLS_CLOSED;
       default:
          return PGAGROAL_TLS_ERROR;
+   }
+}
+
+/* Capture the TLS 1.3 application traffic secrets as OpenSSL derives them,
+ * recovering the owning context via the SSL app-data back-pointer. */
+static void
+keylog_cb(const SSL* ssl, const char* line)
+{
+   static const char* const labels[2] = {"CLIENT_TRAFFIC_SECRET_0 ", "SERVER_TRAFFIC_SECRET_0 "};
+   struct tls* t = (struct tls*)SSL_get_app_data(ssl);
+   int which;
+
+   if (t == NULL)
+   {
+      return;
+   }
+
+   for (which = 0; which < 2; which++)
+   {
+      size_t llen = strlen(labels[which]);
+      const char* hex;
+      unsigned char* dst;
+      size_t n = 0;
+
+      if (strncmp(line, labels[which], llen) != 0)
+      {
+         continue;
+      }
+
+      /* line = "<LABEL> <client_random_hex> <secret_hex>" */
+      hex = strchr(line + llen, ' ');
+      if (hex == NULL)
+      {
+         return;
+      }
+      hex++;
+
+      dst = (which == 0) ? t->client_secret : t->server_secret;
+      while (hex[0] != '\0' && hex[1] != '\0' && hex[0] != '\n' && n < 48)
+      {
+         unsigned int b;
+         if (sscanf(hex, "%2x", &b) != 1)
+         {
+            break;
+         }
+         dst[n++] = (unsigned char)b;
+         hex += 2;
+      }
+      t->secret_len = n;
+      t->secret_mask |= (which == 0) ? 0x1 : 0x2;
+      return;
    }
 }
 
@@ -101,6 +156,9 @@ pgagroal_tls_create(SSL_CTX* ctx, bool server, struct tls** tls)
 
    /* Back-pointer so the I/O layer can recover the wrapper from the SSL object */
    SSL_set_app_data(t->ssl, t);
+
+   /* Capture the TLS 1.3 traffic secrets during the handshake for later harvest */
+   SSL_CTX_set_keylog_callback(ctx, keylog_cb);
 
    if (server)
    {
@@ -411,6 +469,86 @@ socket_fill(struct tls* tls, int fd)
    return pgagroal_tls_feed(tls, buf, (size_t)n, NULL);
 }
 
+/* Owned-mode read: frame one TLS record off the socket and decrypt it ourselves. */
+static int
+owned_read(struct tls* tls, int fd, void* buf, size_t cap, size_t* nread)
+{
+   for (;;)
+   {
+      if (tls->rbuf_len >= 5)
+      {
+         size_t body = ((size_t)tls->rbuf[3] << 8) | (size_t)tls->rbuf[4];
+         size_t total = 5 + body;
+
+         if (total > sizeof(tls->rbuf))
+         {
+            return PGAGROAL_TLS_ERROR;
+         }
+         if (tls->rbuf_len >= total)
+         {
+            int rc = pgagroal_tls_record_open(&tls->record, tls->rbuf, total, buf, cap, nread);
+            memmove(tls->rbuf, tls->rbuf + total, tls->rbuf_len - total);
+            tls->rbuf_len -= total;
+            return rc;
+         }
+      }
+
+      {
+         size_t room = sizeof(tls->rbuf) - tls->rbuf_len;
+         ssize_t n;
+
+         if (room == 0)
+         {
+            return PGAGROAL_TLS_ERROR;
+         }
+         do
+         {
+            n = read(fd, tls->rbuf + tls->rbuf_len, room);
+         }
+         while (n < 0 && errno == EINTR);
+         if (n == 0)
+         {
+            return PGAGROAL_TLS_CLOSED;
+         }
+         if (n < 0)
+         {
+            return PGAGROAL_TLS_ERROR;
+         }
+         tls->rbuf_len += (size_t)n;
+      }
+   }
+}
+
+/* Owned-mode write: seal application data into TLS records and write them out. */
+static int
+owned_write(struct tls* tls, int fd, const unsigned char* buf, size_t len)
+{
+   unsigned char rec[PGAGROAL_TLS_RECORD_MAX];
+   size_t off = 0;
+
+   while (off < len)
+   {
+      size_t chunk = len - off;
+      size_t rlen = 0;
+
+      if (chunk > 16384)
+      {
+         chunk = 16384; /* one TLS record carries at most 2^14 plaintext bytes */
+      }
+      if (pgagroal_tls_record_seal(&tls->record, buf + off, chunk, rec, sizeof(rec), &rlen) != PGAGROAL_TLS_OK)
+      {
+         return PGAGROAL_TLS_ERROR;
+      }
+      if (socket_write_all(fd, rec, rlen) != PGAGROAL_TLS_OK)
+      {
+         return PGAGROAL_TLS_ERROR;
+      }
+      off += chunk;
+   }
+
+   return PGAGROAL_TLS_OK;
+}
+
 int
 pgagroal_tls_socket_handshake(struct tls* tls, int fd)
 {
@@ -457,6 +595,11 @@ pgagroal_tls_socket_read(struct tls* tls, int fd, void* buf, size_t cap, size_t*
       return PGAGROAL_TLS_ERROR;
    }
 
+   if (tls->owned)
+   {
+      return owned_read(tls, fd, buf, cap, nread);
+   }
+
    for (;;)
    {
       int rc = pgagroal_tls_read(tls, buf, cap, nread);
@@ -490,6 +633,11 @@ pgagroal_tls_socket_write(struct tls* tls, int fd, const void* buf, size_t len)
    if (tls == NULL || fd < 0 || (buf == NULL && len > 0))
    {
       return PGAGROAL_TLS_ERROR;
+   }
+
+   if (tls->owned)
+   {
+      return owned_write(tls, fd, (const unsigned char*)buf, len);
    }
 
    while (off < len)
@@ -884,4 +1032,500 @@ error:
    SSL_CTX_free(ctx);
 
    return 1;
+}
+
+/* The fixed AEAD parameters for each supported TLS 1.3 suite. */
+static int
+aead_lookup(int aead, const EVP_CIPHER** cipher, size_t* key_len, const char** hash)
+{
+   switch (aead)
+   {
+      case PGAGROAL_TLS_AEAD_AES_128_GCM:
+         *cipher = EVP_aes_128_gcm();
+         *key_len = 16;
+         *hash = "SHA256";
+         return PGAGROAL_TLS_OK;
+      case PGAGROAL_TLS_AEAD_AES_256_GCM:
+         *cipher = EVP_aes_256_gcm();
+         *key_len = 32;
+         *hash = "SHA384";
+         return PGAGROAL_TLS_OK;
+      default:
+         return PGAGROAL_TLS_ERROR;
+   }
+}
+
+/* RFC 8446 7.1 HKDF-Expand-Label with an empty context. */
+static int
+hkdf_expand_label(const char* hash, const unsigned char* secret, size_t secret_len,
+                  const char* label, unsigned char* out, size_t out_len)
+{
+   unsigned char info[256];
+   size_t ilen = 0;
+   char full[64];
+   int flen;
+   EVP_KDF* kdf;
+   EVP_KDF_CTX* kctx;
+   OSSL_PARAM params[5];
+   int ok;
+
+   flen = snprintf(full, sizeof(full), "tls13 %s", label);
+   if (flen <= 0)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   info[ilen++] = (unsigned char)(out_len >> 8);
+   info[ilen++] = (unsigned char)(out_len & 0xff);
+   info[ilen++] = (unsigned char)flen;
+   memcpy(info + ilen, full, (size_t)flen);
+   ilen += (size_t)flen;
+   info[ilen++] = 0x00;
+
+   kdf = EVP_KDF_fetch(NULL, "HKDF", NULL);
+   if (kdf == NULL)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+   kctx = EVP_KDF_CTX_new(kdf);
+   EVP_KDF_free(kdf);
+   if (kctx == NULL)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   params[0] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_MODE, "EXPAND_ONLY", 0);
+   params[1] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, (char*)hash, 0);
+   params[2] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY, (void*)secret, secret_len);
+   params[3] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO, info, ilen);
+   params[4] = OSSL_PARAM_construct_end();
+
+   ok = EVP_KDF_derive(kctx, out, out_len, params) > 0;
+   EVP_KDF_CTX_free(kctx);
+
+   return ok ? PGAGROAL_TLS_OK : PGAGROAL_TLS_ERROR;
+}
+
+/* Per-record nonce: static IV XOR the 64-bit sequence number (RFC 8446 5.3). */
+static void
+build_nonce(const unsigned char* iv, uint64_t seq, unsigned char* nonce)
+{
+   int i;
+
+   memcpy(nonce, iv, 12);
+   for (i = 0; i < 8; i++)
+   {
+      nonce[11 - i] ^= (unsigned char)(seq >> (8 * i));
+   }
+}
+
+static int
+aead_seal(const EVP_CIPHER* cipher, const unsigned char* key, const unsigned char* nonce,
+          const unsigned char* aad, size_t aad_len,
+          const unsigned char* pt, size_t pt_len,
+          unsigned char* ct, unsigned char* tag)
+{
+   EVP_CIPHER_CTX* c = EVP_CIPHER_CTX_new();
+   int len;
+   int rc = 0;
+
+   if (c == NULL)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+   if (EVP_EncryptInit_ex(c, cipher, NULL, NULL, NULL) != 1 ||
+       EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_AEAD_SET_IVLEN, 12, NULL) != 1 ||
+       EVP_EncryptInit_ex(c, NULL, NULL, key, nonce) != 1 ||
+       EVP_EncryptUpdate(c, NULL, &len, aad, (int)aad_len) != 1 ||
+       EVP_EncryptUpdate(c, ct, &len, pt, (int)pt_len) != 1 ||
+       EVP_EncryptFinal_ex(c, ct + len, &len) != 1 ||
+       EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_AEAD_GET_TAG, 16, tag) != 1)
+   {
+      goto done;
+   }
+   rc = 1;
+done:
+   EVP_CIPHER_CTX_free(c);
+   return rc ? PGAGROAL_TLS_OK : PGAGROAL_TLS_ERROR;
+}
+
+static int
+aead_open(const EVP_CIPHER* cipher, const unsigned char* key, const unsigned char* nonce,
+          const unsigned char* aad, size_t aad_len,
+          const unsigned char* ct, size_t ct_len,
+          const unsigned char* tag, unsigned char* out, int* out_len)
+{
+   EVP_CIPHER_CTX* c = EVP_CIPHER_CTX_new();
+   int len = 0;
+   int rc = 0;
+
+   if (c == NULL)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+   if (EVP_DecryptInit_ex(c, cipher, NULL, NULL, NULL) != 1 ||
+       EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_AEAD_SET_IVLEN, 12, NULL) != 1 ||
+       EVP_DecryptInit_ex(c, NULL, NULL, key, nonce) != 1 ||
+       EVP_DecryptUpdate(c, NULL, &len, aad, (int)aad_len) != 1 ||
+       EVP_DecryptUpdate(c, out, &len, ct, (int)ct_len) != 1)
+   {
+      goto done;
+   }
+   *out_len = len;
+   if (EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_AEAD_SET_TAG, 16, (void*)tag) != 1 ||
+       EVP_DecryptFinal_ex(c, out + len, &len) != 1)
+   {
+      goto done; /* tag mismatch */
+   }
+   *out_len += len;
+   rc = 1;
+done:
+   EVP_CIPHER_CTX_free(c);
+   return rc ? PGAGROAL_TLS_OK : PGAGROAL_TLS_ERROR;
+}
+
+int
+pgagroal_tls_record_dir_init(struct tls_record_dir* dir, int aead, const unsigned char* secret, size_t secret_len)
+{
+   const EVP_CIPHER* cipher;
+   size_t key_len;
+   const char* hash;
+
+   if (dir == NULL || secret == NULL || secret_len > sizeof(dir->secret))
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+   if (aead_lookup(aead, &cipher, &key_len, &hash) != PGAGROAL_TLS_OK)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   memcpy(dir->secret, secret, secret_len);
+   dir->secret_len = secret_len;
+
+   if (hkdf_expand_label(hash, secret, secret_len, "key", dir->key, key_len) != PGAGROAL_TLS_OK ||
+       hkdf_expand_label(hash, secret, secret_len, "iv", dir->iv, sizeof(dir->iv)) != PGAGROAL_TLS_OK)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+   dir->seq = 0;
+
+   return PGAGROAL_TLS_OK;
+}
+
+int
+pgagroal_tls_record_seal(struct tls_record* record, const unsigned char* plaintext, size_t plaintext_len, unsigned char* out, size_t cap, size_t* out_len)
+{
+   const EVP_CIPHER* cipher;
+   size_t key_len;
+   const char* hash;
+   unsigned char nonce[12];
+   unsigned char inner[16384];
+   size_t inner_len;
+   size_t record_len;
+
+   if (out_len != NULL)
+   {
+      *out_len = 0;
+   }
+   if (record == NULL || (plaintext == NULL && plaintext_len > 0) || out == NULL)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+   if (aead_lookup(record->aead, &cipher, &key_len, &hash) != PGAGROAL_TLS_OK)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   inner_len = plaintext_len + 1; /* + inner content type */
+   if (inner_len > sizeof(inner))
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+   record_len = 5 + inner_len + 16; /* header + ciphertext + tag */
+   if (cap < record_len)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   memcpy(inner, plaintext, plaintext_len);
+   inner[plaintext_len] = 0x17; /* TLSInnerPlaintext content type = application_data */
+
+   out[0] = 0x17;
+   out[1] = 0x03;
+   out[2] = 0x03;
+   out[3] = (unsigned char)((inner_len + 16) >> 8);
+   out[4] = (unsigned char)((inner_len + 16) & 0xff);
+
+   build_nonce(record->write.iv, record->write.seq, nonce);
+
+   if (aead_seal(cipher, record->write.key, nonce, out, 5, inner, inner_len,
+                 out + 5, out + 5 + inner_len) != PGAGROAL_TLS_OK)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   record->write.seq++;
+   if (out_len != NULL)
+   {
+      *out_len = record_len;
+   }
+
+   return PGAGROAL_TLS_OK;
+}
+
+int
+pgagroal_tls_record_open(struct tls_record* record, const unsigned char* rec, size_t rec_len, unsigned char* out, size_t cap, size_t* out_len)
+{
+   const EVP_CIPHER* cipher;
+   size_t key_len;
+   const char* hash;
+   unsigned char nonce[12];
+   unsigned char inner[16384];
+   int inner_len = 0;
+   size_t body_len;
+   size_t ct_len;
+
+   if (out_len != NULL)
+   {
+      *out_len = 0;
+   }
+   if (record == NULL || rec == NULL || out == NULL || rec_len < 5 + 16 + 1)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+   if (aead_lookup(record->aead, &cipher, &key_len, &hash) != PGAGROAL_TLS_OK)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   body_len = ((size_t)rec[3] << 8) | (size_t)rec[4];
+   if (body_len < 16 || 5 + body_len > rec_len || body_len - 16 > sizeof(inner))
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+   ct_len = body_len - 16;
+
+   build_nonce(record->read.iv, record->read.seq, nonce);
+
+   /* AAD is the 5-byte record header */
+   if (aead_open(cipher, record->read.key, nonce, rec, 5,
+                 rec + 5, ct_len, rec + 5 + ct_len, inner, &inner_len) != PGAGROAL_TLS_OK)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   /* TLSInnerPlaintext = content || content_type || zero padding */
+   while (inner_len > 0 && inner[inner_len - 1] == 0x00)
+   {
+      inner_len--;
+   }
+   if (inner_len <= 0)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+   /* Resume only application_data (0x17); fail closed on a post-handshake record
+    * or alert rather than hand non-application bytes up. PG sends none mid-session. */
+   if (inner[inner_len - 1] != 0x17)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+   inner_len--; /* drop the content type byte */
+
+   if ((size_t)inner_len > cap)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+   memcpy(out, inner, (size_t)inner_len);
+   record->read.seq++;
+   if (out_len != NULL)
+   {
+      *out_len = (size_t)inner_len;
+   }
+
+   return PGAGROAL_TLS_OK;
+}
+
+static void
+export_dir(unsigned char** p, const struct tls_record_dir* dir)
+{
+   int i;
+
+   *(*p)++ = (unsigned char)dir->secret_len;
+   memcpy(*p, dir->secret, dir->secret_len);
+   *p += dir->secret_len;
+   for (i = 0; i < 8; i++)
+   {
+      *(*p)++ = (unsigned char)(dir->seq >> (8 * (7 - i)));
+   }
+}
+
+static int
+import_dir(const unsigned char** p, const unsigned char* end, int aead, struct tls_record_dir* dir)
+{
+   size_t sl;
+   uint64_t seq = 0;
+   int i;
+
+   if (*p >= end)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+   sl = *(*p)++;
+   if (sl > sizeof(dir->secret) || *p + sl + 8 > end)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+   if (pgagroal_tls_record_dir_init(dir, aead, *p, sl) != PGAGROAL_TLS_OK)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+   *p += sl;
+   for (i = 0; i < 8; i++)
+   {
+      seq = (seq << 8) | (uint64_t)(*(*p)++);
+   }
+   dir->seq = seq;
+
+   return PGAGROAL_TLS_OK;
+}
+
+int
+pgagroal_tls_record_export(const struct tls_record* record, unsigned char* buf, size_t cap, size_t* len)
+{
+   unsigned char* p = buf;
+   size_t need;
+
+   if (len != NULL)
+   {
+      *len = 0;
+   }
+   if (record == NULL || buf == NULL)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   need = 2 + (1 + record->read.secret_len + 8) + (1 + record->write.secret_len + 8);
+   if (cap < need)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   *p++ = 1; /* format version */
+   *p++ = (unsigned char)record->aead;
+   export_dir(&p, &record->read);
+   export_dir(&p, &record->write);
+
+   if (len != NULL)
+   {
+      *len = (size_t)(p - buf);
+   }
+
+   return PGAGROAL_TLS_OK;
+}
+
+int
+pgagroal_tls_record_import(const unsigned char* buf, size_t len, struct tls_record* record)
+{
+   const unsigned char* p = buf;
+   const unsigned char* end = buf + len;
+
+   if (buf == NULL || record == NULL || len < 2)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   memset(record, 0, sizeof(*record));
+
+   if (*p++ != 1) /* format version */
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+   record->aead = *p++;
+
+   if (import_dir(&p, end, record->aead, &record->read) != PGAGROAL_TLS_OK ||
+       import_dir(&p, end, record->aead, &record->write) != PGAGROAL_TLS_OK)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   return PGAGROAL_TLS_OK;
+}
+
+int
+pgagroal_tls_harvest(struct tls* tls, struct tls_record* record)
+{
+   const unsigned char* wsec;
+   const unsigned char* rsec;
+   int aead;
+   uint16_t id;
+
+   if (tls == NULL || tls->ssl == NULL || record == NULL ||
+       !tls->handshake_complete || tls->secret_mask != 0x3)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   /* TLS 1.3 AEAD suites only */
+   id = SSL_CIPHER_get_protocol_id(SSL_get_current_cipher(tls->ssl));
+   switch (id)
+   {
+      case 0x1301:
+         aead = PGAGROAL_TLS_AEAD_AES_128_GCM;
+         break;
+      case 0x1302:
+         aead = PGAGROAL_TLS_AEAD_AES_256_GCM;
+         break;
+      default:
+         return PGAGROAL_TLS_ERROR;
+   }
+
+   memset(record, 0, sizeof(*record));
+   record->aead = aead;
+
+   /* Send with our own role's secret; receive with the peer's. */
+   wsec = tls->server ? tls->server_secret : tls->client_secret;
+   rsec = tls->server ? tls->client_secret : tls->server_secret;
+
+   if (pgagroal_tls_record_dir_init(&record->write, aead, wsec, tls->secret_len) != PGAGROAL_TLS_OK ||
+       pgagroal_tls_record_dir_init(&record->read, aead, rsec, tls->secret_len) != PGAGROAL_TLS_OK)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   return PGAGROAL_TLS_OK;
+}
+
+int
+pgagroal_tls_own(struct tls* tls)
+{
+   int n;
+
+   if (tls == NULL)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+   if (pgagroal_tls_harvest(tls, &tls->record) != PGAGROAL_TLS_OK)
+   {
+      pgagroal_log_debug("TLS: record-layer harvest failed; staying OpenSSL-backed (not parkable)");
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   /* Capture any ciphertext OpenSSL buffered but did not consume during the
+    * handshake, so owned_read does not miss records already off the socket. */
+   tls->rbuf_len = 0;
+   if (tls->rbio != NULL)
+   {
+      n = BIO_read(tls->rbio, tls->rbuf, (int)sizeof(tls->rbuf));
+      if (n > 0)
+      {
+         tls->rbuf_len = (size_t)n;
+      }
+   }
+
+   tls->owned = true;
+
+   pgagroal_log_debug("TLS: owning record layer (aead=%d, buffered=%zu bytes)", tls->record.aead, tls->rbuf_len);
+
+   return PGAGROAL_TLS_OK;
 }

--- a/test/testcases/test_tls.c
+++ b/test/testcases/test_tls.c
@@ -36,6 +36,7 @@
 #include <unistd.h>
 
 #include <openssl/evp.h>
+#include <openssl/rand.h>
 #include <openssl/x509.h>
 
 // Generate a throwaway self-signed certificate and key for the server side
@@ -493,6 +494,352 @@ MCTF_TEST(test_pgagroal_tls_from_ssl_backpointer)
 
 cleanup:
    pgagroal_tls_free(client);
+   if (cctx != NULL)
+   {
+      SSL_CTX_free(cctx);
+   }
+   MCTF_FINISH();
+}
+
+/* A sender (write dir) and receiver (read dir) sharing one secret: loopback. */
+static void
+record_mk_pair(struct tls_record* snd, struct tls_record* rcv, int aead, const unsigned char* secret, size_t sl)
+{
+   memset(snd, 0, sizeof(*snd));
+   memset(rcv, 0, sizeof(*rcv));
+   snd->aead = aead;
+   rcv->aead = aead;
+   pgagroal_tls_record_dir_init(&snd->write, aead, secret, sl);
+   pgagroal_tls_record_dir_init(&rcv->read, aead, secret, sl);
+}
+
+// A sealed record opens back to the original plaintext, advancing the sequence
+MCTF_TEST(test_pgagroal_tls_record_roundtrip)
+{
+   unsigned char secret[32];
+   struct tls_record snd, rcv;
+   unsigned char rec[512];
+   unsigned char pt[512];
+   size_t rlen = 0;
+   size_t plen = 0;
+
+   RAND_bytes(secret, sizeof(secret));
+   record_mk_pair(&snd, &rcv, PGAGROAL_TLS_AEAD_AES_128_GCM, secret, 32);
+
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_record_seal(&snd, (const unsigned char*)"hello", 5, rec, sizeof(rec), &rlen),
+                      PGAGROAL_TLS_OK, cleanup, "seal hello");
+   MCTF_ASSERT(rec[0] == 0x17, cleanup, "record is application_data");
+   MCTF_ASSERT(snd.write.seq == 1, cleanup, "write seq advanced");
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_record_open(&rcv, rec, rlen, pt, sizeof(pt), &plen),
+                      PGAGROAL_TLS_OK, cleanup, "open hello");
+   MCTF_ASSERT(plen == 5 && memcmp(pt, "hello", 5) == 0, cleanup, "hello round trip");
+   MCTF_ASSERT(rcv.read.seq == 1, cleanup, "read seq advanced");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+// Export/import preserves the sequence state so the stream continues across a move
+MCTF_TEST(test_pgagroal_tls_record_serialize)
+{
+   unsigned char secret[32];
+   struct tls_record snd, rcv, snd2;
+   unsigned char rec[512];
+   unsigned char pt[512];
+   unsigned char blob[256];
+   size_t rlen = 0;
+   size_t plen = 0;
+   size_t blen = 0;
+
+   RAND_bytes(secret, sizeof(secret));
+   record_mk_pair(&snd, &rcv, PGAGROAL_TLS_AEAD_AES_128_GCM, secret, 32);
+
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_record_seal(&snd, (const unsigned char*)"one", 3, rec, sizeof(rec), &rlen),
+                      PGAGROAL_TLS_OK, cleanup, "seal one");
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_record_open(&rcv, rec, rlen, pt, sizeof(pt), &plen),
+                      PGAGROAL_TLS_OK, cleanup, "open one");
+
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_record_export(&snd, blob, sizeof(blob), &blen),
+                      PGAGROAL_TLS_OK, cleanup, "export");
+   memset(&snd2, 0, sizeof(snd2));
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_record_import(blob, blen, &snd2),
+                      PGAGROAL_TLS_OK, cleanup, "import");
+   MCTF_ASSERT(snd2.write.seq == snd.write.seq, cleanup, "sequence preserved across import");
+
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_record_seal(&snd2, (const unsigned char*)"two", 3, rec, sizeof(rec), &rlen),
+                      PGAGROAL_TLS_OK, cleanup, "seal two (imported)");
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_record_open(&rcv, rec, rlen, pt, sizeof(pt), &plen),
+                      PGAGROAL_TLS_OK, cleanup, "open two");
+   MCTF_ASSERT(plen == 3 && memcmp(pt, "two", 3) == 0, cleanup, "two round trip after import");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+// A tampered record fails AEAD integrity
+MCTF_TEST(test_pgagroal_tls_record_tamper)
+{
+   unsigned char secret[32];
+   struct tls_record snd, rcv;
+   unsigned char rec[512];
+   unsigned char pt[512];
+   size_t rlen = 0;
+   size_t plen = 0;
+
+   RAND_bytes(secret, sizeof(secret));
+   record_mk_pair(&snd, &rcv, PGAGROAL_TLS_AEAD_AES_128_GCM, secret, 32);
+
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_record_seal(&snd, (const unsigned char*)"secret-data", 11, rec, sizeof(rec), &rlen),
+                      PGAGROAL_TLS_OK, cleanup, "seal");
+   rec[7] ^= 0x01;
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_record_open(&rcv, rec, rlen, pt, sizeof(pt), &plen),
+                      PGAGROAL_TLS_ERROR, cleanup, "tampered record rejected");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+// The AES-256-GCM suite (SHA-384, 48-byte secret) seals, opens, and survives export/import
+MCTF_TEST(test_pgagroal_tls_record_aes256)
+{
+   unsigned char secret[48];
+   struct tls_record snd, rcv, snd2;
+   unsigned char rec[512];
+   unsigned char pt[512];
+   unsigned char blob[256];
+   size_t rlen = 0;
+   size_t plen = 0;
+   size_t blen = 0;
+
+   RAND_bytes(secret, sizeof(secret));
+   record_mk_pair(&snd, &rcv, PGAGROAL_TLS_AEAD_AES_256_GCM, secret, 48);
+
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_record_seal(&snd, (const unsigned char*)"aes256", 6, rec, sizeof(rec), &rlen),
+                      PGAGROAL_TLS_OK, cleanup, "seal aes256");
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_record_open(&rcv, rec, rlen, pt, sizeof(pt), &plen),
+                      PGAGROAL_TLS_OK, cleanup, "open aes256");
+   MCTF_ASSERT(plen == 6 && memcmp(pt, "aes256", 6) == 0, cleanup, "aes256 round trip");
+
+   /* Export/import must preserve the SHA-384 secret length and the sequence */
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_record_export(&snd, blob, sizeof(blob), &blen),
+                      PGAGROAL_TLS_OK, cleanup, "export aes256");
+   memset(&snd2, 0, sizeof(snd2));
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_record_import(blob, blen, &snd2),
+                      PGAGROAL_TLS_OK, cleanup, "import aes256");
+   MCTF_ASSERT(snd2.aead == PGAGROAL_TLS_AEAD_AES_256_GCM, cleanup, "aead preserved across import");
+   MCTF_ASSERT(snd2.write.secret_len == 48, cleanup, "sha-384 secret length preserved");
+
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_record_seal(&snd2, (const unsigned char*)"more", 4, rec, sizeof(rec), &rlen),
+                      PGAGROAL_TLS_OK, cleanup, "seal after import");
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_record_open(&rcv, rec, rlen, pt, sizeof(pt), &plen),
+                      PGAGROAL_TLS_OK, cleanup, "open after import");
+   MCTF_ASSERT(plen == 4 && memcmp(pt, "more", 4) == 0, cleanup, "round trip after import");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+static SSL_CTX*
+tls_test_server_ctx_tls13(void)
+{
+   EVP_PKEY* key = NULL;
+   X509* crt = NULL;
+   SSL_CTX* ctx = NULL;
+
+   if (tls_test_self_signed(&key, &crt))
+   {
+      return NULL;
+   }
+   ctx = SSL_CTX_new(TLS_server_method());
+   if (ctx == NULL)
+   {
+      goto error;
+   }
+   SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION);
+   SSL_CTX_set_max_proto_version(ctx, TLS1_3_VERSION);
+   SSL_CTX_set_ciphersuites(ctx, "TLS_AES_128_GCM_SHA256");
+   SSL_CTX_set_num_tickets(ctx, 0);
+   if (SSL_CTX_use_certificate(ctx, crt) != 1 || SSL_CTX_use_PrivateKey(ctx, key) != 1)
+   {
+      goto error;
+   }
+   X509_free(crt);
+   EVP_PKEY_free(key);
+   return ctx;
+
+error:
+   if (ctx != NULL)
+   {
+      SSL_CTX_free(ctx);
+   }
+   X509_free(crt);
+   EVP_PKEY_free(key);
+   return NULL;
+}
+
+static SSL_CTX*
+tls_test_client_ctx_tls13(void)
+{
+   SSL_CTX* ctx = SSL_CTX_new(TLS_client_method());
+
+   if (ctx == NULL)
+   {
+      return NULL;
+   }
+   SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION);
+   SSL_CTX_set_max_proto_version(ctx, TLS1_3_VERSION);
+   SSL_CTX_set_num_tickets(ctx, 0);
+   SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
+   return ctx;
+}
+
+/* OpenSSL writes one app record; our harvested record context must decrypt it. */
+static int
+harvest_check_dir(struct tls* writer, struct tls_record* reader, const char* msg)
+{
+   unsigned char rec[4096];
+   unsigned char pt[4096];
+   size_t rlen = 0;
+   size_t plen = 0;
+   size_t written = 0;
+
+   if (pgagroal_tls_write(writer, msg, strlen(msg), &written) != PGAGROAL_TLS_OK)
+   {
+      return 1;
+   }
+   if (pgagroal_tls_drain(writer, rec, sizeof(rec), &rlen) != PGAGROAL_TLS_OK || rlen == 0)
+   {
+      return 1;
+   }
+   if (pgagroal_tls_record_open(reader, rec, rlen, pt, sizeof(pt), &plen) != PGAGROAL_TLS_OK)
+   {
+      return 1;
+   }
+   if (plen != strlen(msg) || memcmp(pt, msg, plen) != 0)
+   {
+      return 1;
+   }
+   return 0;
+}
+
+// After a TLS 1.3 handshake, the harvested record context decrypts OpenSSL's own records
+MCTF_TEST(test_pgagroal_tls_harvest_handoff)
+{
+   SSL_CTX* sctx = NULL;
+   SSL_CTX* cctx = NULL;
+   struct tls* s = NULL;
+   struct tls* c = NULL;
+   struct tls_record srec;
+   struct tls_record crec;
+   int i;
+
+   sctx = tls_test_server_ctx_tls13();
+   cctx = tls_test_client_ctx_tls13();
+   MCTF_ASSERT_PTR_NONNULL(sctx, cleanup, "server ctx");
+   MCTF_ASSERT_PTR_NONNULL(cctx, cleanup, "client ctx");
+
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_create(sctx, true, &s), PGAGROAL_TLS_OK, cleanup, "server create");
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_create(cctx, false, &c), PGAGROAL_TLS_OK, cleanup, "client create");
+
+   for (i = 0; i < 32; i++)
+   {
+      pgagroal_tls_handshake(c);
+      pgagroal_tls_handshake(s);
+      tls_test_transfer(c, s);
+      tls_test_transfer(s, c);
+      if (s->handshake_complete && c->handshake_complete)
+      {
+         break;
+      }
+   }
+   MCTF_ASSERT(s->handshake_complete && c->handshake_complete, cleanup, "handshake complete");
+
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_harvest(s, &srec), PGAGROAL_TLS_OK, cleanup, "harvest server");
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_harvest(c, &crec), PGAGROAL_TLS_OK, cleanup, "harvest client");
+
+   MCTF_ASSERT_INT_EQ(harvest_check_dir(s, &crec, "from the server"), 0, cleanup, "server->client decrypt");
+   MCTF_ASSERT_INT_EQ(harvest_check_dir(c, &srec, "from the client"), 0, cleanup, "client->server decrypt");
+
+cleanup:
+   pgagroal_tls_free(s);
+   pgagroal_tls_free(c);
+   if (sctx != NULL)
+   {
+      SSL_CTX_free(sctx);
+   }
+   if (cctx != NULL)
+   {
+      SSL_CTX_free(cctx);
+   }
+   MCTF_FINISH();
+}
+
+// After pgagroal_tls_own, I/O flows over a real socket via our own record layer
+MCTF_TEST(test_pgagroal_tls_owned_io)
+{
+   SSL_CTX* sctx = NULL;
+   SSL_CTX* cctx = NULL;
+   struct tls* s = NULL;
+   struct tls* c = NULL;
+   int sv[2] = {-1, -1};
+   unsigned char out[256];
+   size_t n = 0;
+   int i;
+
+   sctx = tls_test_server_ctx_tls13();
+   cctx = tls_test_client_ctx_tls13();
+   MCTF_ASSERT_PTR_NONNULL(sctx, cleanup, "server ctx");
+   MCTF_ASSERT_PTR_NONNULL(cctx, cleanup, "client ctx");
+
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_create(sctx, true, &s), PGAGROAL_TLS_OK, cleanup, "server create");
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_create(cctx, false, &c), PGAGROAL_TLS_OK, cleanup, "client create");
+
+   for (i = 0; i < 32; i++)
+   {
+      pgagroal_tls_handshake(c);
+      pgagroal_tls_handshake(s);
+      tls_test_transfer(c, s);
+      tls_test_transfer(s, c);
+      if (s->handshake_complete && c->handshake_complete)
+      {
+         break;
+      }
+   }
+   MCTF_ASSERT(s->handshake_complete && c->handshake_complete, cleanup, "handshake complete");
+
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_own(s), PGAGROAL_TLS_OK, cleanup, "own server");
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_own(c), PGAGROAL_TLS_OK, cleanup, "own client");
+   MCTF_ASSERT(s->owned && c->owned, cleanup, "owned flag set");
+
+   MCTF_ASSERT_INT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0, cleanup, "socketpair");
+   pgagroal_tls_set_fd(s, sv[0]);
+   pgagroal_tls_set_fd(c, sv[1]);
+
+   /* server -> client over our own record layer */
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_socket_write(s, sv[0], "ping", 4), PGAGROAL_TLS_OK, cleanup, "owned write s->c");
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_socket_read(c, sv[1], out, sizeof(out), &n), PGAGROAL_TLS_OK, cleanup, "owned read c");
+   MCTF_ASSERT(n == 4 && memcmp(out, "ping", 4) == 0, cleanup, "s->c via owned layer");
+
+   /* client -> server over our own record layer */
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_socket_write(c, sv[1], "pong", 4), PGAGROAL_TLS_OK, cleanup, "owned write c->s");
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_socket_read(s, sv[0], out, sizeof(out), &n), PGAGROAL_TLS_OK, cleanup, "owned read s");
+   MCTF_ASSERT(n == 4 && memcmp(out, "pong", 4) == 0, cleanup, "c->s via owned layer");
+
+cleanup:
+   pgagroal_tls_free(s);
+   pgagroal_tls_free(c);
+   if (sv[0] >= 0)
+   {
+      close(sv[0]);
+   }
+   if (sv[1] >= 0)
+   {
+      close(sv[1]);
+   }
+   if (sctx != NULL)
+   {
+      SSL_CTX_free(sctx);
+   }
    if (cctx != NULL)
    {
       SSL_CTX_free(cctx);


### PR DESCRIPTION
After the OpenSSL handshake pgagroal takes over a serializable TLS 1.3 record layer, so a backend session is parked in shared memory on return and resumed on a later checkout without a new handshake. Scoped to the session and performance pipelines; enforces TLS 1.3 with an AEAD cipher whitelist and cleanses parked secrets when a slot is killed.