### PR TITLE
[#974] Fix compatibility with OpenSSL4

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,4 @@ Ameen Sakr <ameensakr623@gmail.com>
 Rohan Mishra <kmrrohan29@gmail.com>
 youssef-joe <joe92228@gmail.com>
 Mohammad El-Shennawy <mohamedwork216@gmail.com>
+Finn Rayk Gartner <finn.gartner@canonical.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -48,6 +48,7 @@ Abdallah Hany Ragab <abdallah.hany1974@gmail.com>
 Rohan Mishra <kmrrohan29@gmail.com>
 youssef-joe <joe92228@gmail.com>
 Mohammad El-Shennawy <mohamedwork216@gmail.com>
+Finn Rayk Gartner <finn.gartner@canonical.com>
 ```
 
 ## Committers

--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -3561,8 +3561,8 @@ parse_certificate_file(const char* cert_path, struct certificate_info* cert_info
 {
    FILE* fp = NULL;
    X509* cert = NULL;
-   X509_NAME* subject_name = NULL;
-   X509_NAME* issuer_name = NULL;
+   const X509_NAME* subject_name = NULL;
+   const X509_NAME* issuer_name = NULL;
    ASN1_TIME* not_after = NULL;
    ASN1_TIME* not_before_asn1 = NULL;
    ASN1_INTEGER* serial = NULL;
@@ -3754,23 +3754,8 @@ parse_certificate_file(const char* cert_path, struct certificate_info* cert_info
       }
    }
 
-   // Check if this is a CA certificate - compatible with older OpenSSL versions
-   X509_EXTENSION* ext = NULL;
-   BASIC_CONSTRAINTS* bc = NULL;
-   int ca_idx = X509_get_ext_by_NID(cert, NID_basic_constraints, -1);
-   if (ca_idx >= 0)
-   {
-      ext = X509_get_ext(cert, ca_idx);
-      if (ext)
-      {
-         bc = X509V3_EXT_d2i(ext);
-         if (bc)
-         {
-            cert_info->is_ca = (bc->ca == 0xFF); // ASN1_BOOLEAN true is 0xFF
-            BASIC_CONSTRAINTS_free(bc);
-         }
-      }
-   }
+   // Check if this is a CA certificate
+   cert_info->is_ca = X509_check_ca(cert) != 0;
 
    // Success path - clean up and return 0
    if (cert)

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -5560,7 +5560,7 @@ char*
 pgagroal_extract_cert_identity(SSL* ssl)
 {
    X509* cert = NULL;
-   X509_NAME* subject_name = NULL;
+   const X509_NAME* subject_name = NULL;
    GENERAL_NAMES* san_names = NULL;
    char* identity = NULL;
    char cn_buf[256];

--- a/test/testcases/test_tls.c
+++ b/test/testcases/test_tls.c
@@ -64,10 +64,19 @@ tls_test_self_signed(EVP_PKEY** out_key, X509** out_crt)
    X509_gmtime_adj(X509_getm_notAfter(crt), 60L * 60L * 24L * 365L);
    X509_set_pubkey(crt, pkey);
 
-   name = X509_get_subject_name(crt);
-   X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
-                              (const unsigned char*)"localhost", -1, -1, 0);
-   X509_set_issuer_name(crt, name);
+   name = X509_NAME_new();
+   if (name == NULL ||
+       X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+                                  (const unsigned char*)"localhost", -1, -1, 0) != 1 ||
+       X509_set_subject_name(crt, name) != 1 ||
+       X509_set_issuer_name(crt, name) != 1)
+   {
+      X509_NAME_free(name);
+      X509_free(crt);
+      EVP_PKEY_free(pkey);
+      return 1;
+   }
+   X509_NAME_free(name);
 
    if (X509_sign(crt, pkey, EVP_sha256()) == 0)
    {


### PR DESCRIPTION
Fixes #974. I decided to replace the ca certificate check block with `X509_check_ca`, since it exists at least since version 1.1.1: https://docs.openssl.org/1.1.1/man3/X509_check_ca/. Please let me know if I should revert this back to the old method for a reason unknown to me.