### PR TITLE
[#965] Import the aarch64 PGDG signing key in the test PostgreSQL image

### DIFF
--- a/test/postgresql/src/postgresql17/Dockerfile
+++ b/test/postgresql/src/postgresql17/Dockerfile
@@ -36,6 +36,14 @@ ENV PGROOT="/usr/pgsql-${PGVERSION}"
 
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
 RUN dnf -y install --nogpgcheck --allowerasing https://download.postgresql.org/pub/repos/yum/reporpms/EL-10-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+# The PGDG aarch64 repositories are signed with a separate per-architecture key
+# (PGDG-RPM-GPG-KEY-AARCH64-RHEL) that the repo RPM does not install, so on
+# aarch64 `dnf makecache` and the postgresql17 install fail with "Signing key
+# not found". Import it and add it to gpgkey= so GPG checking stays enabled on
+# both architectures (a harmless extra trusted key on x86_64). See #965.
+RUN curl -so /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-AARCH64-RHEL https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-AARCH64-RHEL && \
+    sed -i 's|^gpgkey=.*|& file:///etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-AARCH64-RHEL|' /etc/yum.repos.d/pgdg-redhat-all.repo && \
+    rpm --import /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-AARCH64-RHEL
 RUN dnf -qy --nogpgcheck module disable postgresql 2>/dev/null || true
 RUN dnf -y upgrade
 RUN dnf install -y dnf-plugins-core


### PR DESCRIPTION
Fixes #965.

On aarch64 the PGDG repositories are signed with a separate per-architecture key (`PGDG-RPM-GPG-KEY-AARCH64-RHEL`, `177B343BB9738825`), but `pgdg-redhat-repo-latest` installs only the x86_64 RHEL key and references only it in `gpgkey=`. So on ARM the test image fails at `dnf makecache` and the `postgresql17` install with "Signing key not found" (x86_64 is unaffected, which is why CI has been green).

This imports the aarch64 key into `/etc/pki/rpm-gpg/`, adds it to `gpgkey=` in `pgdg-redhat-all.repo`, and `rpm --import`s it — keeping `repo_gpgcheck`/`gpgcheck` fully enabled on both architectures. On x86_64 it is just an extra trusted key, so no arch-conditional logic is needed.

Verified in a fresh Rocky 10 aarch64 container: `dnf makecache` and `dnf install postgresql17-libs` both pass with repo and package GPG checks on.

The upstream-side fix (the PGDG repo RPM shipping the aarch64 key) is tracked with @devrimgunduz in #965; this unblocks the test image independently.