### PR TITLE
[#692]Add standby WAL receiver status to CLI

### DIFF
--- a/src/include/management.h
+++ b/src/include/management.h
@@ -137,7 +137,12 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_TIMESTAMP           "Timestamp"
 #define MANAGEMENT_ARGUMENT_TOTAL_CONNECTIONS   "TotalConnections"
 #define MANAGEMENT_ARGUMENT_USERNAME            "Username"
-
+#define MANAGEMENT_ARGUMENT_STANDBYS            "Standbys"
+#define MANAGEMENT_ARGUMENT_STREAMING           "Streaming"
+#define MANAGEMENT_ARGUMENT_WAL_RECEIVER_STATUS "WALReceiverStatus"
+#define MANAGEMENT_ARGUMENT_SLOT_NAME           "SlotName"
+#define MANAGEMENT_ARGUMENT_PRIMARY_HOST        "PrimaryHost"
+#define MANAGEMENT_ARGUMENT_PRIMARY_PORT        "PrimaryPort"
 /**
  * Management error
  */

--- a/src/include/queries.h
+++ b/src/include/queries.h
@@ -57,6 +57,25 @@ const char*
 pgagroal_queries_replication_lag_bytes(void);
 
 /**
+ * SQL for replica status (multiple columns).
+ * @return Static query string (do not free)
+ */
+const char*
+pgagroal_queries_wal_receiver_status(void);
+
+/**
+ * Read PostgreSQL wire-protocol messages from fd until ReadyForQuery, and fill values
+ *
+ * @param fd Open server connection after a query was sent
+ * @param expected_cols The exact number of columns expected in the result
+ * @param values Array of pointers to output buffers
+ * @param value_sizes Array containing the maximum size for each output buffer
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgagroal_read_query_multiple_columns_text(int fd, int expected_cols, char** values, size_t* value_sizes);
+
+/**
  * Read PostgreSQL wire-protocol messages from fd until ReadyForQuery, and fill
  * @a value with the text of the first column of the first DataRow ('D').
  *

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -129,6 +129,26 @@ int
 pgagroal_server_get_connectivity_info(int server, char** status, char** primary, int64_t* behind_bytes);
 
 /**
+ * Get the WAL receiver status and streaming details for a configured standby server.
+ *
+ * @param server        The server index into config->servers[]
+ * @param rep_status    Output: the replication status (e.g., "streaming")
+ * @param status_size   The maximum size of the rep_status buffer
+ * @param slot_name     Output: the replication slot name
+ * @param slot_size     The maximum size of the slot_name buffer
+ * @param sender_host   Output: the primary host the standby is streaming from
+ * @param host_size     The maximum size of the sender_host buffer
+ * @param sender_port   Output: the primary port the standby is streaming from
+ * @param port_size     The maximum size of the sender_port buffer
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgagroal_server_get_wal_receiver_status(int server,
+                                        char* rep_status, size_t status_size,
+                                        char* slot_name, size_t slot_size,
+                                        char* sender_host, size_t host_size,
+                                        char* sender_port, size_t port_size);
+/**
  * Check if the server is a primary server
  * @param server The server index
  * @return true if primary, false otherwise

--- a/src/libpgagroal/queries.c
+++ b/src/libpgagroal/queries.c
@@ -50,6 +50,116 @@ pgagroal_queries_replication_lag_bytes(void)
    return "SELECT COALESCE(pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn()), 0)::bigint;";
 }
 
+const char*
+pgagroal_queries_wal_receiver_status(void)
+{
+   return "SELECT status, slot_name, sender_host, sender_port FROM pg_stat_wal_receiver;";
+}
+
+int
+pgagroal_read_query_multiple_columns_text(int fd, int expected_cols, char** values, size_t* value_sizes)
+{
+   int status;
+   int offset = 0;
+   bool has_value = false;
+   struct message* msg = NULL;
+
+   if (values == NULL || value_sizes == NULL || expected_cols <= 0)
+   {
+      return 1;
+   }
+
+   for (int i = 0; i < expected_cols; i++)
+   {
+      if (values[i] != NULL && value_sizes[i] > 0)
+      {
+         values[i][0] = '\0';
+      }
+      else
+      {
+         return 1;
+      }
+   }
+
+   while (true)
+   {
+      status = pgagroal_read_timeout_message(NULL, fd, 5, &msg);
+      if (status != MESSAGE_STATUS_OK || msg == NULL)
+      {
+         goto error;
+      }
+
+      offset = 0;
+      while (offset < msg->length)
+      {
+         char kind = pgagroal_read_byte(msg->data + offset);
+         int len = pgagroal_read_int32(msg->data + offset + 1);
+
+         if (len <= 0)
+            goto error;
+
+         if (kind == 'D')
+         {
+            int dr_offset = offset + 5;
+            int num_cols = pgagroal_read_int16(msg->data + dr_offset);
+            dr_offset += 2;
+
+            if (num_cols == expected_cols)
+            {
+               for (int i = 0; i < num_cols; i++)
+               {
+                  int col_len = pgagroal_read_int32(msg->data + dr_offset);
+                  dr_offset += 4;
+
+                  if (col_len <= 0)
+                  {
+                     if (values[i] != NULL && value_sizes[i] > 0)
+                     {
+                        values[i][0] = '\0';
+                     }
+                  }
+                  else
+                  {
+                     if (values[i] != NULL && (size_t)col_len < value_sizes[i])
+                     {
+                        memcpy(values[i], msg->data + dr_offset, (size_t)col_len);
+                        values[i][col_len] = '\0';
+                     }
+                     else
+                     {
+                        goto error;
+                     }
+                     dr_offset += col_len;
+                  }
+               }
+               has_value = true;
+            }
+            else
+            {
+               goto error;
+            }
+         }
+         else if (kind == 'E')
+         {
+            goto error;
+         }
+         else if (kind == 'Z')
+         {
+            pgagroal_clear_message(msg);
+            return has_value ? 0 : 1;
+         }
+
+         offset += 1 + len;
+      }
+
+      pgagroal_clear_message(msg);
+      msg = NULL;
+   }
+
+error:
+   pgagroal_clear_message(msg);
+   return 1;
+}
 int
 pgagroal_read_query_first_column_text(int fd, char* value, size_t value_size)
 {

--- a/src/libpgagroal/server.c
+++ b/src/libpgagroal/server.c
@@ -727,6 +727,73 @@ done:
 }
 
 int
+pgagroal_server_get_wal_receiver_status(int server,
+                                        char* rep_status, size_t status_size,
+                                        char* slot_name, size_t slot_size,
+                                        char* sender_host, size_t host_size,
+                                        char* sender_port, size_t port_size)
+{
+   int fd = -1;
+   struct main_configuration* config = (struct main_configuration*)shmem;
+   char* cols[] = {rep_status, slot_name, sender_host, sender_port};
+   size_t sizes[] = {status_size, slot_size, host_size, port_size};
+
+   if (rep_status == NULL || slot_name == NULL || sender_host == NULL || sender_port == NULL)
+   {
+      return 1;
+   }
+
+   rep_status[0] = '\0';
+   slot_name[0] = '\0';
+   sender_host[0] = '\0';
+   sender_port[0] = '\0';
+
+   if (server < 0 || server >= config->number_of_servers)
+   {
+      return 1;
+   }
+
+   if (strlen(config->health_check_user) == 0)
+   {
+      pgagroal_log_debug("ping/status: health_check_user is not configured, cannot check WAL receiver status");
+      return 1;
+   }
+
+   if (pgagroal_server_query_execute(server,
+                                     config->health_check_user,
+                                     config->health_check_user,
+                                     (char*)pgagroal_queries_wal_receiver_status(),
+                                     MAX(1, (int)pgagroal_time_convert(config->health_check_timeout, FORMAT_TIME_S)),
+                                     NULL, &fd))
+   {
+      pgagroal_log_debug("Failed to execute WAL receiver query for server %d", server);
+      goto error;
+   }
+
+   if (pgagroal_read_query_multiple_columns_text(fd, 4, cols, sizes))
+   {
+      pgagroal_log_debug("Failed to read WAL receiver status columns for server %d", server);
+      goto error;
+   }
+
+   if (fd != -1)
+   {
+      (void)pgagroal_write_terminate(NULL, fd);
+      pgagroal_disconnect(fd);
+   }
+
+   return 0;
+error:
+   if (fd != -1)
+   {
+      (void)pgagroal_write_terminate(NULL, fd);
+      pgagroal_disconnect(fd);
+   }
+
+   return 1;
+}
+
+int
 pgagroal_get_primary(int* server)
 {
    int primary;

--- a/src/libpgagroal/status.c
+++ b/src/libpgagroal/status.c
@@ -157,6 +157,7 @@ status_details(bool details, struct json* response)
    int active = 0;
    int total = 0;
    struct json* servers = NULL;
+   struct json* standbys = NULL;
    struct main_configuration* config;
 
    config = (struct main_configuration*)shmem;
@@ -193,6 +194,7 @@ status_details(bool details, struct json* response)
    pgagroal_json_put(response, MANAGEMENT_ARGUMENT_NUMBER_OF_SERVERS, (uintptr_t)config->number_of_servers, ValueInt32);
 
    pgagroal_json_create(&servers);
+   pgagroal_json_create(&standbys);
 
    FOREACH_VALID_SERVER
    {
@@ -230,9 +232,36 @@ status_details(bool details, struct json* response)
          pgagroal_json_put(js, MANAGEMENT_ARGUMENT_BEHIND, (uintptr_t)behind_bytes, ValueInt64);
 
       pgagroal_json_put(servers, config->servers[i].name, (uintptr_t)js, ValueJSON);
+
+      if (srv_primary != NULL && pgagroal_compare_string(srv_primary, "No"))
+      {
+         char rep_status[64] = {0};
+         char slot_name[64] = {0};
+         char sender_host[MISC_LENGTH] = {0};
+         char sender_port[16] = {0};
+
+         int wal_result = pgagroal_server_get_wal_receiver_status(i,
+                                                                  rep_status, sizeof(rep_status),
+                                                                  slot_name, sizeof(slot_name),
+                                                                  sender_host, sizeof(sender_host),
+                                                                  sender_port, sizeof(sender_port));
+         struct json* standby_js = NULL;
+         pgagroal_json_create(&standby_js);
+         if (wal_result == 0)
+         {
+            bool is_streaming = pgagroal_compare_string(rep_status, "streaming");
+            pgagroal_json_put(standby_js, MANAGEMENT_ARGUMENT_STREAMING, (uintptr_t)is_streaming, ValueBool);
+            pgagroal_json_put(standby_js, MANAGEMENT_ARGUMENT_WAL_RECEIVER_STATUS, (uintptr_t)rep_status, ValueString);
+            pgagroal_json_put(standby_js, MANAGEMENT_ARGUMENT_SLOT_NAME, (uintptr_t)slot_name, ValueString);
+            pgagroal_json_put(standby_js, MANAGEMENT_ARGUMENT_PRIMARY_HOST, (uintptr_t)sender_host, ValueString);
+            pgagroal_json_put(standby_js, MANAGEMENT_ARGUMENT_PRIMARY_PORT, (uintptr_t)sender_port, ValueString);
+         }
+         pgagroal_json_put(standbys, config->servers[i].name, (uintptr_t)standby_js, ValueJSON);
+      }
    }
 
    pgagroal_json_put(response, MANAGEMENT_ARGUMENT_SERVERS, (uintptr_t)servers, ValueJSON);
+   pgagroal_json_put(response, MANAGEMENT_ARGUMENT_STANDBYS, (uintptr_t)standbys, ValueJSON);
 
    /* Show invalid servers separately */
    {


### PR DESCRIPTION
This PR resolves #692 by extending the pgagroal-cli status details command to report the streaming health of configured standby servers. It adds a new Standbys section to the output that details the WAL receiver status, replication slot, and the upstream primary host/port.

Implementation Details:

- Added new query for getting required info for standbys `SELECT status, slot_name, sender_host, sender_port FROM pg_stat_wal_receiver;`

- Generic Multi-Column Parser: Added pgagroal_read_query_multiple_columns_text to queries.c. This mimics the original pgagroal_read_query_first_column_text but is extended to retreive multiple column values

- Modified status_details to selectively execute the WAL receiver check only on servers identified as replicas (Primary: No). This prevents unnecessary querying.

Example Output:

<img width="516" height="372" alt="image" src="https://github.com/user-attachments/assets/1401edd0-2328-47d7-9946-ffcc0afc4152" />




Open Questions (Feedback Requested):

As discussed in the issue thread, there are a few follow-up items I would like your input on to see if they should be included in this PR or handled in a separate issue:

1. Split-Brain Detection: For the split-brain detection (multiple primaries), should we log an error in the FOREACH_VALID_SERVER loop in status_details, or add a specific split_brain flag to the output?

2. Primary Validation: Should we explicitly validate that the standbys are actually streaming from our recognized primary? (This might require IP resolving to match sender_host against our configured primary host/port).

closes #692 