### PR TITLE
[#973] Fix reading split PostgreSQL message headers

### DIFF
--- a/src/include/message.h
+++ b/src/include/message.h
@@ -46,8 +46,8 @@ extern "C" {
 #define MESSAGE_STATUS_ERROR 2
 
 /** @struct message
- * Defines a message
- */
+   * Defines a message
+   */
 struct message
 {
    signed char kind; /**< The kind of the message */
@@ -56,401 +56,450 @@ struct message
 } __attribute__((aligned(64)));
 
 /**
- * Read a message in blocking mode
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @param msg The resulting message
- * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
- */
+   * Read a message in blocking mode
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @param msg The resulting message
+   * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
+   */
 int
 pgagroal_read_block_message(SSL* ssl, int socket, struct message** msg);
 
 /**
- * Read a complete typed message in blocking mode. The message must carry the
- * standard header (1 byte kind + 4 byte length); the read continues until the
- * number of bytes declared in the header has arrived, so a message split
- * across multiple network segments is never returned partially. A message
- * whose declared length is malformed (less than 4 bytes or larger than the
- * parse buffer) is an error.
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @param msg The resulting message
- * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
- */
+   * Read a complete typed message in blocking mode. The message must carry the
+   * standard header (1 byte kind + 4 byte length); the read continues until the
+   * number of bytes declared in the header has arrived, so a message split
+   * across multiple network segments is never returned partially. A message
+   * whose declared length is malformed (less than 4 bytes or larger than the
+   * parse buffer) is an error.
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @param msg The resulting message
+   * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
+   */
 int
 pgagroal_read_complete_message(SSL* ssl, int socket, struct message** msg);
 
 /**
- * Read a message with a timeout
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @param timeout The timeout in seconds
- * @param msg The resulting message
- * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
- */
+   * Read a message with a timeout
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @param timeout The timeout in seconds
+   * @param msg The resulting message
+   * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
+   */
 int
 pgagroal_read_timeout_message(SSL* ssl, int socket, int timeout, struct message** msg);
 
 /**
- * Write a message using a socket
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @param msg The message
- * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
- */
+   * Write a message using a socket
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @param msg The message
+   * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
+   */
 int
 pgagroal_write_message(SSL* ssl, int socket, struct message* msg);
 
 /**
- * Create a message
- * @param data A pointer to the data
- * @param length The length of the message
- * @param msg The resulting message
- * @return 0 upon success, otherwise 1
- */
+   * Create a message
+   * @param data A pointer to the data
+   * @param length The length of the message
+   * @param msg The resulting message
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_create_message(void* data, ssize_t length, struct message** msg);
 
 /**
- * Clear a message
- * @param msg The resulting message
- */
+   * Clear a message
+   * @param msg The resulting message
+   */
 void
 pgagroal_clear_message(struct message* msg);
 
 /**
- * Copy a message
- * @param msg The resulting message
- * @return The copy
- */
+   * Copy a message
+   * @param msg The resulting message
+   * @return The copy
+   */
 struct message*
 pgagroal_copy_message(struct message* msg);
 
 /**
- * Free a message
- * @param msg The resulting message
- */
+   * Free a message
+   * @param msg The resulting message
+   */
 void
 pgagroal_free_message(struct message* msg);
 
 /**
- * Write an empty message
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @return 0 upon success, otherwise 1
- */
+   * A callback declaration to use whenere a chunk of a message is
+   * ready for parsing. This is used by pgagroal_parse_message.
+   *
+   *
+   * \param kind the message kind (first byte of the message)
+   * \param msg is a  pointer to the message start (ATTENTION: kind byte included)
+   * \param msglen the declared total length of the message (kind byte + payload)
+   * \param arg any caller supplied argument (e.g., io related structs)
+   */
+typedef void (*pgagroal_postgresql_message_callback)(char kind, char* msg, int msglen, void* arg);
+
+/**
+   * A struct that stores the current state of a PostgreSQL message parsing.
+   * It is used by pgagroal_parse_message across all the chunks.
+   */
+struct postgresql_message_state
+{
+   char header[5];          /**< buffer to assemble a message header split across reads (kind + length) */
+   char first_payload_byte; /**< first byte of the payload (e.g. Z state byte) */
+   int header_len;          /**< how many bytes of a split header have arrived (if 5, full header is present) */
+   int payload_remaining;   /**< bytes of a message payload still to be received */
+};
+
+/**
+   * Read a buffer holding one or more concatenated PostgreSQL protocol messages
+   * that may be split across multiple reads. The caller keeps the parser state
+   * in `state` (zero it before the first call); it is updated so a subsequent
+   * call can continue exactly where this one stopped.
+   *
+   * The callback is invoked once per message. For a message without a payload
+   * it fires as soon as the header (kind byte + length field) is complete; for
+   * a message with a payload it fires when the header and the first payload
+   * byte are present, so the callback can read past the header (e.g. the
+   * transaction state byte of a Z message). A header split across reads is
+   * buffered in the state until it can be parsed, so a split never
+   * desynchronizes the parser.
+   * @param state Parser state, zero-initialized before the first call
+   * @param data The buffer holding the received bytes
+   * @param length The number of received bytes
+   * @param callback The callback to invoke per message
+   * @param arg An argument passed through to the callback
+   */
+void
+pgagroal_parse_message(struct postgresql_message_state* state,
+                       char* data,
+                       int length,
+                       pgagroal_postgresql_message_callback callback, void* arg);
+
+/**
+   * Write an empty message
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_write_empty(SSL* ssl, int socket);
 
 /**
- * Write a notice message
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @return 0 upon success, otherwise 1
- */
+   * Write a notice message
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_write_notice(SSL* ssl, int socket);
 
 /**
- * Write a pool is full message
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @return 0 upon success, otherwise 1
- */
+   * Write a pool is full message
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_write_pool_full(SSL* ssl, int socket);
 
 /**
- * Write a connection refused message
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @return 0 upon success, otherwise 1
- */
+   * Write a connection refused message
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_write_connection_refused(SSL* ssl, int socket);
 
 /**
- * Write a connection refused message (protocol 1 or 2)
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @return 0 upon success, otherwise 1
- */
+   * Write a connection refused message (protocol 1 or 2)
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_write_connection_refused_old(SSL* ssl, int socket);
 
 /**
- * Write a bad password message
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @param username The user name
- * @return 0 upon success, otherwise 1
- */
+   * Write a bad password message
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @param username The user name
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_write_bad_password(SSL* ssl, int socket, char* username);
 
 /**
- * Write an unsupported security model message
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @param username The user name
- * @return 0 upon success, otherwise 1
- */
+   * Write an unsupported security model message
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @param username The user name
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_write_unsupported_security_model(SSL* ssl, int socket, char* username);
 
 /**
- * Write a no HBA entry message
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @param username The user name
- * @param database The database
- * @param address The client address
- * @return 0 upon success, otherwise 1
- */
+   * Write a no HBA entry message
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @param username The user name
+   * @param database The database
+   * @param address The client address
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_write_no_hba_entry(SSL* ssl, int socket, char* username, char* database, char* address);
 
 /**
- * Write a deallocate all message
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @return 0 upon success, otherwise 1
- */
+   * Write a deallocate all message
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_write_deallocate_all(SSL* ssl, int socket);
 
 /**
- * Write the configured connection reset query (server_reset_query) as a simple query
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @return 0 upon success, otherwise 1
- */
+   * Write the configured connection reset query (server_reset_query) as a simple query
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_write_reset_query(SSL* ssl, int socket);
 
 /**
- * Write TLS response
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @return 0 upon success, otherwise 1
- */
+   * Write TLS response
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_write_tls(SSL* ssl, int socket);
 
 /**
- * Write a terminate message
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @return 0 upon success, otherwise 1
- */
+   * Write a terminate message
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_write_terminate(SSL* ssl, int socket);
 
 /**
- * Write a failover message to the client
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @return 0 upon success, otherwise 1
- */
+   * Write a failover message to the client
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_write_client_failover(SSL* ssl, int socket);
 
 /**
- * Write an auth password message
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @return 0 upon success, otherwise 1
- */
+   * Write an auth password message
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_write_auth_password(SSL* ssl, int socket);
 
 /**
- * Write a rollback message
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @return 0 upon success, otherwise 1
- */
+   * Write a rollback message
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_write_rollback(SSL* ssl, int socket);
 
 /**
- * Create an auth password response message
- * @param password The password
- * @param msg The resulting message
- * @return 0 upon success, otherwise 1
- */
+   * Create an auth password response message
+   * @param password The password
+   * @param msg The resulting message
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_create_auth_password_response(char* password, struct message** msg);
 
 /**
- * Write an auth SCRAM-SHA-256 message
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @param channel_binding Advertise SCRAM-SHA-256-PLUS as well (requires a TLS frontend)
- * @return 0 upon success, otherwise 1
- */
+   * Write an auth SCRAM-SHA-256 message
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @param channel_binding Advertise SCRAM-SHA-256-PLUS as well (requires a TLS frontend)
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_write_auth_scram256(SSL* ssl, int socket, bool channel_binding);
 
 /**
- * Create an auth SCRAM-SHA-256 response message
- * @param nounce The nounce
- * @param msg The resulting message
- * @return 0 upon success, otherwise 1
- */
+   * Create an auth SCRAM-SHA-256 response message
+   * @param nounce The nounce
+   * @param msg The resulting message
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_create_auth_scram256_response(char* nounce, struct message** msg);
 
 /**
- * Create an auth SCRAM-SHA-256-PLUS response message (tls-server-end-point channel binding)
- * @param nounce The nounce
- * @param msg The resulting message
- * @return 0 upon success, otherwise 1
- */
+   * Create an auth SCRAM-SHA-256-PLUS response message (tls-server-end-point channel binding)
+   * @param nounce The nounce
+   * @param msg The resulting message
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_create_auth_scram256_plus_response(char* nounce, struct message** msg);
 
 /**
- * Create an auth SCRAM-SHA-256/Continue message
- * @param cn The client nounce
- * @param sn The server nounce
- * @param salt The salt
- * @param msg The resulting message
- * @return 0 upon success, otherwise 1
- */
+   * Create an auth SCRAM-SHA-256/Continue message
+   * @param cn The client nounce
+   * @param sn The server nounce
+   * @param salt The salt
+   * @param msg The resulting message
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_create_auth_scram256_continue(char* cn, char* sn, char* salt, struct message** msg);
 
 /**
- * Create an auth SCRAM-SHA-256/Continue response message
- * @param wp The without proff
- * @param p The proff
- * @param msg The resulting message
- * @return 0 upon success, otherwise 1
- */
+   * Create an auth SCRAM-SHA-256/Continue response message
+   * @param wp The without proff
+   * @param p The proff
+   * @param msg The resulting message
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_create_auth_scram256_continue_response(char* wp, char* p, struct message** msg);
 
 /**
- * Create an auth SCRAM-SHA-256/Final message
- * @param ss The server signature (BASE64)
- * @param msg The resulting message
- * @return 0 upon success, otherwise 1
- */
+   * Create an auth SCRAM-SHA-256/Final message
+   * @param ss The server signature (BASE64)
+   * @param msg The resulting message
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_create_auth_scram256_final(char* ss, struct message** msg);
 
 /**
- * Write an auth success message
- * @param ssl The SSL struct
- * @param socket The socket descriptor
- * @return 0 upon success, otherwise 1
- */
+   * Write an auth success message
+   * @param ssl The SSL struct
+   * @param socket The socket descriptor
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_write_auth_success(SSL* ssl, int socket);
 
 /**
- * Create a SSL message
- * @param msg The resulting message
- * @return 0 upon success, otherwise 1
- */
+   * Create a SSL message
+   * @param msg The resulting message
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_create_ssl_message(struct message** msg);
 
 /**
- * Create a startup message
- * @param username The user name
- * @param database The database
- * @param msg The resulting message
- * @return 0 upon success, otherwise 1
- */
+   * Create a startup message
+   * @param username The user name
+   * @param database The database
+   * @param msg The resulting message
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_create_startup_message(char* username, char* database, struct message** msg);
 
 /**
- * Create a cancel request message
- * @param pid The pid
- * @param secret The secret
- * @param msg The resulting message
- * @return 0 upon success, otherwise 1
- */
+   * Create a cancel request message
+   * @param pid The pid
+   * @param secret The secret
+   * @param msg The resulting message
+   * @return 0 upon success, otherwise 1
+   */
 int
 pgagroal_create_cancel_request_message(int pid, int secret, struct message** msg);
 
 /**
- * Is the connection valid
- * @param socket The socket descriptor
- * @return true upon success, otherwise false
- */
+   * Is the connection valid
+   * @param socket The socket descriptor
+   * @return true upon success, otherwise false
+   */
 bool
 pgagroal_connection_isvalid(int socket);
 
 /**
- * Log a message
- * @param msg The message
- */
+   * Log a message
+   * @param msg The message
+   */
 void
 pgagroal_log_message(struct message* msg);
 
 /**
- * Read a message from a buffer (io_uring backend)
- * @param watcher The io_wacher used to recv
- * @param msg The message received
- * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
- */
+   * Read a message from a buffer (io_uring backend)
+   * @param watcher The io_wacher used to recv
+   * @param msg The message received
+   * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
+   */
 int
 pgagroal_recv_message(struct io_watcher* watcher, struct message** msg);
 
 /**
- * Get the message buffer for a watcher
- * @param watcher The watcher
- * @return The message buffer
- */
+   * Get the message buffer for a watcher
+   * @param watcher The watcher
+   * @return The message buffer
+   */
 struct message*
 pgagroal_get_watcher_message(struct io_watcher* watcher);
 
 /**
- * Write a message to a buffer (io_uring backend)
- * @param watcher The io_wacher used to send
- * @param msg The message to send
- * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
- */
+   * Write a message to a buffer (io_uring backend)
+   * @param watcher The io_wacher used to send
+   * @param msg The message to send
+   * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
+   */
 int
 pgagroal_send_message(struct io_watcher* watcher, struct message* msg);
 
 /**
- * Read a message using a socket
- * @param socket The socket descriptor
- * @param msg The resulting message
- * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
- */
+   * Read a message using a socket
+   * @param socket The socket descriptor
+   * @param msg The resulting message
+   * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
+   */
 int
 pgagroal_read_socket_message(int socket, struct message** msg);
 
 /**
- * Write a message using a socket
- * @param socket The socket descriptor
- * @param msg The message
- * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
- */
+   * Write a message using a socket
+   * @param socket The socket descriptor
+   * @param msg The message
+   * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
+   */
 int
 pgagroal_write_socket_message(int socket, struct message* msg);
 
 /**
- * Read a message using SSL
- * @param ssl The SSL descriptor
- * @param msg The resulting message
- * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
- */
+   * Read a message using SSL
+   * @param ssl The SSL descriptor
+   * @param msg The resulting message
+   * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
+   */
 int
 pgagroal_read_ssl_message(SSL* ssl, struct message** msg);
 
 /**
- * Write a message using SSL
- * @param ssl The SSL descriptor
- * @param msg The message
- * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
- */
+   * Write a message using SSL
+   * @param ssl The SSL descriptor
+   * @param msg The message
+   * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
+   */
 int
 pgagroal_write_ssl_message(SSL* ssl, struct message* msg);
 

--- a/src/libpgagroal/message.c
+++ b/src/libpgagroal/message.c
@@ -392,6 +392,154 @@ pgagroal_free_message(struct message* msg)
    }
 }
 
+void
+pgagroal_parse_message(struct postgresql_message_state* state,
+                       char* data,
+                       int length,
+                       pgagroal_postgresql_message_callback callback,
+                       void* arg)
+{
+   int offset = 0;
+
+   while (offset < length)
+   {
+      /*
+       * Something arrived, so we need to check `state` to understand
+       * where we were.
+       */
+
+      if (state->header_len == 5)
+      {
+         /*
+           * a full header is now present, since it has the length of 5 (kind + length)
+           * therefore get the first byte after the header (e.g., a `I` after a `Z` kind)
+           */
+         state->first_payload_byte = data[offset];
+         offset += 1;
+         state->payload_remaining -= 1;
+         state->header_len = 0; // header read
+
+         if (callback != NULL)
+         {
+            char kind = pgagroal_read_byte(state->header);
+            int msglen = pgagroal_read_int32(state->header + 1) + 1;
+
+            /*
+               * pass the whole thing to the callback, so the kind + length + first byte
+               */
+            char msg[6];
+            memcpy(msg, state->header, 5);
+            msg[5] = state->first_payload_byte;
+            callback(kind, msg, msglen, arg);
+         }
+
+         continue;
+      }
+
+      /*
+       * move forward to consume every other stuff
+       * within the payload
+       */
+      if (state->payload_remaining > 0)
+      {
+         int to_consume = MIN(state->payload_remaining, length - offset);
+         offset += to_consume;
+         state->payload_remaining -= to_consume;
+         continue;
+      }
+
+      /*
+       * here the header has fully arrived and there is nothing
+       * more (no payload)
+       */
+      if (state->header_len == 0 && offset + 5 <= length)
+      {
+         char kind = pgagroal_read_byte(data + offset);
+         int msglen = pgagroal_read_int32(data + offset + 1) + 1;
+
+         if (msglen == 5 || offset + 6 <= length)
+         {
+            /*
+               * payload is present, or the message has none, so the
+               * callback may read past the header (e.g. the Z state byte).
+               */
+            if (callback != NULL)
+            {
+               callback(kind, data + offset, msglen, arg);
+            }
+
+            offset += 5;
+            state->payload_remaining = msglen - 5;
+         }
+         else
+         {
+            /*
+               * header arrived, wait to handle the first payload byte (if any)
+               */
+            memcpy(state->header, data + offset, 5);
+            state->header_len = 5;
+            state->payload_remaining = msglen - 5;
+            offset = length;
+            continue;
+         }
+      }
+      else
+      {
+         /* Buffer a message header split across reads until it is complete */
+         int n = MIN(5 - state->header_len, length - offset);
+         memcpy(state->header + state->header_len, data + offset, n);
+         state->header_len += n;
+         offset += n;
+
+         if (state->header_len < 5)
+         {
+            /* Buffer exhausted mid-header; continue on the next call */
+            continue;
+         }
+
+         char kind = pgagroal_read_byte(state->header);
+         int msglen = pgagroal_read_int32(state->header + 1) + 1;
+
+         state->payload_remaining = msglen - 5;
+
+         if (msglen == 5 || offset < length)
+         {
+            /* The payload is present, or the message has none */
+            state->first_payload_byte = (msglen > 5) ? data[offset] : 0;
+            state->header_len = 0;
+
+            if (callback != NULL)
+            {
+               /* Build a contiguous view so the callback may read msg+5
+                   * (e.g. the state byte of a Z message). */
+               char msg[8];
+               memcpy(msg, state->header, 5);
+               msg[5] = state->first_payload_byte;
+               msg[6] = 0;
+               msg[7] = 0;
+               callback(kind, msg, msglen, arg);
+            }
+         }
+         else
+         {
+            /* Await the first payload byte in a later call */
+            state->header_len = 5;
+            continue;
+         }
+      }
+
+      /*
+       * consume any remaining payload
+       */
+      if (state->payload_remaining > 0)
+      {
+         int to_consume = MIN(state->payload_remaining, length - offset);
+         offset += to_consume;
+         state->payload_remaining -= to_consume;
+      }
+   }
+}
+
 int
 pgagroal_write_empty(SSL* ssl, int socket)
 {
@@ -766,7 +914,7 @@ pgagroal_write_reset_query(SSL* ssl, int socket)
    }
 
    /* XXX: someone is destroying the memory before reaching here in the worker.
-    * Allocate another buffer for now, but this needs fixing. */
+   * Allocate another buffer for now, but this needs fixing. */
    pgagroal_memory_init();
 
    if (ssl == NULL)
@@ -987,8 +1135,8 @@ pgagroal_write_auth_scram256(SSL* ssl, int socket, bool channel_binding)
    offset = 9;
 
    /* Offer channel binding first so a capable client prefers it; it is only
-    * meaningful once the frontend link is TLS. The NUL after each mechanism and
-    * the empty string terminating the list come from the zeroed buffer. */
+   * meaningful once the frontend link is TLS. The NUL after each mechanism and
+   * the empty string terminating the list come from the zeroed buffer. */
    if (channel_binding && ssl != NULL)
    {
       pgagroal_write_string(&(scram[offset]), "SCRAM-SHA-256-PLUS");

--- a/src/libpgagroal/pipeline_session.c
+++ b/src/libpgagroal/pipeline_session.c
@@ -60,8 +60,8 @@ static void session_destroy(void*, size_t);
 static void session_periodic(void);
 
 static bool in_tx;
-static int next_client_message;
-static int next_server_message;
+static struct postgresql_message_state client_message_state;
+static struct postgresql_message_state server_message_state;
 static bool saw_x = false;
 
 #define CLIENT_INIT   0
@@ -140,8 +140,8 @@ session_start(struct event_loop* loop __attribute__((unused)), struct worker_io*
    config = (struct main_configuration*)shmem;
 
    in_tx = false;
-   next_client_message = 0;
-   next_server_message = 0;
+   memset(&client_message_state, 0, sizeof(client_message_state));
+   memset(&server_message_state, 0, sizeof(server_message_state));
 
    for (int i = 0; i < config->max_connections; i++)
    {
@@ -283,6 +283,40 @@ session_periodic(void)
 }
 
 static void
+session_client_message(char kind, char* msg, int msglen __attribute__((unused)), void* arg)
+{
+   struct worker_io* wi = (struct worker_io*)arg;
+
+   /* The Q and E message tell us the execute of the simple query and the prepared statement */
+   if (kind == 'Q' || kind == 'E')
+   {
+      pgagroal_prometheus_query_count_add();
+      if (wi != NULL)
+         pgagroal_prometheus_query_count_specified_add(wi->slot);
+   }
+}
+
+static void
+session_server_message(char kind, char* msg, int msglen __attribute__((unused)), void* arg __attribute__((unused)))
+{
+   /*
+   * 'Z' needs the first payload byte to get the
+   * transaction status
+   */
+   if (kind == 'Z')
+   {
+      char tx_state = pgagroal_read_byte(msg + 5);
+
+      if (tx_state != 'I' && !in_tx)
+      {
+         pgagroal_prometheus_tx_count_add();
+      }
+
+      in_tx = tx_state != 'I';
+   }
+}
+
+static void
 session_client(struct io_watcher* watcher)
 {
    int status = MESSAGE_STATUS_ERROR;
@@ -303,40 +337,11 @@ session_client(struct io_watcher* watcher)
 
       if (likely(msg->kind != 'X'))
       {
-         int offset = 0;
-
-         while (offset < msg->length)
-         {
-            if (next_client_message == 0)
-            {
-               char kind = pgagroal_read_byte(msg->data + offset);
-               int length = pgagroal_read_int32(msg->data + offset + 1);
-
-               /* The Q and E message tell us the execute of the simple query and the prepared statement */
-               if (kind == 'Q' || kind == 'E')
-               {
-                  pgagroal_prometheus_query_count_add();
-                  pgagroal_prometheus_query_count_specified_add(wi->slot);
-               }
-
-               /* Calculate the offset to the next message */
-               if (offset + length + 1 <= msg->length)
-               {
-                  next_client_message = 0;
-                  offset += length + 1;
-               }
-               else
-               {
-                  next_client_message = length + 1 - (msg->length - offset);
-                  offset = msg->length;
-               }
-            }
-            else
-            {
-               offset = MIN(next_client_message, msg->length);
-               next_client_message -= offset;
-            }
-         }
+         pgagroal_parse_message(&client_message_state,
+                                msg->data,
+                                msg->length,
+                                session_client_message,
+                                wi);
 
          status = pgagroal_send_message(watcher, msg);
 
@@ -452,46 +457,11 @@ session_server(struct io_watcher* watcher)
    {
       pgagroal_prometheus_network_received_add(msg->length);
 
-      int offset = 0;
-
-      while (offset < msg->length)
-      {
-         if (next_server_message == 0)
-         {
-            char kind = pgagroal_read_byte(msg->data + offset);
-            int length = pgagroal_read_int32(msg->data + offset + 1);
-
-            /* The Z message tell us the transaction state */
-            if (kind == 'Z')
-            {
-               char tx_state = pgagroal_read_byte(msg->data + offset + 5);
-
-               if (tx_state != 'I' && !in_tx)
-               {
-                  pgagroal_prometheus_tx_count_add();
-               }
-
-               in_tx = tx_state != 'I';
-            }
-
-            /* Calculate the offset to the next message */
-            if (offset + length + 1 <= msg->length)
-            {
-               next_server_message = 0;
-               offset += length + 1;
-            }
-            else
-            {
-               next_server_message = length + 1 - (msg->length - offset);
-               offset = msg->length;
-            }
-         }
-         else
-         {
-            offset = MIN(next_server_message, msg->length);
-            next_server_message -= offset;
-         }
-      }
+      pgagroal_parse_message(&server_message_state,
+                             msg->data,
+                             msg->length,
+                             session_server_message,
+                             NULL);
 
       status = pgagroal_send_message(watcher, msg);
 

--- a/src/libpgagroal/pipeline_transaction.c
+++ b/src/libpgagroal/pipeline_transaction.c
@@ -68,8 +68,8 @@ static char username[MAX_USERNAME_LENGTH];
 static char database[MAX_DATABASE_LENGTH];
 static char appname[MAX_APPLICATION_NAME];
 static bool in_tx;
-static int next_client_message;
-static int next_server_message;
+static struct postgresql_message_state client_message_state;
+static struct postgresql_message_state server_message_state;
 static int unix_socket = -1;
 static int deallocate;
 static bool fatal;
@@ -115,8 +115,8 @@ transaction_start(struct event_loop* loop, struct worker_io* w)
    memcpy(&database[0], config->connections[w->slot].database, MAX_DATABASE_LENGTH);
    memcpy(&appname[0], config->connections[w->slot].appname, MAX_APPLICATION_NAME);
    in_tx = false;
-   next_client_message = 0;
-   next_server_message = 0;
+   memset(&client_message_state, 0, sizeof(client_message_state));
+   memset(&server_message_state, 0, sizeof(server_message_state));
    deallocate = false;
 
    memset(&p, 0, sizeof(p));
@@ -199,6 +199,36 @@ transaction_periodic(void)
 }
 
 static void
+transaction_client_message(char kind, char* msg, int msglen __attribute__((unused)), void* arg)
+{
+   struct worker_io* wi = (struct worker_io*)arg;
+   struct main_configuration* config = (struct main_configuration*)shmem;
+
+   if (config->track_prepared_statements)
+   {
+      /* The P message tell us the prepared statement */
+      if (kind == 'P')
+      {
+         char* ps = pgagroal_read_string(msg + 5);
+         if (strcmp(ps, ""))
+         {
+            deallocate = true;
+         }
+      }
+   }
+
+   /* The Q and E message tell us the execute of the simple query and the prepared statement */
+   if (kind == 'Q' || kind == 'E')
+   {
+      pgagroal_prometheus_query_count_add();
+      if (wi != NULL)
+      {
+         pgagroal_prometheus_query_count_specified_add(wi->slot);
+      }
+   }
+}
+
+static void
 transaction_client(struct io_watcher* watcher)
 {
    int status = MESSAGE_STATUS_ERROR;
@@ -250,53 +280,11 @@ transaction_client(struct io_watcher* watcher)
 
       if (likely(msg->kind != 'X'))
       {
-         int offset = 0;
-
-         while (offset < msg->length)
-         {
-            if (next_client_message == 0)
-            {
-               char kind = pgagroal_read_byte(msg->data + offset);
-               int length = pgagroal_read_int32(msg->data + offset + 1);
-
-               if (config->track_prepared_statements)
-               {
-                  /* The P message tell us the prepared statement */
-                  if (kind == 'P')
-                  {
-                     char* ps = pgagroal_read_string(msg->data + offset + 5);
-                     if (strcmp(ps, ""))
-                     {
-                        deallocate = true;
-                     }
-                  }
-               }
-
-               /* The Q and E message tell us the execute of the simple query and the prepared statement */
-               if (kind == 'Q' || kind == 'E')
-               {
-                  pgagroal_prometheus_query_count_add();
-                  pgagroal_prometheus_query_count_specified_add(wi->slot);
-               }
-
-               /* Calculate the offset to the next message */
-               if (offset + length + 1 <= msg->length)
-               {
-                  next_client_message = 0;
-                  offset += length + 1;
-               }
-               else
-               {
-                  next_client_message = length + 1 - (msg->length - offset);
-                  offset = msg->length;
-               }
-            }
-            else
-            {
-               offset = MIN(next_client_message, msg->length);
-               next_client_message -= offset;
-            }
-         }
+         pgagroal_parse_message(&client_message_state,
+                                msg->data,
+                                msg->length,
+                                transaction_client_message,
+                                wi);
 
          status = pgagroal_send_message(watcher, msg);
 
@@ -392,6 +380,26 @@ get_error:
 }
 
 static void
+transaction_server_message(char kind, char* msg, int msglen __attribute__((unused)), void* arg __attribute__((unused)))
+{
+   /*
+   * if 'Z' need to read the first payload byte
+   * to get the transaction status
+   */
+   if (kind == 'Z')
+   {
+      char tx_state = pgagroal_read_byte(msg + 5);
+
+      if (tx_state != 'I' && !in_tx)
+      {
+         pgagroal_prometheus_tx_count_add();
+      }
+
+      in_tx = tx_state != 'I';
+   }
+}
+
+static void
 transaction_server(struct io_watcher* watcher)
 {
    int status = MESSAGE_STATUS_ERROR;
@@ -413,46 +421,11 @@ transaction_server(struct io_watcher* watcher)
    {
       pgagroal_prometheus_network_received_add(msg->length);
 
-      int offset = 0;
-
-      while (offset < msg->length)
-      {
-         if (next_server_message == 0)
-         {
-            char kind = pgagroal_read_byte(msg->data + offset);
-            int length = pgagroal_read_int32(msg->data + offset + 1);
-
-            /* The Z message tell us the transaction state */
-            if (kind == 'Z')
-            {
-               char tx_state = pgagroal_read_byte(msg->data + offset + 5);
-
-               if (tx_state != 'I' && !in_tx)
-               {
-                  pgagroal_prometheus_tx_count_add();
-               }
-
-               in_tx = tx_state != 'I';
-            }
-
-            /* Calculate the offset to the next message */
-            if (offset + length + 1 <= msg->length)
-            {
-               next_server_message = 0;
-               offset += length + 1;
-            }
-            else
-            {
-               next_server_message = length + 1 - (msg->length - offset);
-               offset = msg->length;
-            }
-         }
-         else
-         {
-            offset = MIN(next_server_message, msg->length);
-            next_server_message -= offset;
-         }
-      }
+      pgagroal_parse_message(&server_message_state,
+                             msg->data,
+                             msg->length,
+                             transaction_server_message,
+                             NULL);
 
       status = pgagroal_send_message(watcher, msg);
 
@@ -482,10 +455,10 @@ transaction_server(struct io_watcher* watcher)
          if (!fatal)
          {
             /* In transaction pooling the reset query runs only when
-             * server_reset_query_always is enabled (PgBouncer parity). A
-             * non-empty reset (e.g. DISCARD ALL) subsumes DEALLOCATE ALL. If it
-             * fails the backend is discarded rather than returned dirty. */
-            if (config->server_reset_query_always && config->server_reset_query[0] != '\0' && !config->connections[slot].reset_query_failed)
+               * server_reset_query_always is enabled (PgBouncer parity). A
+               * non-empty reset (e.g. DISCARD ALL) subsumes DEALLOCATE ALL. If it
+               * fails the backend is discarded rather than returned dirty. */
+            if (config->server_reset_query_always && config->server_reset_query[0] != '\0')
             {
                if (pgagroal_write_reset_query(wi->server_ssl, wi->server_fd))
                {
@@ -503,7 +476,7 @@ transaction_server(struct io_watcher* watcher)
 
                      default:
                         /* SERVER_RESET_QUERY_BEHAVIOR_ON_FAILURE_DISCARD and _TRY both kill the
-                         * connection; any unrecognised future value also falls here safely. */
+                           * connection; any unrecognised future value also falls here safely. */
                         pgagroal_tracking_event_slot(TRACKER_TX_RETURN_CONNECTION, slot);
                         pgagroal_kill_connection(slot, wi->server_ssl);
                         slot = -1;

--- a/test/testcases/test_message.c
+++ b/test/testcases/test_message.c
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2026 The pgagroal community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include <pgagroal.h>
+#include <message.h>
+#include <utils.h>
+#include <mctf.h>
+
+#include <string.h>
+
+/*
+ * Regression tests for the message walker used by the transaction and session
+ * pipelines. A message header (kind byte + int32 length) split across reads
+ * previously desynchronized the parser: the length was read past the end of
+ * the received bytes, the walker skipped a bogus number of payload bytes, and
+ * a 'Z' inside a payload (e.g. the data of "select repeat('Z',4096)") could
+ * be misparsed as a ReadyForQuery. The walker must buffer a split header in
+ * its state until it is complete, and must keep the I/O-stop decision of the
+ * pipelines (a 'Z' at the end of a chunk) working across multiple reads.
+ */
+
+#define D_PAYLOAD_SIZE 4096
+
+/* Collection of messages reported by the walker callback */
+struct walk_result
+{
+  int count;
+  char kinds[64];
+  int z_count;
+  char z_state;
+  int last_msglen;
+};
+
+/* Callback invoked by pgagroal_parse_message for each complete header */
+static void
+walk_cb(char kind, char* msg, int msglen, void* arg)
+{
+  struct walk_result* result = (struct walk_result*)arg;
+
+  if (result->count < (int)sizeof(result->kinds))
+    {
+      result->kinds[result->count] = kind;
+    }
+  result->count++;
+  result->last_msglen = msglen;
+
+  if (kind == 'Z')
+    {
+      result->z_count++;
+      result->z_state = pgagroal_read_byte(msg + 5);
+    }
+}
+
+/* Append one wire message to buffer at offset, returning the new offset */
+static int
+append_message(char* buffer, int offset, char kind, const char* payload, int payload_len)
+{
+  pgagroal_write_byte(buffer + offset, kind);
+  pgagroal_write_int32(buffer + offset + 1, payload_len + 4);
+  if (payload_len > 0)
+    {
+      memcpy(buffer + offset + 5, payload, payload_len);
+    }
+  return offset + 5 + payload_len;
+}
+
+/* Build a server result: DataRow(4096 Z bytes) + CommandComplete + ReadyForQuery */
+static int
+build_server_result(char* buffer)
+{
+  char payload[D_PAYLOAD_SIZE];
+  int offset = 0;
+
+  memset(payload, 'Z', sizeof(payload));
+  offset = append_message(buffer, offset, 'D', payload, sizeof(payload));
+  offset = append_message(buffer, offset, 'C', NULL, 0);
+  offset = append_message(buffer, offset, 'Z', "I", 1);
+
+  return offset;
+}
+
+static bool
+result_ok(int expected_count, const char* expected_kinds, int expected_z_count,
+          struct walk_result* result, char expected_z_state, bool check_z_state)
+{
+  if (result->count != expected_count)
+    {
+      return false;
+    }
+  if (result->count > (int)sizeof(result->kinds))
+    {
+      return false;
+    }
+  result->kinds[expected_count] = '\0';
+  if (strcmp(result->kinds, expected_kinds) != 0)
+    {
+      return false;
+    }
+  if (result->z_count != expected_z_count)
+    {
+      return false;
+    }
+  if (check_z_state && result->z_state != expected_z_state)
+    {
+      return false;
+    }
+  return true;
+}
+
+/* The whole result buffer arrives in a single read. */
+MCTF_TEST(test_message_aligned)
+{
+  char buffer[8192];
+  struct walk_result result;
+  struct postgresql_message_state state;
+  int length;
+
+  length = build_server_result(buffer);
+  memset(&state, 0, sizeof(state));
+  memset(&result, 0, sizeof(result));
+
+  pgagroal_parse_message(&state, buffer, length, walk_cb, &result);
+
+  MCTF_ASSERT(result_ok(3, "DCZ", 1, &result, 'I', true), cleanup,
+              "aligned walk must report D, C and a single idle Z");
+
+ cleanup:
+  MCTF_FINISH();
+}
+
+/* A message header split across reads at every possible position. */
+MCTF_TEST(test_message_header_split)
+{
+  char buffer[8192];
+  struct walk_result result;
+  struct postgresql_message_state state;
+  int length;
+  int split;
+
+  length = build_server_result(buffer);
+
+  for (split = 1; split <= 4; split++)
+    {
+      memset(&state, 0, sizeof(state));
+      memset(&result, 0, sizeof(result));
+
+      pgagroal_parse_message(&state, buffer, split, walk_cb, &result);
+      pgagroal_parse_message(&state, buffer + split, length - split, walk_cb, &result);
+
+      MCTF_ASSERT(result_ok(3, "DCZ", 1, &result, 'I', true), cleanup,
+                  "server header split at %d must not desynchronize the walker", split);
+    }
+
+ cleanup:
+  MCTF_FINISH();
+}
+
+/* A message payload split across reads at every possible position. */
+MCTF_TEST(test_message_payload_split)
+{
+  char buffer[8192];
+  struct walk_result result;
+  struct postgresql_message_state state;
+  int length;
+  int split;
+
+  length = build_server_result(buffer);
+
+  for (split = 1; split < D_PAYLOAD_SIZE; split++)
+    {
+      memset(&state, 0, sizeof(state));
+      memset(&result, 0, sizeof(result));
+
+      pgagroal_parse_message(&state, buffer, 5 + split, walk_cb, &result);
+      pgagroal_parse_message(&state, buffer + 5 + split, length - (5 + split), walk_cb, &result);
+
+      MCTF_ASSERT(result_ok(3, "DCZ", 1, &result, 'I', true), cleanup,
+                  "payload split at %d must not desynchronize the walker", split);
+    }
+
+ cleanup:
+  MCTF_FINISH();
+}
+
+/* Every possible split point of the complete result buffer. */
+MCTF_TEST(test_message_exhaustive_splits)
+{
+  char buffer[8192];
+  struct walk_result result;
+  struct postgresql_message_state state;
+  int length;
+  int split;
+
+  length = build_server_result(buffer);
+
+  for (split = 1; split < length; split++)
+    {
+      memset(&state, 0, sizeof(state));
+      memset(&result, 0, sizeof(result));
+
+      pgagroal_parse_message(&state, buffer, split, walk_cb, &result);
+      pgagroal_parse_message(&state, buffer + split, length - split, walk_cb, &result);
+
+      MCTF_ASSERT(result_ok(3, "DCZ", 1, &result, 'I', true), cleanup,
+                  "split at %d must not desynchronize the walker", split);
+    }
+
+ cleanup:
+  MCTF_FINISH();
+}
+
+/* A client query split at every possible position. */
+MCTF_TEST(test_message_client_query_split)
+{
+  char buffer[8192];
+  const char* query = "SELECT 1";
+  struct walk_result result;
+  struct postgresql_message_state state;
+  int length;
+  int split;
+
+  length = append_message(buffer, 0, 'Q', query, (int)strlen(query));
+
+  for (split = 1; split < length; split++)
+    {
+      memset(&state, 0, sizeof(state));
+      memset(&result, 0, sizeof(result));
+
+      pgagroal_parse_message(&state, buffer, split, walk_cb, &result);
+      pgagroal_parse_message(&state, buffer + split, length - split, walk_cb, &result);
+
+      MCTF_ASSERT(result_ok(1, "Q", 0, &result, 0, false), cleanup,
+                  "query split at %d must not desynchronize the walker", split);
+    }
+
+ cleanup:
+  MCTF_FINISH();
+}
+
+/* A header arriving one byte at a time, then a payload in chunks. */
+MCTF_TEST(test_message_multi_split)
+{
+  char buffer[8192];
+  struct walk_result result;
+  struct postgresql_message_state state;
+  int length;
+  int i;
+
+  length = build_server_result(buffer);
+  memset(&state, 0, sizeof(state));
+  memset(&result, 0, sizeof(result));
+
+  for (i = 0; i < 5; i++)
+    {
+      pgagroal_parse_message(&state, buffer + i, 1, walk_cb, &result);
+    }
+  for (i = 5; i < length; i += 100)
+    {
+      int n = MIN(100, length - i);
+      pgagroal_parse_message(&state, buffer + i, n, walk_cb, &result);
+    }
+
+  MCTF_ASSERT(result_ok(3, "DCZ", 1, &result, 'I', true), cleanup,
+              "a header split into single bytes must be assembled");
+
+ cleanup:
+  MCTF_FINISH();
+}
+
+/* The Z message split exactly between its length field and its state byte: the
+ * walker must hold the completed header until the state byte arrives so the
+ * callback reports the real transaction state, not a zero. */
+MCTF_TEST(test_message_z_state_split)
+{
+  char buffer[8192];
+  struct walk_result result;
+  struct postgresql_message_state state;
+  int length;
+
+  length = build_server_result(buffer);
+  memset(&state, 0, sizeof(state));
+  memset(&result, 0, sizeof(result));
+
+  pgagroal_parse_message(&state, buffer, length - 1, walk_cb, &result);
+  pgagroal_parse_message(&state, buffer + length - 1, 1, walk_cb, &result);
+
+  MCTF_ASSERT(result_ok(3, "DCZ", 1, &result, 'I', true), cleanup,
+              a               "a Z split at 5/1 must report its real state byte");
+
+ cleanup:
+  MCTF_FINISH();
+}


### PR DESCRIPTION
Introduces a new structure `postgresql_message_state` that is shared across several continuos invocations of `pgagroal_parse_message` to inspect the header and the content arrived so far.

`pgagroal_parse_message` gets the bytes of an incoming message and look to see if the header is complete or not, and unless the header is complete and a first payload byte has arrived it does nothing but keeping the status of incoming data.
Once the first byte of payload arrives, a callback function is invoked to parse the header and possibly the first byte.

Close #973