### PR TITLE
Check star_fds allocations in network.c

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,3 +41,4 @@ Rohan Mishra <kmrrohan29@gmail.com>
 youssef-joe <joe92228@gmail.com>
 Mohammad El-Shennawy <mohamedwork216@gmail.com>
 Finn Rayk Gartner <finn.gartner@canonical.com>
+R Sai Pranav <rajasaipranav0@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -59,6 +59,7 @@ Luca Ferrari <fluca1978@gmail.com>
 Haoran Zhang <andrewzhr9911@gmail.com>
 Bassam Adnan <mailbassam@gmail.com>
 Tejas Tyagi <tejastyagi.tt@gmail.com>
+R Sai Pranav <rajasaipranav0@gmail.com>
 ```
 
 ## Contributing

--- a/src/libpgagroal/network.c
+++ b/src/libpgagroal/network.c
@@ -87,6 +87,7 @@ pgagroal_bind(const char* hostname, int port, int** fds, int* length, bool no_de
              (ifa->ifa_flags & IFF_UP))
          {
             int* new_fds = NULL;
+            int* tmp_fds = NULL;
             int new_length = 0;
 
             memset(addr, 0, sizeof(addr));
@@ -111,12 +112,23 @@ pgagroal_bind(const char* hostname, int port, int** fds, int* length, bool no_de
             if (star_fds == NULL)
             {
                star_fds = malloc(new_length * sizeof(int));
+               if (star_fds == NULL)
+               {
+                  free(new_fds);
+                  continue;
+               }
                memcpy(star_fds, new_fds, new_length * sizeof(int));
                star_length = new_length;
             }
             else
             {
-               star_fds = realloc(star_fds, (star_length + new_length) * sizeof(int));
+               tmp_fds = realloc(star_fds, (star_length + new_length) * sizeof(int));
+               if (tmp_fds == NULL)
+               {
+                  free(new_fds);
+                  continue;
+               }
+               star_fds = tmp_fds;
                memcpy(star_fds + star_length, new_fds, new_length * sizeof(int));
                star_length += new_length;
             }


### PR DESCRIPTION
Cross-port of pgmoneta/pgmoneta#1246 (issue pgmoneta/pgmoneta#1245), as requested by @jesperpedersen.

`network.c` contains the same code in all four projects. `star_fds` is overwritten with the result of `malloc` and `realloc` and then passed straight to `memcpy` with no check. `realloc` returns NULL *without* freeing the original, so on failure the original buffer is leaked and then written through a NULL pointer. The `malloc` branch one block above has the same problem.

Allocate into a temporary, check it, and on failure free `new_fds` and `continue` — which is what the loop already does when `bind_host` fails.

## Verification

- `cppcheck --enable=warning` reported `memleakOnRealloc` on this line before the change and reports nothing after.
- `clang-format` reports no changes for the file.
- I have **not** built this project locally, so the change is verified by static analysis and by being character-identical to the pgmoneta fix rather than by a compile here. CI will be the real check.

Added myself to `AUTHORS` and `doc/manual/en/97-acknowledgement.md` per DEVELOPERS.md, since this is my first PR here.

These are OOM-only paths, so practical severity is low.