### PR TITLE
[#963] CI: bump FreeBSD VM to 14.4 to match the package repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
         uses: vmactions/freebsd-vm@v1
         id: freebsd-vm
         with:
-          release: "14.3"
+          release: "14.4"
           usesh: true
           envs: "PATH,GITHUB_ENV,GITHUB_WORKSPACE,GITHUB_OUTPUT"
           mem: 4096


### PR DESCRIPTION
Fixes the FreeBSD Build and Test jobs failing at 'Setup FreeBSD VM' on every PR (close #963): FreeBSD's pkg repo moved to 14.4-built packages, and the 14.3 VM's pkg refuses the version mismatch with an interactive prompt that can't be answered in CI. vmactions/freebsd-vm ships a 14.4 image (conf/14.4.conf), so this bumps the pinned release. This PR's own FreeBSD jobs validate the change.