### PR TITLE
[#1000] Clear freed pointers in add_user and update_user

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -839,14 +839,20 @@ password:
    fputs(entry, users_file);
 
    free(entry);
+   entry = NULL;
    free(master_key);
+   master_key = NULL;
    free(encrypted);
+   encrypted = NULL;
    free(encoded);
+   encoded = NULL;
    if (do_free)
    {
       free(password);
+      password = NULL;
    }
    free(verify);
+   verify = NULL;
 
    fclose(users_file);
    users_file = NULL;
@@ -1167,13 +1173,18 @@ password:
    }
 
    free(master_key);
+   master_key = NULL;
    free(encrypted);
+   encrypted = NULL;
    free(encoded);
+   encoded = NULL;
    if (do_free)
    {
       free(password);
+      password = NULL;
    }
    free(verify);
+   verify = NULL;
 
    fclose(users_file);
    users_file = NULL;


### PR DESCRIPTION
Fixes #1000. Cross-port of pgmoneta/pgmoneta#1248, as requested by @jesperpedersen on pgmoneta/pgmoneta#1242.

`add_user` and `update_user` free `entry`, `master_key`, `encrypted`, `encoded`, `password` and `verify` on the success path, then run `pgagroal_management_create_outcome_success` and `create_response`, both of which `goto error`. The `error:` label frees the same pointers again, so a failure in either call frees each of them twice.

Setting the pointers to NULL after the free makes the error label's `free()` a no-op — matching what the surrounding code already does for the file handles (`users_file = NULL;` right after `fclose`).

## Verification

- Full `cmake --build` succeeds; `clang-format` reports no changes.
- `clang --analyze` reported `Attempt to free released memory` three times in `admin.c` before the change and reports one after — the remaining one is `admin.c:573`, in a different function that I deliberately did not touch because I have not traced its flow.
- `src/libpgagroal/management.c:1331` has the same analyzer finding and is likewise not claimed here.
- Verified by reading the code and with the analyzer, not by forcing `create_response` to fail at runtime.

I ran the same analysis across the family: pgexporter and pgvictoria show no `free released` findings, so this particular fix is pgagroal-only.
