### PR TITLE
[#979] Add Prometheus metric for standby streaming status

### DIFF
--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -150,6 +150,10 @@ extern "C" {
 #define SERVER_HEALTH_UP               1
 #define SERVER_HEALTH_DOWN             2
 
+#define SERVER_STREAMING_PRIMARY       -1
+#define SERVER_STREAMING_NO            0
+#define SERVER_STREAMING_YES           1
+
 #define HEALTH_CHECK_AUTH_UNKNOWN      0
 #define HEALTH_CHECK_AUTH_TRUST        1
 #define HEALTH_CHECK_AUTH_SCRAM        3
@@ -402,6 +406,7 @@ struct server
    unsigned char channel_binding; /**< SCRAM channel binding (CHANNEL_BINDING_*) */
    atomic_schar state;            /**< The state of the server */
    atomic_schar health_state;     /**< The health state of the server */
+   atomic_int streaming_state;    /**< The streaming state of the server SERVER_STREAMING_PRIMARY/NO/YES */
    unsigned int failures;         /**< The number of failures */
    atomic_schar auth_type;        /**< The authentication type used for health check */
    int lineno;                    /**< The line number within the configuration file */

--- a/src/libpgagroal/health.c
+++ b/src/libpgagroal/health.c
@@ -201,6 +201,48 @@ health_check_loop(void)
                atomic_store(&config->servers[i].health_state, SERVER_HEALTH_DOWN);
             }
          }
+
+         int current_state = atomic_load(&config->servers[i].state);
+         if (current_state == SERVER_PRIMARY || current_state == SERVER_NOTINIT_PRIMARY)
+         {
+            atomic_store(&config->servers[i].streaming_state, SERVER_STREAMING_PRIMARY);
+         }
+         else if (up)
+         {
+            char rep_status[64] = {0};
+            char slot_name[64] = {0};
+            char sender_host[MISC_LENGTH] = {0};
+            char sender_port[16] = {0};
+
+            int wal_result = pgagroal_server_get_wal_receiver_status(i,
+                                                                     rep_status, sizeof(rep_status),
+                                                                     slot_name, sizeof(slot_name),
+                                                                     sender_host, sizeof(sender_host),
+                                                                     sender_port, sizeof(sender_port));
+            bool is_streaming = pgagroal_compare_string(rep_status, "streaming");
+
+            if (wal_result == 0)
+            {
+               if (is_streaming)
+               {
+                  atomic_store(&config->servers[i].streaming_state, SERVER_STREAMING_YES);
+               }
+               else
+               {
+                  atomic_store(&config->servers[i].streaming_state, SERVER_STREAMING_NO);
+               }
+            }
+            else
+            {
+               pgagroal_log_debug("server %d failed to receive wal_result, setting streaming state to NO", i);
+               atomic_store(&config->servers[i].streaming_state, SERVER_STREAMING_NO);
+            }
+         }
+         else
+         {
+            pgagroal_log_debug("server %d not up defaulting streaming state to No", i);
+            atomic_store(&config->servers[i].streaming_state, SERVER_STREAMING_NO);
+         }
       }
    }
 

--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -1485,6 +1485,18 @@ home_page(SSL* client_ssl, int client_fd)
    data = pgagroal_append(data, "      </tr>\n");
    data = pgagroal_append(data, "    </tbody>\n");
    data = pgagroal_append(data, "  </table>\n");
+   data = pgagroal_append(data, "  <h2>pgagroal_server_streaming</h2>\n");
+   data = pgagroal_append(data, "  <p>\n");
+   data = pgagroal_append(data, "   Whether a standby is actively streaming from its primary (-1=primary, 0=no, 1=yes)\n");
+   data = pgagroal_append(data, "  </p>\n");
+   data = pgagroal_append(data, "  <table>\n");
+   data = pgagroal_append(data, "    <tbody>\n");
+   data = pgagroal_append(data, "      <tr>\n");
+   data = pgagroal_append(data, "        <td>name</td>\n");
+   data = pgagroal_append(data, "        <td>The name of the server</td>\n");
+   data = pgagroal_append(data, "      </tr>\n");
+   data = pgagroal_append(data, "    </tbody>\n");
+   data = pgagroal_append(data, "  </table>\n");
    data = pgagroal_append(data, "  <h2>pgagroal_failed_servers</h2>\n");
    data = pgagroal_append(data, "  <p>\n");
    data = pgagroal_append(data, "   The number of failed servers. Only set if failover is enabled\n");
@@ -2375,6 +2387,26 @@ general_information(prometheus_metrics_container_t* container)
    if (data != NULL)
    {
       add_metric_to_art(container->general_metrics, "pgagroal_server_error", data, NULL, NULL, 0);
+      free(data);
+      data = NULL;
+   }
+
+   data = pgagroal_append(data, "#HELP pgagroal_server_streaming Whether a standby is actively streaming from its primary (-1=primary, 0=no, 1=yes)\n");
+   data = pgagroal_append(data, "#TYPE pgagroal_server_streaming gauge\n");
+   FOREACH_VALID_SERVER
+   {
+      int streaming_state = atomic_load(&config->servers[i].streaming_state);
+
+      data = pgagroal_append(data, "pgagroal_server_streaming{");
+      data = pgagroal_append(data, "name=\"");
+      data = pgagroal_append(data, config->servers[i].name);
+      data = pgagroal_append(data, "\"} ");
+      data = pgagroal_append_int(data, streaming_state);
+      data = pgagroal_append(data, "\n");
+   }
+   if (data != NULL)
+   {
+      add_metric_to_art(container->general_metrics, "pgagroal_server_streaming", data, NULL, NULL, 0);
       free(data);
       data = NULL;
    }


### PR DESCRIPTION
Adding pgagroal_server_streaming gauge metric to prometheus (-1 = primary server, 0 = not streaming, 1 = streaming)

Description:
Adds the pgagroal_server_streaming gauge metric to Prometheus to monitor whether a standby server is actively streaming from its primary. The metric is evaluated during the periodic health check loop via pg_stat_wal_receiver.

config
<img width="283" height="106" alt="image" src="https://github.com/user-attachments/assets/a1473864-6328-4777-a60c-9db130ddf40b" />

results:
primary server correctly shows -1 both before initializing as it is (not_init_primary) and after initialization (connection to pgagroal)
<img width="998" height="350" alt="image" src="https://github.com/user-attachments/assets/50616c94-675b-4ccc-bee6-a530e91771d4" />

metrics html
<img width="743" height="144" alt="image" src="https://github.com/user-attachments/assets/bc078196-d6b0-452b-b0c2-af2740cdf5a8" />



closes #979 