### PR TITLE
Fix SCRAM salted_password key reuse on OpenSSL 3.0.2

### DIFF
--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -4088,8 +4088,9 @@ salted_password(char* password, char* salt, int salt_length, int iterations, uns
 
    for (int i = 2; i <= iterations; i++)
    {
-      /* passing nulls cause function to reuse the same key / password in the context */
-      if (EVP_MAC_init(ctx, NULL, 0, NULL) != 1)
+      /* Re-key with the password each round; a NULL re-init does not reliably
+       * reuse the key across all OpenSSL 3 providers. */
+      if (EVP_MAC_init(ctx, (const unsigned char*)password, password_length, params) != 1)
       {
          goto error;
       }


### PR DESCRIPTION
EVP_MAC_init(ctx, NULL, 0, NULL) does not reuse the HMAC key after EVP_MAC_final() on OpenSSL 3.0.2, so PBKDF2 iterations 2..n use a wrong key and every SCRAM authentication fails. Re-pass the password each round.