### PR TITLE
[#52] Add SCRAM-SHA-256-PLUS channel binding

### DIFF
--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -701,6 +701,15 @@ int
 pgagroal_as_hugepage(char* str, unsigned char* hp);
 
 /**
+ * Parse a string as a channel binding setting
+ * @param str The string to parse
+ * @param cb The resulting channel binding setting
+ * @return 0 on success, 1 on failure
+ */
+int
+pgagroal_as_channel_binding(char* str, unsigned char* cb);
+
+/**
  * Parse a string as a startup validation mode
  * @param str The string to parse
  * @param sv The resulting startup validation mode

--- a/src/include/message.h
+++ b/src/include/message.h
@@ -286,10 +286,11 @@ pgagroal_create_auth_password_response(char* password, struct message** msg);
  * Write an auth SCRAM-SHA-256 message
  * @param ssl The SSL struct
  * @param socket The socket descriptor
+ * @param channel_binding Advertise SCRAM-SHA-256-PLUS as well (requires a TLS frontend)
  * @return 0 upon success, otherwise 1
  */
 int
-pgagroal_write_auth_scram256(SSL* ssl, int socket);
+pgagroal_write_auth_scram256(SSL* ssl, int socket, bool channel_binding);
 
 /**
  * Create an auth SCRAM-SHA-256 response message
@@ -299,6 +300,15 @@ pgagroal_write_auth_scram256(SSL* ssl, int socket);
  */
 int
 pgagroal_create_auth_scram256_response(char* nounce, struct message** msg);
+
+/**
+ * Create an auth SCRAM-SHA-256-PLUS response message (tls-server-end-point channel binding)
+ * @param nounce The nounce
+ * @param msg The resulting message
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgagroal_create_auth_scram256_plus_response(char* nounce, struct message** msg);
 
 /**
  * Create an auth SCRAM-SHA-256/Continue message

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -172,6 +172,10 @@ extern "C" {
 #define HUGEPAGE_TRY                   1
 #define HUGEPAGE_ON                    2
 
+#define CHANNEL_BINDING_DISABLED       0
+#define CHANNEL_BINDING_PREFER         1
+#define CHANNEL_BINDING_REQUIRE        2
+
 #define STARTUP_VALIDATION_OFF         0
 #define STARTUP_VALIDATION_TRY         1
 #define STARTUP_VALIDATION_ON          2
@@ -384,22 +388,23 @@ extern void* prometheus_cache_shmem;
  */
 struct server
 {
-   char name[MISC_LENGTH];       /**< The name of the server */
-   char host[MISC_LENGTH];       /**< The host name of the server */
-   int port;                     /**< The port of the server */
-   int version;                  /**< The major version of the server */
-   int minor_version;            /**< The minor version of the server */
-   char system_identifier[64];   /**< The system identifier of the server */
-   bool tls;                     /**< Use TLS if possible */
-   bool valid;                   /**< Is the server valid */
-   char tls_cert_file[MAX_PATH]; /**< TLS certificate path */
-   char tls_key_file[MAX_PATH];  /**< TLS key path */
-   char tls_ca_file[MAX_PATH];   /**< TLS CA certificate path */
-   atomic_schar state;           /**< The state of the server */
-   atomic_schar health_state;    /**< The health state of the server */
-   unsigned int failures;        /**< The number of failures */
-   atomic_schar auth_type;       /**< The authentication type used for health check */
-   int lineno;                   /**< The line number within the configuration file */
+   char name[MISC_LENGTH];        /**< The name of the server */
+   char host[MISC_LENGTH];        /**< The host name of the server */
+   int port;                      /**< The port of the server */
+   int version;                   /**< The major version of the server */
+   int minor_version;             /**< The minor version of the server */
+   char system_identifier[64];    /**< The system identifier of the server */
+   bool tls;                      /**< Use TLS if possible */
+   bool valid;                    /**< Is the server valid */
+   char tls_cert_file[MAX_PATH];  /**< TLS certificate path */
+   char tls_key_file[MAX_PATH];   /**< TLS key path */
+   char tls_ca_file[MAX_PATH];    /**< TLS CA certificate path */
+   unsigned char channel_binding; /**< SCRAM channel binding (CHANNEL_BINDING_*) */
+   atomic_schar state;            /**< The state of the server */
+   atomic_schar health_state;     /**< The health state of the server */
+   unsigned int failures;         /**< The number of failures */
+   atomic_schar auth_type;        /**< The authentication type used for health check */
+   int lineno;                    /**< The line number within the configuration file */
 } __attribute__((aligned(64)));
 
 #define FOREACH_SERVER for (int i = 0; i < config->number_of_servers; i++)

--- a/src/include/tls.h
+++ b/src/include/tls.h
@@ -323,6 +323,20 @@ int
 pgagroal_tls_own(struct tls* tls);
 
 /**
+ * Compute the tls-server-end-point channel binding hash (RFC 5929 4.1) for a
+ * connection's certificate: our own when acting as the TLS server, the peer's
+ * when acting as the client
+ * @param ssl The OpenSSL connection
+ * @param peer true to hash the peer certificate, false for our own
+ * @param out The destination buffer (>= EVP_MAX_MD_SIZE)
+ * @param cap The buffer capacity
+ * @param out_len The produced hash length
+ * @return PGAGROAL_TLS_OK upon success, otherwise PGAGROAL_TLS_ERROR
+ */
+int
+pgagroal_tls_cert_endpoint_hash(SSL* ssl, bool peer, unsigned char* out, size_t cap, size_t* out_len);
+
+/**
  * Initialize one record direction from its TLS 1.3 application traffic secret
  * @param dir The direction
  * @param aead The AEAD suite (PGAGROAL_TLS_AEAD_*)

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -129,6 +129,7 @@ static int to_update_process_title(char* where, int value);
 static int to_validation(char* where, int value);
 static int to_startup_validation(char* where, int value);
 static int to_hugepage(char* where, int value);
+static int to_channel_binding(char* where, int value);
 static int to_pipeline(char* where, int value);
 static int to_log_mode(char* where, int value);
 static int to_log_level(char* where, int value);
@@ -316,6 +317,7 @@ pgagroal_read_configuration(void* shm, char* filename, bool emit_warnings)
                memcpy(&srv.name, &section, strlen(section));
                srv.lineno = lineno;
                srv.valid = true;
+               srv.channel_binding = CHANNEL_BINDING_PREFER;
                idx_server++;
             }
          }
@@ -3015,6 +3017,30 @@ pgagroal_as_hugepage(char* str, unsigned char* hp)
 }
 
 int
+pgagroal_as_channel_binding(char* str, unsigned char* cb)
+{
+   if (!strcasecmp(str, "disabled"))
+   {
+      *cb = CHANNEL_BINDING_DISABLED;
+      return 0;
+   }
+
+   if (!strcasecmp(str, "prefer"))
+   {
+      *cb = CHANNEL_BINDING_PREFER;
+      return 0;
+   }
+
+   if (!strcasecmp(str, "require"))
+   {
+      *cb = CHANNEL_BINDING_REQUIRE;
+      return 0;
+   }
+
+   return 1;
+}
+
+int
 pgagroal_as_startup_validation(char* str, int* sv)
 {
    if (!strcasecmp(str, "off"))
@@ -3909,6 +3935,7 @@ static bool
 is_same_tls(struct server* src, struct server* dst)
 {
    if (src->tls == dst->tls &&
+       src->channel_binding == dst->channel_binding &&
        !strncmp(src->tls_cert_file, dst->tls_cert_file, MAX_PATH) &&
        !strncmp(src->tls_key_file, dst->tls_key_file, MAX_PATH) &&
        !strncmp(src->tls_ca_file, dst->tls_ca_file, MAX_PATH))
@@ -4019,6 +4046,7 @@ copy_server(struct server* dst, struct server* src)
    dst->minor_version = minor_version;
    memcpy(&dst->system_identifier[0], system_identifier, sizeof(dst->system_identifier));
    dst->tls = src->tls;
+   dst->channel_binding = src->channel_binding;
    memcpy(&dst->tls_cert_file[0], &src->tls_cert_file[0], MAX_PATH);
    memcpy(&dst->tls_key_file[0], &src->tls_key_file[0], MAX_PATH);
    memcpy(&dst->tls_ca_file[0], &src->tls_ca_file[0], MAX_PATH);
@@ -5016,6 +5044,10 @@ pgagroal_write_server_config_value(char* buffer, char* server_name, char* config
    {
       return to_bool(buffer, config->servers[server_index].tls);
    }
+   else if (!strncmp(config_key, "channel_binding", MISC_LENGTH))
+   {
+      return to_channel_binding(buffer, config->servers[server_index].channel_binding);
+   }
    else if (!strncmp(config_key, "tls_cert_file", MAX_PATH))
    {
       return to_string(buffer, config->servers[server_index].tls_cert_file, buffer_size);
@@ -5431,6 +5463,36 @@ to_hugepage(char* where, int value)
 }
 
 /**
+ * An utility function to convert the channel_binding enum to its string value
+ * @param where the buffer used to store the resulting string
+ * @param value the server channel_binding setting
+ * @return 0 on success, 1 otherwise
+ */
+static int
+to_channel_binding(char* where, int value)
+{
+   if (!where || value < 0)
+   {
+      return 1;
+   }
+
+   switch (value)
+   {
+      case CHANNEL_BINDING_DISABLED:
+         pgagroal_snprintf(where, MISC_LENGTH, "%s", "disabled");
+         break;
+      case CHANNEL_BINDING_PREFER:
+         pgagroal_snprintf(where, MISC_LENGTH, "%s", "prefer");
+         break;
+      case CHANNEL_BINDING_REQUIRE:
+         pgagroal_snprintf(where, MISC_LENGTH, "%s", "require");
+         break;
+   }
+
+   return 0;
+}
+
+/**
  * An utility function to convert the enumeration of values for the pipeline setting
  * into one of its possible string descriptions.
  *
@@ -5826,6 +5888,13 @@ pgagroal_apply_main_configuration(struct main_configuration* config,
    else if (key_in_section("tls", section, key, false, &unknown))
    {
       if (pgagroal_as_bool(value, &srv->tls))
+      {
+         unknown = true;
+      }
+   }
+   else if (key_in_section("channel_binding", section, key, false, &unknown))
+   {
+      if (pgagroal_as_channel_binding(value, &srv->channel_binding))
       {
          unknown = true;
       }

--- a/src/libpgagroal/message.c
+++ b/src/libpgagroal/message.c
@@ -973,21 +973,37 @@ pgagroal_create_auth_password_response(char* password, struct message** msg)
 }
 
 int
-pgagroal_write_auth_scram256(SSL* ssl, int socket)
+pgagroal_write_auth_scram256(SSL* ssl, int socket, bool channel_binding)
 {
-   char scram[24];
+   char scram[43];
    struct message msg;
+   size_t offset;
 
    memset(&msg, 0, sizeof(struct message));
    memset(&scram, 0, sizeof(scram));
 
    scram[0] = 'R';
-   pgagroal_write_int32(&(scram[1]), 23);
    pgagroal_write_int32(&(scram[5]), 10);
-   pgagroal_write_string(&(scram[9]), "SCRAM-SHA-256");
+   offset = 9;
+
+   /* Offer channel binding first so a capable client prefers it; it is only
+    * meaningful once the frontend link is TLS. The NUL after each mechanism and
+    * the empty string terminating the list come from the zeroed buffer. */
+   if (channel_binding && ssl != NULL)
+   {
+      pgagroal_write_string(&(scram[offset]), "SCRAM-SHA-256-PLUS");
+      offset += strlen("SCRAM-SHA-256-PLUS") + 1;
+   }
+
+   pgagroal_write_string(&(scram[offset]), "SCRAM-SHA-256");
+   offset += strlen("SCRAM-SHA-256") + 1;
+
+   offset += 1;
+
+   pgagroal_write_int32(&(scram[1]), offset - 1);
 
    msg.kind = 'R';
-   msg.length = 24;
+   msg.length = offset;
    msg.data = &scram;
 
    if (ssl == NULL)
@@ -1028,6 +1044,56 @@ pgagroal_create_auth_scram256_response(char* nounce, struct message** msg)
    pgagroal_write_string(m->data + 5, "SCRAM-SHA-256");
    pgagroal_write_string(m->data + 22, " n,,n=,r=");
    pgagroal_write_string(m->data + 31, nounce);
+
+   *msg = m;
+
+   return MESSAGE_STATUS_OK;
+}
+
+int
+pgagroal_create_auth_scram256_plus_response(char* nounce, struct message** msg)
+{
+   struct message* m = NULL;
+   size_t size;
+   size_t offset;
+   char* mechanism = "SCRAM-SHA-256-PLUS";
+   char* initial = "p=tls-server-end-point,,n=,r=";
+   int ir_len;
+
+   ir_len = (int)(strlen(initial) + strlen(nounce));
+
+   /* 'p' + length + mechanism + NUL + initial-response length + initial response */
+   size = 1 + 4 + strlen(mechanism) + 1 + 4 + strlen(initial) + strlen(nounce);
+
+   m = (struct message*)malloc(sizeof(struct message));
+   if (m == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating auth_scram256_plus_response");
+      return MESSAGE_STATUS_ERROR;
+   }
+   m->data = calloc(1, size);
+   if (m->data == NULL)
+   {
+      pgagroal_log_fatal("Couldn't allocate memory while creating auth_scram256_plus_response");
+      free(m);
+      return MESSAGE_STATUS_ERROR;
+   }
+
+   m->kind = 'p';
+   m->length = size;
+
+   offset = 0;
+   pgagroal_write_byte(m->data + offset, 'p');
+   offset += 1;
+   pgagroal_write_int32(m->data + offset, size - 1);
+   offset += 4;
+   pgagroal_write_string(m->data + offset, mechanism);
+   offset += strlen(mechanism) + 1;
+   pgagroal_write_int32(m->data + offset, ir_len);
+   offset += 4;
+   pgagroal_write_string(m->data + offset, initial);
+   offset += strlen(initial);
+   pgagroal_write_string(m->data + offset, nounce);
 
    *msg = m;
 

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -87,6 +87,7 @@ static int client_password(SSL* c_ssl, int client_fd, char* username, char* pass
 static int client_scram256(SSL* c_ssl, int client_fd, char* username, char* password, int slot);
 static int client_ok(SSL* c_ssl, int client_fd, int slot);
 static int server_passthrough(struct message* msg, int auth_type, SSL* c_ssl, SSL* s_ssl, int client_fd, int slot);
+static void scram_strip_channel_binding(struct message* msg);
 static int server_authenticate(struct message* msg, int auth_type, char* username, char* password,
                                int slot, SSL* server_ssl);
 static int server_trust(int slot, SSL* server_ssl);
@@ -1954,6 +1955,12 @@ client_scram256(SSL* c_ssl, int client_fd, char* username __attribute__((unused)
    size_t server_signature_calc_length = 0;
    char* base64_server_signature_calc = NULL;
    size_t base64_server_signature_calc_length;
+   bool client_plus = false;
+   char gs2_header[64];
+   size_t gs2_header_length = 0;
+   char* base64_channel_binding = NULL;
+   unsigned char* channel_binding = NULL;
+   size_t channel_binding_length = 0;
    struct main_configuration* config;
    struct message* msg = NULL;
    struct message* sasl_continue = NULL;
@@ -1963,7 +1970,7 @@ client_scram256(SSL* c_ssl, int client_fd, char* username __attribute__((unused)
 
    config = (struct main_configuration*)shmem;
 
-   status = pgagroal_write_auth_scram256(c_ssl, client_fd);
+   status = pgagroal_write_auth_scram256(c_ssl, client_fd, true);
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;
@@ -1991,17 +1998,70 @@ retry:
       goto error;
    }
 
-   /* 'p' + length + mechanism + "n,,n=,r=" + nounce */
+   /* SASLInitialResponse: 'p' + length + mechanism + NUL + int32 initial-response
+    * length + gs2-header + client-first-message-bare */
    if (msg->length <= 26)
    {
       goto error;
    }
 
-   client_first_message_bare = calloc(1, msg->length - 25);
+   {
+      char* mechanism = (char*)msg->data + 5;
+      char* ir;
+      size_t ir_length;
+      size_t header;
+      size_t gs2_length = 0;
+      int commas = 0;
 
-   memcpy(client_first_message_bare, msg->data + 26, msg->length - 26);
+      client_plus = strcmp(mechanism, "SCRAM-SHA-256-PLUS") == 0;
 
-   get_scram_attribute('r', (char*)msg->data + 26, msg->length - 26, &client_nounce);
+      /* The initial response follows the mechanism NUL and its int32 length */
+      header = 5 + strlen(mechanism) + 1 + 4;
+      if ((size_t)msg->length <= header)
+      {
+         goto error;
+      }
+      ir = (char*)msg->data + header;
+      ir_length = msg->length - header;
+
+      /* The gs2 header ends after the second comma: "n,," / "y,," / "p=...,," */
+      for (size_t i = 0; i < ir_length; i++)
+      {
+         if (ir[i] == ',' && ++commas == 2)
+         {
+            gs2_length = i + 1;
+            break;
+         }
+      }
+      if (commas < 2 || gs2_length > sizeof(gs2_header))
+      {
+         goto error;
+      }
+
+      if (client_plus)
+      {
+         /* Only tls-server-end-point is supported, and only over a TLS frontend */
+         if (c_ssl == NULL || gs2_length != 24 ||
+             memcmp(ir, "p=tls-server-end-point,,", 24) != 0)
+         {
+            goto error;
+         }
+      }
+      else if (c_ssl != NULL && ir[0] == 'y')
+      {
+         /* We advertised -PLUS, so "y" is a channel-binding downgrade attempt */
+         goto error;
+      }
+
+      /* msg is reused for later reads, so keep our own copy of the gs2 header */
+      memcpy(gs2_header, ir, gs2_length);
+      gs2_header_length = gs2_length;
+
+      client_first_message_bare = calloc(1, ir_length - gs2_length + 1);
+      memcpy(client_first_message_bare, ir + gs2_length, ir_length - gs2_length);
+
+      get_scram_attribute('r', client_first_message_bare, ir_length - gs2_length, &client_nounce);
+   }
 
    if (client_nounce == NULL)
    {
@@ -2039,24 +2099,69 @@ retry:
       goto error;
    }
 
-   /* 'p' + length + "c=biws,r=" + nounces (57 bytes) + ",p=" + proof */
+   /* client-final: 'p' + length + "c=<cbind>,r=<combined>" + ",p=" + proof */
    if (msg->length < 62)
    {
       goto error;
    }
 
-   get_scram_attribute('p', (char*)msg->data + 5, msg->length - 5, &base64_client_proof);
-
-   if (base64_client_proof == NULL)
    {
-      goto error;
+      char* cf = (char*)msg->data + 5;
+      size_t cf_length = msg->length - 5;
+      char* proof_delim = NULL;
+      unsigned char expected_cbind[64 + EVP_MAX_MD_SIZE];
+      size_t expected_cbind_length;
+      size_t endpoint_hash_length = 0;
+
+      get_scram_attribute('p', cf, cf_length, &base64_client_proof);
+      if (base64_client_proof == NULL)
+      {
+         goto error;
+      }
+      pgagroal_base64_decode(base64_client_proof, strlen(base64_client_proof), (void**)&client_proof_received, &client_proof_received_length);
+
+      /* client-final-message-without-proof is everything before ",p=" */
+      for (size_t i = 0; i + 2 < cf_length; i++)
+      {
+         if (cf[i] == ',' && cf[i + 1] == 'p' && cf[i + 2] == '=')
+         {
+            proof_delim = cf + i;
+            break;
+         }
+      }
+      if (proof_delim == NULL)
+      {
+         goto error;
+      }
+      client_final_message_without_proof = calloc(1, (proof_delim - cf) + 1);
+      memcpy(client_final_message_without_proof, cf, proof_delim - cf);
+
+      /* Channel binding: c= must equal base64(gs2-header [|| endpoint hash]) */
+      get_scram_attribute('c', cf, cf_length, &base64_channel_binding);
+      if (base64_channel_binding == NULL)
+      {
+         goto error;
+      }
+      pgagroal_base64_decode(base64_channel_binding, strlen(base64_channel_binding), (void**)&channel_binding, &channel_binding_length);
+
+      memcpy(expected_cbind, gs2_header, gs2_header_length);
+      expected_cbind_length = gs2_header_length;
+      if (client_plus)
+      {
+         if (pgagroal_tls_cert_endpoint_hash(c_ssl, false, &expected_cbind[gs2_header_length],
+                                             sizeof(expected_cbind) - gs2_header_length, &endpoint_hash_length))
+         {
+            goto error;
+         }
+         expected_cbind_length += endpoint_hash_length;
+      }
+
+      if (channel_binding == NULL || channel_binding_length != expected_cbind_length ||
+          memcmp(channel_binding, expected_cbind, expected_cbind_length) != 0)
+      {
+         goto error;
+      }
    }
-
-   pgagroal_base64_decode(base64_client_proof, strlen(base64_client_proof), (void**)&client_proof_received, &client_proof_received_length);
-
-   client_final_message_without_proof = calloc(1, 58);
-
-   memcpy(client_final_message_without_proof, msg->data + 5, 57);
 
    sasl_prep(password, &password_prep);
 
@@ -2115,7 +2220,9 @@ retry:
    free(salt);
    free(base64_salt);
    free(base64_client_proof);
+   free(base64_channel_binding);
    free(client_proof_received);
+   free(channel_binding);
    free(client_proof_calc);
    free(server_signature_calc);
    free(base64_server_signature_calc);
@@ -2135,7 +2242,9 @@ bad_password:
    free(salt);
    free(base64_salt);
    free(base64_client_proof);
+   free(base64_channel_binding);
    free(client_proof_received);
+   free(channel_binding);
    free(client_proof_calc);
    free(server_signature_calc);
    free(base64_server_signature_calc);
@@ -2155,7 +2264,9 @@ error:
    free(salt);
    free(base64_salt);
    free(base64_client_proof);
+   free(base64_channel_binding);
    free(client_proof_received);
+   free(channel_binding);
    free(client_proof_calc);
    free(server_signature_calc);
    free(base64_server_signature_calc);
@@ -2262,6 +2373,13 @@ server_passthrough(struct message* msg, int auth_type, SSL* c_ssl, SSL* s_ssl, i
       pgagroal_log_message(msg);
       pgagroal_log_error("Security message too large: %ld", msg->length);
       goto error;
+   }
+
+   /* Passthrough terminates the client TLS locally, so channel binding cannot be
+    * relayed to the backend: never offer SCRAM-SHA-256-PLUS on this path. */
+   if (auth_type == SECURITY_SCRAM256)
+   {
+      scram_strip_channel_binding(msg);
    }
 
    config->connections[slot].security_lengths[auth_index] = msg->length;
@@ -2649,11 +2767,92 @@ error:
    return AUTH_ERROR;
 }
 
+/* Return true if the backend AuthenticationSASL message advertises the mechanism. */
+static bool
+scram_mechanism_offered(char* sasl, size_t sasl_length, const char* name)
+{
+   size_t offset = 9; /* 'R' + int32 length + int32 auth type */
+
+   if (sasl == NULL)
+   {
+      return false;
+   }
+
+   while (offset < sasl_length)
+   {
+      char* mechanism = sasl + offset;
+      size_t len = strlen(mechanism);
+
+      if (len == 0)
+      {
+         break;
+      }
+      if (!strcmp(mechanism, name))
+      {
+         return true;
+      }
+      offset += len + 1;
+   }
+
+   return false;
+}
+
+/* Drop SCRAM-SHA-256-PLUS from a relayed AuthenticationSASL mechanism list.
+ * pgagroal terminates the client TLS, so a passthrough client that bound to our
+ * certificate would be rejected by the backend; not advertising channel binding
+ * lets channel_binding=prefer fall back to SCRAM-SHA-256 and channel_binding=require
+ * fail cleanly. Mirrors PostgreSQL's conditional scram_get_mechanisms(). */
+static void
+scram_strip_channel_binding(struct message* msg)
+{
+   char* data;
+   size_t offset = 9; /* 'R' + int32 length + int32 auth type */
+   size_t out = 9;
+
+   if (msg == NULL || msg->kind != 'R' || msg->length < 9 ||
+       pgagroal_read_int32((char*)msg->data + 5) != 10)
+   {
+      return;
+   }
+
+   data = (char*)msg->data;
+
+   while (offset < (size_t)msg->length && data[offset] != '\0')
+   {
+      char* mechanism = data + offset;
+      size_t len = strlen(mechanism);
+
+      if (strcmp(mechanism, "SCRAM-SHA-256-PLUS"))
+      {
+         if (out != offset)
+         {
+            memmove(data + out, mechanism, len + 1);
+         }
+         out += len + 1;
+      }
+
+      offset += len + 1;
+   }
+
+   /* Empty string terminates the mechanism list */
+   data[out] = '\0';
+   out += 1;
+
+   msg->length = out;
+   pgagroal_write_int32(data + 1, out - 1);
+}
+
 static int
 server_scram256(char* username, char* password, int slot, SSL* server_ssl)
 {
    int status = MESSAGE_STATUS_ERROR;
    int auth_index = 1;
+   size_t client_first_message_bare_length = 0;
+   char cfmb[128];
+   char plus_final[256];
+   char* client_final = NULL;
+   struct server* srv = NULL;
+   bool use_plus = false;
    int server_fd;
    char* salt = NULL;
    size_t salt_length = 0;
@@ -2696,7 +2895,31 @@ server_scram256(char* username, char* password, int slot, SSL* server_ssl)
 
    generate_nounce(&client_nounce);
 
-   status = pgagroal_create_auth_scram256_response(client_nounce, &sasl_response);
+   srv = &config->servers[config->connections[slot].server];
+
+   /* Offer -PLUS when the backend link is TLS, the backend advertised it, and
+    * channel_binding permits it. */
+   if (server_ssl != NULL && srv->channel_binding != CHANNEL_BINDING_DISABLED &&
+       scram_mechanism_offered(config->connections[slot].security_messages[0],
+                               config->connections[slot].security_lengths[0], "SCRAM-SHA-256-PLUS"))
+   {
+      use_plus = true;
+      pgagroal_log_debug("SCRAM: using channel binding (SCRAM-SHA-256-PLUS) for server %s", srv->name);
+   }
+   else if (srv->channel_binding == CHANNEL_BINDING_REQUIRE)
+   {
+      pgagroal_log_error("SCRAM: channel binding required but unavailable for server %s", srv->name);
+      goto error;
+   }
+
+   if (use_plus)
+   {
+      status = pgagroal_create_auth_scram256_plus_response(client_nounce, &sasl_response);
+   }
+   else
+   {
+      status = pgagroal_create_auth_scram256_response(client_nounce, &sasl_response);
+   }
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;
@@ -2765,18 +2988,48 @@ server_scram256(char* username, char* password, int slot, SSL* server_ssl)
    }
 
    memset(&wo_proof[0], 0, sizeof(wo_proof));
-   pgagroal_snprintf(&wo_proof[0], sizeof(wo_proof), "c=biws,r=%s", combined_nounce);
+   if (use_plus)
+   {
+      unsigned char cbind[24 + EVP_MAX_MD_SIZE];
+      size_t cbind_length = 24;
+      size_t cbind_hash_length = 0;
+      char* cbind_b64 = NULL;
+      size_t cbind_b64_length = 0;
 
-   /* n=,r=... */
-   client_first_message_bare = config->connections[slot].security_messages[1] + 26;
+      /* cbind-input = gs2-header || tls-server-end-point(backend certificate) */
+      memcpy(cbind, "p=tls-server-end-point,,", 24);
+      if (pgagroal_tls_cert_endpoint_hash(server_ssl, true, cbind + 24, sizeof(cbind) - 24, &cbind_hash_length))
+      {
+         goto error;
+      }
+      cbind_length += cbind_hash_length;
+
+      pgagroal_base64_encode((char*)cbind, cbind_length, &cbind_b64, &cbind_b64_length);
+      pgagroal_snprintf(plus_final, sizeof(plus_final), "c=%s,r=%s", cbind_b64, combined_nounce);
+      free(cbind_b64);
+      client_final = plus_final;
+
+      pgagroal_snprintf(cfmb, sizeof(cfmb), "n=,r=%s", client_nounce);
+      client_first_message_bare = cfmb;
+      client_first_message_bare_length = strlen(cfmb);
+   }
+   else
+   {
+      pgagroal_snprintf(&wo_proof[0], sizeof(wo_proof), "c=biws,r=%s", combined_nounce);
+      client_final = &wo_proof[0];
+
+      /* n=,r=... */
+      client_first_message_bare = config->connections[slot].security_messages[1] + 26;
+      client_first_message_bare_length = config->connections[slot].security_lengths[1] - 26;
+   }
 
    /* r=...,s=...,i=4096 */
    server_first_message = config->connections[slot].security_messages[2] + 9;
 
    if (client_proof(password_prep, salt, salt_length, iteration,
-                    client_first_message_bare, config->connections[slot].security_lengths[1] - 26,
+                    client_first_message_bare, client_first_message_bare_length,
                     server_first_message, config->connections[slot].security_lengths[2] - 9,
-                    &wo_proof[0], strlen(wo_proof),
+                    client_final, strlen(client_final),
                     &proof, &proof_length))
    {
       goto error;
@@ -2784,7 +3037,7 @@ server_scram256(char* username, char* password, int slot, SSL* server_ssl)
 
    pgagroal_base64_encode((char*)proof, proof_length, &proof_base, &proof_base_length);
 
-   status = pgagroal_create_auth_scram256_continue_response(&wo_proof[0], (char*)proof_base, &sasl_continue_response);
+   status = pgagroal_create_auth_scram256_continue_response(client_final, (char*)proof_base, &sasl_continue_response);
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;
@@ -2835,9 +3088,9 @@ server_scram256(char* username, char* password, int slot, SSL* server_ssl)
 
    if (server_signature(password_prep, salt, salt_length, iteration,
                         NULL, 0,
-                        client_first_message_bare, config->connections[slot].security_lengths[1] - 26,
+                        client_first_message_bare, client_first_message_bare_length,
                         server_first_message, config->connections[slot].security_lengths[2] - 9,
-                        &wo_proof[0], strlen(wo_proof),
+                        client_final, strlen(client_final),
                         &server_signature_calc, &server_signature_calc_length))
    {
       goto error;
@@ -5076,7 +5329,7 @@ auth_query_client_scram256(SSL* c_ssl, int client_fd, char* username __attribute
 
    config = (struct main_configuration*)shmem;
 
-   status = pgagroal_write_auth_scram256(c_ssl, client_fd);
+   status = pgagroal_write_auth_scram256(c_ssl, client_fd, false);
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;

--- a/src/libpgagroal/tls.c
+++ b/src/libpgagroal/tls.c
@@ -1529,3 +1529,76 @@ pgagroal_tls_own(struct tls* tls)
 
    return PGAGROAL_TLS_OK;
 }
+
+int
+pgagroal_tls_cert_endpoint_hash(SSL* ssl, bool peer, unsigned char* out, size_t cap, size_t* out_len)
+{
+   X509* cert = NULL;
+   const EVP_MD* md = NULL;
+   unsigned char hash[EVP_MAX_MD_SIZE];
+   unsigned int len = 0;
+   int algo_nid = 0;
+   int result = PGAGROAL_TLS_ERROR;
+
+   if (out_len != NULL)
+   {
+      *out_len = 0;
+   }
+   if (ssl == NULL || out == NULL)
+   {
+      return PGAGROAL_TLS_ERROR;
+   }
+
+   /* tls-server-end-point binds to the server's certificate: our own when we
+    * are the TLS server, the peer's when we are the client. */
+   cert = peer ? SSL_get_peer_certificate(ssl) : SSL_get_certificate(ssl);
+   if (cert == NULL)
+   {
+      goto error;
+   }
+
+   /* RFC 5929 4.1: hash with the certificate signature's hash, except MD5 and
+    * SHA-1 which are upgraded to SHA-256. */
+   if (!X509_get_signature_info(cert, &algo_nid, NULL, NULL, NULL))
+   {
+      goto error;
+   }
+   if (algo_nid == NID_md5 || algo_nid == NID_sha1)
+   {
+      md = EVP_sha256();
+   }
+   else
+   {
+      md = EVP_get_digestbynid(algo_nid);
+   }
+   if (md == NULL)
+   {
+      goto error;
+   }
+
+   if (!X509_digest(cert, md, hash, &len))
+   {
+      goto error;
+   }
+   if ((size_t)len > cap)
+   {
+      goto error;
+   }
+
+   memcpy(out, hash, len);
+   if (out_len != NULL)
+   {
+      *out_len = (size_t)len;
+   }
+   result = PGAGROAL_TLS_OK;
+
+error:
+
+   /* SSL_get_peer_certificate increments the refcount; SSL_get_certificate does not. */
+   if (peer && cert != NULL)
+   {
+      X509_free(cert);
+   }
+
+   return result;
+}

--- a/test/testcases/test_message_complete.c
+++ b/test/testcases/test_message_complete.c
@@ -227,3 +227,42 @@ cleanup:
    }
    MCTF_FINISH();
 }
+
+/*
+ * SCRAM-SHA-256-PLUS client-first (channel binding). Locks down the fragile
+ * wire layout the backend -PLUS handshake depends on: the mechanism name, the
+ * gs2 header "p=tls-server-end-point,," and the initial-response length.
+ */
+MCTF_TEST(test_scram256_plus_client_first)
+{
+   const char* nounce = "abcdefghijklmnopqrstuvwx";
+   const char* initial = "p=tls-server-end-point,,n=,r=";
+   struct message* msg = NULL;
+   char* data;
+   int status;
+
+   status = pgagroal_create_auth_scram256_plus_response((char*)nounce, &msg);
+   MCTF_ASSERT_INT_EQ(status, MESSAGE_STATUS_OK, cleanup, "builder must succeed");
+   MCTF_ASSERT(msg != NULL, cleanup, "message must be returned");
+
+   data = (char*)msg->data;
+
+   MCTF_ASSERT(msg->kind == 'p', cleanup, "kind must be 'p'");
+   MCTF_ASSERT(data[0] == 'p', cleanup, "first byte must be 'p'");
+   MCTF_ASSERT_INT_EQ(pgagroal_read_int32(data + 1), (int)(msg->length - 1), cleanup,
+                      "declared length excludes the tag byte");
+   MCTF_ASSERT(strcmp(data + 5, "SCRAM-SHA-256-PLUS") == 0, cleanup,
+               "mechanism must be SCRAM-SHA-256-PLUS");
+   MCTF_ASSERT_INT_EQ(pgagroal_read_int32(data + 24), (int)(strlen(initial) + strlen(nounce)), cleanup,
+                      "initial-response length must cover gs2 header + bare");
+   MCTF_ASSERT(memcmp(data + 28, initial, strlen(initial)) == 0, cleanup,
+               "gs2 header + client-first-bare prefix");
+   MCTF_ASSERT(memcmp(data + 28 + strlen(initial), nounce, strlen(nounce)) == 0, cleanup,
+               "client nonce placement");
+   MCTF_ASSERT_INT_EQ((int)msg->length, (int)(1 + 4 + 18 + 1 + 4 + strlen(initial) + strlen(nounce)), cleanup,
+                      "total message length");
+
+cleanup:
+   pgagroal_free_message(msg);
+   MCTF_FINISH();
+}

--- a/test/testcases/test_tls.c
+++ b/test/testcases/test_tls.c
@@ -846,3 +846,56 @@ cleanup:
    }
    MCTF_FINISH();
 }
+
+// tls-server-end-point channel binding hash matches a direct SHA-256 digest of the cert
+MCTF_TEST(test_pgagroal_tls_cert_endpoint_hash)
+{
+   EVP_PKEY* key = NULL;
+   X509* crt = NULL;
+   SSL_CTX* ctx = NULL;
+   SSL* ssl = NULL;
+   unsigned char got[EVP_MAX_MD_SIZE];
+   unsigned char expected[EVP_MAX_MD_SIZE];
+   size_t got_len = 0;
+   unsigned int exp_len = 0;
+
+   MCTF_ASSERT_INT_EQ(tls_test_self_signed(&key, &crt), 0, cleanup, "self-signed cert");
+   ctx = SSL_CTX_new(TLS_server_method());
+   MCTF_ASSERT(ctx != NULL, cleanup, "server ctx");
+   MCTF_ASSERT(SSL_CTX_use_certificate(ctx, crt) == 1, cleanup, "use cert");
+   MCTF_ASSERT(SSL_CTX_use_PrivateKey(ctx, key) == 1, cleanup, "use key");
+   ssl = SSL_new(ctx);
+   MCTF_ASSERT(ssl != NULL, cleanup, "ssl");
+
+   /* our own certificate (peer = false); no handshake needed */
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_cert_endpoint_hash(ssl, false, got, sizeof(got), &got_len),
+                      PGAGROAL_TLS_OK, cleanup, "endpoint hash");
+
+   /* a SHA-256-signed certificate binds with SHA-256 (RFC 5929 4.1) */
+   X509_digest(crt, EVP_sha256(), expected, &exp_len);
+   MCTF_ASSERT(got_len == exp_len && got_len == 32, cleanup, "hash length 32 (SHA-256)");
+   MCTF_ASSERT(memcmp(got, expected, got_len) == 0, cleanup, "matches X509_digest(SHA-256)");
+
+   /* a NULL connection is rejected */
+   MCTF_ASSERT_INT_EQ(pgagroal_tls_cert_endpoint_hash(NULL, false, got, sizeof(got), &got_len),
+                      PGAGROAL_TLS_ERROR, cleanup, "null ssl rejected");
+
+cleanup:
+   if (ssl != NULL)
+   {
+      SSL_free(ssl);
+   }
+   if (ctx != NULL)
+   {
+      SSL_CTX_free(ctx);
+   }
+   if (crt != NULL)
+   {
+      X509_free(crt);
+   }
+   if (key != NULL)
+   {
+      EVP_PKEY_free(key);
+   }
+   MCTF_FINISH();
+}


### PR DESCRIPTION
Dual-sided tls-server-end-point channel binding on the terminated path, gated by a per-server channel_binding option (disabled/prefer/require). Pass-through does not advertise it.