### PR TITLE
[#980] Add split-brain detection to status details

### DIFF
--- a/src/include/management.h
+++ b/src/include/management.h
@@ -119,6 +119,7 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_MODE                "Mode"
 #define MANAGEMENT_ARGUMENT_TIMEOUT             "Timeout"
 #define MANAGEMENT_ARGUMENT_NUMBER_OF_SERVERS   "NumberOfServers"
+#define MANAGEMENT_ARGUMENT_SPLIT_BRAIN         "SplitBrain"
 #define MANAGEMENT_ARGUMENT_OUTPUT              "Output"
 #define MANAGEMENT_ARGUMENT_PASSWORD            "Password"
 #define MANAGEMENT_ARGUMENT_PID                 "PID"

--- a/src/libpgagroal/status.c
+++ b/src/libpgagroal/status.c
@@ -196,6 +196,7 @@ status_details(bool details, struct json* response)
    pgagroal_json_create(&servers);
    pgagroal_json_create(&standbys);
 
+   int number_of_primary = 0;
    FOREACH_VALID_SERVER
    {
       struct json* js = NULL;
@@ -217,6 +218,10 @@ status_details(bool details, struct json* response)
 
       pgagroal_server_get_connectivity_info(i, &srv_status, &srv_primary, &behind_bytes);
 
+      if (pgagroal_compare_string(srv_primary, "Yes"))
+      {
+         number_of_primary++;
+      }
       pgagroal_json_create(&js);
 
       pgagroal_json_put(js, MANAGEMENT_ARGUMENT_SERVER, (uintptr_t)config->servers[i].name, ValueString);
@@ -260,6 +265,11 @@ status_details(bool details, struct json* response)
       }
    }
 
+   if (number_of_primary > 1)
+   {
+      pgagroal_log_warn("Multiple primary servers detected (%d)", number_of_primary);
+      pgagroal_json_put(response, MANAGEMENT_ARGUMENT_SPLIT_BRAIN, (uintptr_t)"Yes", ValueString);
+   }
    pgagroal_json_put(response, MANAGEMENT_ARGUMENT_SERVERS, (uintptr_t)servers, ValueJSON);
    pgagroal_json_put(response, MANAGEMENT_ARGUMENT_STANDBYS, (uintptr_t)standbys, ValueJSON);
 


### PR DESCRIPTION
Following up on the discussion in #977, this PR introduces split-brain detection to identify misconfigurations where multiple servers report as the primary at the same time.

**Changes implemented:**
* Track the total number of primary servers during the `FOREACH_VALID_SERVER` loop in `status_details()` (`status.c`).
* Emit a warning log (`pgagroal_log_warn`) if more than one primary server is detected.
* Introduce a new `split_brain` field (`MANAGEMENT_SPLIT_BRAIN`) to the JSON management response. It outputs "Yes" or "No" based on existence of multiple primaries

I have tested this locally and verified that the tracking logic correctly identifies the primary states and outputs the expected JSON.
warning example:
<img width="702" height="41" alt="image" src="https://github.com/user-attachments/assets/bdcd7648-2b61-47e2-87c5-eb92ac7d230a" />
Status details example:
<img width="349" height="56" alt="image" src="https://github.com/user-attachments/assets/17f7f8a1-ad67-4ada-97fe-1ec29f97a2ef" />

config:
<img width="400" height="230" alt="image" src="https://github.com/user-attachments/assets/7f7c9e46-f67d-4f34-9f72-29d4cd808146" />

closes #980 
