### PR TITLE
[#961] Fix master build: use pgagroal_as_bool for server_reset_query_always

### DIFF
--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -6204,7 +6204,7 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    }
    else if (key_in_section("server_reset_query_always", section, key, true, &unknown))
    {
-      if (as_bool(value, &config->server_reset_query_always))
+      if (pgagroal_as_bool(value, &config->server_reset_query_always))
       {
          unknown = true;
       }


### PR DESCRIPTION
Fixes the build break on master (close #961): #941 and #871 merged without textual conflict, leaving one call to the pre-rename as_bool() in pgagroal_apply_main_configuration. Verified the full build passes locally with the change; this also unblocks CI on every open PR, since merge builds against master currently fail.