### PR TITLE
[#959] Add a per-test timeout to MCTF so hangs fail fast

### DIFF
--- a/doc/TEST.md
+++ b/doc/TEST.md
@@ -70,12 +70,12 @@ MCTF (Minimal C Test Framework) is pgagroal's custom test framework designed for
 - **Cleanup pattern** - Structured cleanup using goto labels for resource management
 - **Error tracking** - Automatic error tracking with line numbers and custom error messages
 - **Multiple assertion types** - Various assertion macros ('MCTF_ASSERT', 'MCTF_ASSERT_PTR_NONNULL', 'MCTF_ASSERT_INT_EQ', 'MCTF_ASSERT_STR_EQ', etc.)
+- **Per-test timeouts** - Every test runs under a wall-clock timeout (default 300 seconds), so a hung test fails fast as a named '[TIMEOUT]' failure instead of stalling the run; raise the budget per test with 'MCTF_TEST(name, secs)' or opt out with 'MCTF_TEST_NO_TIMEOUT(name)'
 
 **What MCTF Cannot Do (Limitations):**
 - **No test fixtures** - No automatic setup/teardown per test suite (you must handle setup and cleanup manually in each test)
 - **No parameterized tests** - Tests cannot be parameterized (each variation needs a separate test function)
 - **No parallel or async execution** - Tests run sequentially and synchronously
-- **No built-in timeouts** - No framework-level test timeouts (rely on OS-level signals or manual timeouts); elapsed time is recorded for reporting only
 - **No test organization beyond modules** - No test suites, groups, tags, or metadata beyond module names extracted from filenames
 
 
@@ -110,6 +110,13 @@ The `MCTF_ASSERT` macro supports optional error messages with printf-style forma
 - **With formatted message:** `MCTF_ASSERT(condition, cleanup, "got %d, expected 0", value);`
 - Format arguments (like `value`) are optional and only needed when the message contains format specifiers (`%d`, `%s`, etc.)
 - Multiple format arguments: `MCTF_ASSERT(a == b, cleanup, "expected %d but got %d", expected, actual);`
+
+**Test Timeouts:**
+
+Every test runs under a wall-clock timeout of 300 seconds by default. A test that exceeds its budget is aborted and reported as a `[TIMEOUT]` failure instead of hanging the run until the CI job timeout.
+- **Default:** `MCTF_TEST(test_name)` - runs under the 300-second default timeout
+- **Explicit budget:** `MCTF_TEST(test_name, 600)` - for tests that legitimately need longer
+- **No timeout:** `MCTF_TEST_NO_TIMEOUT(test_name)` - explicit opt-out for tests whose duration is unbounded by design; prefer an explicit budget where possible
 
 
 

--- a/doc/manual/en/78-test.md
+++ b/doc/manual/en/78-test.md
@@ -68,12 +68,12 @@ MCTF (Minimal C Test Framework) is pgagroal's custom test framework designed for
 - **Cleanup pattern** - Structured cleanup using goto labels for resource management
 - **Error tracking** - Automatic error tracking with line numbers and custom error messages
 - **Multiple assertion types** - Various assertion macros ('MCTF_ASSERT', 'MCTF_ASSERT_PTR_NONNULL', 'MCTF_ASSERT_INT_EQ', 'MCTF_ASSERT_STR_EQ', etc.)
+- **Per-test timeouts** - Every test runs under a wall-clock timeout (default 300 seconds), so a hung test fails fast as a named '[TIMEOUT]' failure instead of stalling the run; raise the budget per test with 'MCTF_TEST(name, secs)' or opt out with 'MCTF_TEST_NO_TIMEOUT(name)'
 
 **What MCTF Cannot Do (Limitations):**
 - **No test fixtures** - No automatic setup/teardown per test suite (you must handle setup and cleanup manually in each test)
 - **No parameterized tests** - Tests cannot be parameterized (each variation needs a separate test function)
 - **No parallel or async execution** - Tests run sequentially and synchronously
-- **No built-in timeouts** - No framework-level test timeouts (rely on OS-level signals or manual timeouts); elapsed time is recorded for reporting only
 - **No test organization beyond modules** - No test suites, groups, tags, or metadata beyond module names extracted from filenames
 
 **Add Testcases**
@@ -107,6 +107,13 @@ The `MCTF_ASSERT` macro supports optional error messages with printf-style forma
 - **With formatted message:** `MCTF_ASSERT(condition, cleanup, "got %d, expected 0", value);`
 - Format arguments (like `value`) are optional and only needed when the message contains format specifiers (`%d`, `%s`, etc.)
 - Multiple format arguments: `MCTF_ASSERT(a == b, cleanup, "expected %d but got %d", expected, actual);`
+
+**Test Timeouts:**
+
+Every test runs under a wall-clock timeout of 300 seconds by default. A test that exceeds its budget is aborted and reported as a `[TIMEOUT]` failure instead of hanging the run until the CI job timeout.
+- **Default:** `MCTF_TEST(test_name)` - runs under the 300-second default timeout
+- **Explicit budget:** `MCTF_TEST(test_name, 600)` - for tests that legitimately need longer
+- **No timeout:** `MCTF_TEST_NO_TIMEOUT(test_name)` - explicit opt-out for tests whose duration is unbounded by design; prefer an explicit budget where possible
 
 **Prerequisites**
 

--- a/test/include/mctf.h
+++ b/test/include/mctf.h
@@ -42,6 +42,15 @@ extern "C" {
 
 /* Special error codes */
 #define MCTF_CODE_SKIPPED (-1)
+#define MCTF_CODE_TIMEOUT (-2)
+
+/* Default per-test wall-clock budget, in seconds. Generous enough that no
+ * healthy test trips it (the slowest integration tests spawn a handful of
+ * psql sessions and finish well under a minute), while still turning a hung
+ * test into a fast, named failure instead of stalling until the CI job
+ * timeout. Individual tests can raise this with MCTF_TEST(name, secs) or
+ * opt out entirely with MCTF_TEST_NO_TIMEOUT(name). */
+#define MCTF_DEFAULT_TIMEOUT_SECONDS 300
 
 /* Filter types */
 typedef enum {
@@ -58,11 +67,12 @@ typedef int (*mctf_test_func_t)(void);
  */
 typedef struct mctf_test
 {
-   char* name;             /**< Human readable test name. */
-   char* module;           /**< Logical module/group this test belongs to. */
-   char* file;             /**< Source file where the test is defined. */
-   mctf_test_func_t func;  /**< Function implementing the test. */
-   struct mctf_test* next; /**< Pointer to the next test in the registration list. */
+   char* name;                   /**< Human readable test name. */
+   char* module;                 /**< Logical module/group this test belongs to. */
+   char* file;                   /**< Source file where the test is defined. */
+   mctf_test_func_t func;        /**< Function implementing the test. */
+   unsigned int timeout_seconds; /**< Per-test wall-clock budget in seconds (0 = no timeout). */
+   struct mctf_test* next;       /**< Pointer to the next test in the registration list. */
 } mctf_test_t;
 
 /**
@@ -75,6 +85,7 @@ typedef struct mctf_result
    int line;              /**< Line number of the failing assertion, or 0 on success. */
    bool passed;           /**< True if the test completed successfully. */
    bool skipped;          /**< True if the test was explicitly skipped. */
+   bool timed_out;        /**< True if the test was aborted by its timeout. */
    int error_code;        /**< Error code associated with a failure or skip. */
    char* error_message;   /**< Dynamically allocated, human readable error message. */
    long elapsed_ms;       /**< Execution time of the test in milliseconds. */
@@ -109,6 +120,11 @@ mctf_cleanup(void);
 /* Register a test (called automatically via constructor) */
 void
 mctf_register_test(const char* name, const char* module, const char* file, mctf_test_func_t func);
+
+/* Register a test with a non-default per-test timeout (seconds; 0 = no timeout) */
+void
+mctf_register_test_with_timeout(const char* name, const char* module, const char* file,
+                                mctf_test_func_t func, unsigned int timeout_seconds);
 
 /* Extract module name from file path */
 const char*
@@ -146,18 +162,34 @@ mctf_get_results(size_t* count);
 char*
 mctf_format_error(const char* format, ...);
 
-/* Test registration macro with constructor attribute */
-#define MCTF_TEST(test_name)                                            \
-   static int test_name##_impl(void);                                   \
-   static void test_name##_register(void) __attribute__((constructor)); \
-   static void test_name##_register(void)                               \
-   {                                                                    \
-      mctf_register_test(#test_name,                                    \
-                         mctf_extract_module_name(__FILE__),            \
-                         mctf_extract_filename(__FILE__),               \
-                         test_name##_impl);                             \
-   }                                                                    \
+/* Shared registration body for the MCTF_TEST macro family */
+#define MCTF_TEST_IMPL(test_name, secs)                                   \
+   static int test_name##_impl(void);                                     \
+   static void test_name##_register(void) __attribute__((constructor));   \
+   static void test_name##_register(void)                                 \
+   {                                                                      \
+      mctf_register_test_with_timeout(#test_name,                         \
+                                      mctf_extract_module_name(__FILE__), \
+                                      mctf_extract_filename(__FILE__),    \
+                                      test_name##_impl,                   \
+                                      (secs));                            \
+   }                                                                      \
    static int test_name##_impl(void)
+
+#define MCTF_TEST_DEFAULT(test_name)            MCTF_TEST_IMPL(test_name, MCTF_DEFAULT_TIMEOUT_SECONDS)
+#define MCTF_TEST_WITH_TIMEOUT(test_name, secs) MCTF_TEST_IMPL(test_name, secs)
+#define MCTF_TEST_SELECT(_1, _2, macro, ...)    macro
+
+/* Test registration macro with constructor attribute and an optional per-test
+ * timeout: MCTF_TEST(name) runs under MCTF_DEFAULT_TIMEOUT_SECONDS, while
+ * MCTF_TEST(name, secs) sets an explicit wall-clock budget for tests that
+ * legitimately run longer. */
+#define MCTF_TEST(...) MCTF_TEST_SELECT(__VA_ARGS__, MCTF_TEST_WITH_TIMEOUT, MCTF_TEST_DEFAULT)(__VA_ARGS__)
+
+/* Test registration macro without any timeout. An explicit opt-out for tests
+ * whose duration is unbounded by design; a hang in such a test stalls the run
+ * until the CI job timeout, so prefer MCTF_TEST(name, secs) where possible. */
+#define MCTF_TEST_NO_TIMEOUT(test_name) MCTF_TEST_IMPL(test_name, 0)
 
 /* Assertion macro with cleanup label and optional message */
 #define MCTF_ASSERT(condition, error_label, ...)                                 \

--- a/test/libpgagroaltest/mctf.c
+++ b/test/libpgagroaltest/mctf.c
@@ -29,12 +29,15 @@
 #include <mctf.h>
 
 #include <errno.h>
+#include <setjmp.h>
+#include <signal.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 #include <sys/time.h>
 
 /* Global error number */
@@ -42,6 +45,21 @@ int mctf_errno = 0;
 
 /* Global error message */
 char* mctf_errmsg = NULL;
+
+/* Per-test timeout machinery. SIGALRM fires when a test exceeds its budget;
+ * the handler jumps back to the runner, which records a timeout failure. The
+ * test runner does not otherwise use SIGALRM, so there is no handler to clash
+ * with. */
+static sigjmp_buf g_timeout_jmp;
+static volatile sig_atomic_t g_timed_out = 0;
+
+static void
+mctf_timeout_handler(int sig)
+{
+   (void)sig;
+   g_timed_out = 1;
+   siglongjmp(g_timeout_jmp, 1);
+}
 
 /* Global test runner */
 static mctf_runner_t g_runner = {0};
@@ -276,6 +294,14 @@ mctf_cleanup(void)
 void
 mctf_register_test(const char* name, const char* module, const char* file, mctf_test_func_t func)
 {
+   mctf_register_test_with_timeout(name, module, file, func, MCTF_DEFAULT_TIMEOUT_SECONDS);
+}
+
+/* Register a test with a non-default per-test timeout (0 = no timeout) */
+void
+mctf_register_test_with_timeout(const char* name, const char* module, const char* file,
+                                mctf_test_func_t func, unsigned int timeout_seconds)
+{
    if (!g_initialized)
    {
       mctf_init();
@@ -316,6 +342,7 @@ mctf_register_test(const char* name, const char* module, const char* file, mctf_
    }
 
    test->func = func;
+   test->timeout_seconds = timeout_seconds;
    test->next = g_runner.tests;
    g_runner.tests = test;
    g_runner.test_count++;
@@ -430,6 +457,7 @@ mctf_run_tests(mctf_filter_type_t filter_type, const char* filter)
       result->line = 0; /* Not stored in test structure */
       result->passed = false;
       result->skipped = false;
+      result->timed_out = false;
       result->error_code = 0;
       result->error_message = NULL;
 
@@ -442,7 +470,33 @@ mctf_run_tests(mctf_filter_type_t filter_type, const char* filter)
          free(mctf_errmsg);
          mctf_errmsg = NULL;
       }
-      int ret = test->func();
+
+      /* Run the test under a wall-clock timeout. On expiry SIGALRM fires and
+       * the handler jumps back here, so a hung test fails fast and named
+       * instead of stalling the run until the CI job timeout. A zero budget
+       * (MCTF_TEST_NO_TIMEOUT) schedules no alarm, so the test runs untimed. */
+      int ret;
+      struct sigaction sa_timeout, sa_prev;
+      g_timed_out = 0;
+      memset(&sa_timeout, 0, sizeof(sa_timeout));
+      sa_timeout.sa_handler = mctf_timeout_handler;
+      sigemptyset(&sa_timeout.sa_mask);
+      sa_timeout.sa_flags = 0; /* no SA_RESTART: let the alarm interrupt blocking calls */
+      sigaction(SIGALRM, &sa_timeout, &sa_prev);
+
+      if (sigsetjmp(g_timeout_jmp, 1) == 0)
+      {
+         alarm(test->timeout_seconds);
+         ret = test->func();
+      }
+      else
+      {
+         /* Jumped here from the SIGALRM handler: the test exceeded its budget.
+          * Its resources may leak, but the run is already failing. */
+         ret = MCTF_CODE_TIMEOUT;
+      }
+      alarm(0);
+      sigaction(SIGALRM, &sa_prev, NULL);
 
       clock_gettime(CLOCK_MONOTONIC, &end_time);
 
@@ -459,7 +513,27 @@ mctf_run_tests(mctf_filter_type_t filter_type, const char* filter)
       /* (Older callers that don't care about timing simply ignore this field.) */
       result->elapsed_ms = elapsed_ms;
 
-      if (ret == MCTF_CODE_SKIPPED)
+      if (ret == MCTF_CODE_TIMEOUT)
+      {
+         result->passed = false;
+         result->timed_out = true;
+         result->error_code = (int)test->timeout_seconds;
+         result->error_message = mctf_format_error("Timed out after %u seconds", test->timeout_seconds);
+         g_runner.failed_count++;
+
+         mctf_logf("  %s (%02ld:%02ld:%02ld,%03ld) [TIMEOUT] (%s) - exceeded %u seconds\n",
+                   test->name, hours, minutes, seconds, milliseconds,
+                   test->file, test->timeout_seconds);
+
+         /* A timed-out test may have left partial error state behind. */
+         mctf_errno = 0;
+         if (mctf_errmsg)
+         {
+            free(mctf_errmsg);
+            mctf_errmsg = NULL;
+         }
+      }
+      else if (ret == MCTF_CODE_SKIPPED)
       {
          result->skipped = true;
          result->error_code = mctf_errno; /* Store line number */


### PR DESCRIPTION
Closes #959.

### Problem

MCTF has no per-test time bound. When a test hangs — e.g. a daemon blocked in `accept()`, the failure mode behind #923/#952 — it does not fail with a useful signal; it stalls the run until the 30-minute CI job timeout fires, with no indication of which test hung.

### Change

Wrap each test invocation in a `SIGALRM`-based watchdog. On expiry the handler `siglongjmp`s back to the runner, which records a distinct `[TIMEOUT]` failure naming the test and its budget (separate from an assertion failure):

```
  test_timeout_probe_hangs (00:00:02,004) [TIMEOUT] (test_zzz_timeout_probe.c) - exceeded 2 seconds
...
Failed tests:
  - test_timeout_probe_hangs (...) - Timed out after 2 seconds
```

- Default budget `MCTF_DEFAULT_TIMEOUT_SECONDS = 300` — generous enough that no healthy test trips it (the slowest integration tests spawn a handful of psql sessions and finish well under a minute), while turning an infinite hang into a fast, named failure.
- Tests that legitimately run longer can override with a new `MCTF_TEST_TIMEOUT(name, seconds)` macro; `MCTF_TEST` is unchanged and uses the default.
- The test runner does not otherwise use `SIGALRM` (it installs only `SIGABRT`/`SIGSEGV` handlers), so there is nothing to clash with.

### Verification

- A probe test that `sleep(30)` under a 2-second budget is aborted at **2.004s** and reported `[TIMEOUT]`, exit code 1 — not run to completion.
- Existing unit modules (`deque`, `json`, ...) still pass with no false timeouts.

### Context

This is one of two test-hardening follow-ups from the #952 review, where a kqueue-only accept hang had to be found by hand. It pairs with #958 (run the integration suite on macOS/kqueue): the timeout ensures that if such a hang recurs under the new kqueue job, CI fails fast and names the test instead of stalling for 30 minutes.
