### PR TITLE
Reposition explicitly before appending to the users file

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -836,6 +836,14 @@ password:
    entry = pgagroal_append(entry, encoded);
    entry = pgagroal_append(entry, "\n");
 
+   /* The stream is open in update mode and was just read to end of file.
+    * Reposition explicitly so the write does not depend on that, since
+    * fgets also returns NULL on a read error. */
+   if (fseek(users_file, 0, SEEK_END) != 0)
+   {
+      goto error;
+   }
+
    fputs(entry, users_file);
 
    free(entry);


### PR DESCRIPTION
Part of the sweep @jesperpedersen asked for on pgmoneta/pgmoneta#1242. Same change in pgmoneta, pgagroal and pgexporter — `admin.c` has the identical shape in all three.

cppcheck reports `IOWithoutPositioning`: the users file is opened in update mode (`"a+"`), read with `fgets`, then written with `fputs`, with no positioning call in between.

**This is not a live bug today.** C11 7.21.5.3p7 allows input to be followed by output when "the input operation encounters end-of-file", and on the only path that reaches the `fputs` the `fgets` loop has run to completion. Every early exit from that loop is a `goto error`, which skips the write.

But `fgets` also returns NULL on a read error, and in that case the exception does not apply and the behaviour is undefined. Seeking to the end before the write removes the dependence on that exception. The stream is in append mode, so output already goes to the end and behaviour is unchanged either way.

This function already calls `fseek(users_file, 0, SEEK_SET)` before the read loop, so an explicit seek before the write matches what it already does.

I would rather say that plainly than present a warning-silencing change as a bug fix. If you would rather take an inline suppression instead, that is a reasonable call and I will send that version.

## Verification

`cppcheck` reported `IOWithoutPositioning` in `admin.c` before and reports none after. No `clang-format` changes. Builds clean.
