### PR TITLE
Check the allocations used in pointer arithmetic

### DIFF
--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -5225,6 +5225,12 @@ auth_query_get_password(int socket, SSL* server_ssl, char* username, char* datab
 
    size = 53 + strlen(username);
    aq = calloc(1, size);
+   if (aq == NULL)
+   {
+      /* Nothing is allocated yet and the error label dereferences tmsg,
+       * which is still NULL here. */
+      return 1;
+   }
 
    memset(&qmsg, 0, sizeof(struct message));
 


### PR DESCRIPTION
Part of the sweep from pgmoneta/pgmoneta#1242. `cppcheck` reports `nullPointerArithmeticOutOfMemory` — an allocation whose result is used in pointer arithmetic without being checked, so an allocation failure turns into arithmetic on NULL and then a write through it.

`security.c` — `auth_query_get_password` allocates the query buffer with `calloc(1, size)` and immediately does `pgagroal_write_byte(aq, ...)`, `aq + 1`, `aq + 5`, `aq + 49`.

The check returns directly rather than using `goto error`, deliberately. The `error:` label in this function does

```c
error:
   pgagroal_log_trace("auth_query_get_password: socket (%d) status (%d)", socket, status);

   if (tmsg->kind == 'E')
```

and at the point of this allocation `tmsg` is still NULL and `status` is still uninitialised, so jumping there would have swapped an OOM for a NULL dereference. The compiler caught the `status` half of that immediately — `-Werror,-Wsometimes-uninitialized`.

**Separately, that error label looks worth a look on its own** and I have not touched it here:

- `tmsg->kind` is dereferenced although `tmsg` is initialised to NULL, so any `goto error` reached before `tmsg` is assigned dereferences NULL;
- `status` is logged although several `goto error` paths run before it is assigned;
- the block contains `goto error;` **inside itself**, so a failure in `pgagroal_extract_error_message` loops forever.

Happy to open that as its own issue if it is not already known.

## Verification

- `cppcheck` reported these findings before and reports none after.
- `clang-format` reports no changes.
- Full `cmake --build` succeeds.

These are OOM-only paths, so practical severity is low.
