### PR TITLE
Leave room for the terminator when reading a password

### DIFF
--- a/src/libpgagroal/utils.c
+++ b/src/libpgagroal/utils.c
@@ -556,7 +556,7 @@ pgagroal_get_password(void)
 
    tcsetattr(STDIN_FILENO, TCSANOW, &newt);
 
-   while ((c = getchar()) != '\n' && c != EOF && i < MAX_PASSWORD_LENGTH)
+   while ((c = getchar()) != '\n' && c != EOF && i < MAX_PASSWORD_LENGTH - 1)
    {
       p[i++] = c;
    }


### PR DESCRIPTION
Part of the sweep from pgmoneta/pgmoneta#1242.

`get_password` reads into a fixed stack buffer:

```c
   char p[MAX_PASSWORD_LENGTH];
   ...
   while ((c = getchar()) != '\n' && c != EOF && i < MAX_PASSWORD_LENGTH)
   {
      p[i++] = c;
   }
   p[i] = '\0';
```

The loop stops when `i` reaches `MAX_PASSWORD_LENGTH`, so a password of exactly that many characters leaves `i == MAX_PASSWORD_LENGTH` and the terminator is written to `p[MAX_PASSWORD_LENGTH]` — one byte past the end of the array. `MAX_PASSWORD_LENGTH` is 8192, so it takes a deliberately long entry to reach, but it is reachable from the interactive prompt.

Stopping one character earlier keeps the terminator inside the buffer.

The same function exists with the same bound in pgmoneta, pgagroal, pgexporter and pgvictoria, so this is going to all four.

## Verification

- cppcheck reported `arrayIndexOutOfBoundsCond` on this line and reports none after.
- `clang-format` reports no changes.
- Builds clean.
