### PR TITLE
Guard the auth_query_get_password error path against an unset tmsg

### DIFF
--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -5255,8 +5255,20 @@ auth_query_get_password(int socket, SSL* server_ssl, char* username, char* datab
       goto error;
    }
 
+   if (dmsg->length < 11)
+   {
+      /* Below the 1 byte kind + 4 byte length + 6 byte fixed header that
+       * pgagroal_extract_message() already copied. dmsg->length - 11 would
+       * be negative and, once converted to size_t below, an enormous value. */
+      goto error;
+   }
+
    result_size = dmsg->length - 11 + 1;
    result = (char*)calloc(1, result_size);
+   if (result == NULL)
+   {
+      goto error;
+   }
    memcpy(result, dmsg->data + 11, dmsg->length - 11);
 
    *password = result;
@@ -5270,17 +5282,17 @@ auth_query_get_password(int socket, SSL* server_ssl, char* username, char* datab
 error:
    pgagroal_log_trace("auth_query_get_password: socket (%d) status (%d)", socket, status);
 
-   if (tmsg->kind == 'E')
+   /* tmsg is still NULL if the write above failed, so this has to be
+    * guarded rather than assumed set just because the label was reached. */
+   if (tmsg != NULL && tmsg->kind == 'E')
    {
       char* error = NULL;
 
-      if (pgagroal_extract_error_message(tmsg, &error))
+      if (!pgagroal_extract_error_message(tmsg, &error))
       {
-         goto error;
+         pgagroal_log_error("%s in %s", error, database);
+         free(error);
       }
-
-      pgagroal_log_error("%s in %s", error, database);
-      free(error);
    }
 
    free(aq);


### PR DESCRIPTION
Fixes #1004.

`error:` dereferences `tmsg->kind` unconditionally, but `tmsg` is still NULL when the label is reached from the write failure above the read, so that path was a NULL dereference rather than the trace-and-return every other failure gets. Guarded it — `tmsg is still NULL if the write above failed` is the actual reason, not a defensive habit.

The same block did `goto error` back to itself when `pgagroal_extract_error_message` failed. That loops forever with no state change between iterations. It now just skips logging the server's error text in that case and falls through to the return.

`result_size = dmsg->length - 11 + 1` was unchecked. A `'D'` message shorter than 11 bytes (the 1 byte kind + 4 byte length + the fixed header `pgagroal_extract_message` already strips) makes that negative, and both `result_size` and the `memcpy()` length are `size_t`, so it becomes an enormous value. `pgagroal_extract_message` does not enforce a minimum length — it trusts the length field from the wire — so this is reachable from a malformed response, not just a hypothetical. Rejected before the arithmetic. The `calloc()` result is also checked before the `memcpy()` writes through it.

## What I have not done

Restructuring so the `'E'` check is not reachable from a pre-read failure at all, rather than guarding it — that was closer to what you described in the issue thread. I went with the guard because it is the smaller change and keeps the one call site that legitimately needs the check (read succeeded, message was not `'D'`) exactly as it was. Happy to restructure it the other way if you would rather.

## Verification

`cppcheck` reports no new findings in the changed lines (the `nullPointerArithmeticOutOfMemory` warnings on `aq` above are pre-existing and #1003's territory). `clang-format` reports no changes. I have not been able to configure a full build locally, so this has not run — verified by reading and by the analyzer.

I used an AI assistant while preparing this. I understand the change and can explain it.
