### PR TITLE
[#997] Reject reserved words for databases and users

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -250,6 +250,17 @@ main(int argc, char** argv)
       goto error;
    }
 
+   /*
+    * if the user has specified a username via the -u flag, better
+    * check _also_ here if it is restricted and then exit
+    * instead of asking via a prompt for a good username
+    */
+   if (pgagroal_is_username_reserved(username))
+   {
+      warnx("Username <%s> is a reserved word, cannot use it!", username);
+      goto error;
+   }
+
    // if here, the action is understood, but we need
    // the file to operate onto!
    // Therefore, if the user did not specify any config file
@@ -664,6 +675,13 @@ username:
       goto username;
    }
 
+   /* check the username is not restricted */
+   if (pgagroal_is_username_reserved(username))
+   {
+      warnx("Username <%s> is a reserved word, cannot use it!", username);
+      goto username;
+   }
+
    /* Verify */
 #ifdef HAVE_FREEBSD
    fseek(users_file, 0, SEEK_SET);
@@ -1006,6 +1024,13 @@ username:
       goto username;
    }
 
+   /* check the username is not restricted */
+   if (pgagroal_is_username_reserved(username))
+   {
+      warnx("Username <%s> is a reserved word, cannot use it!", username);
+      goto username;
+   }
+
    /* Update */
    while (fgets(line, sizeof(line), users_file))
    {
@@ -1327,6 +1352,13 @@ username:
 
    if (username == NULL || strlen(username) == 0)
    {
+      goto username;
+   }
+
+   /* check the username is not restricted */
+   if (pgagroal_is_username_reserved(username))
+   {
+      warnx("Username <%s> is a reserved word, cannot use it!", username);
       goto username;
    }
 

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -715,6 +715,31 @@ pgagroal_time_format(pgagroal_time_t t, enum pgagroal_time_format_t fmt, char** 
 int
 pgagroal_parse_seconds(const char* str, int64_t* out_seconds);
 
+/**
+ * Utility function to understand if a given username
+ * belongs to a list of restricted values, that 
+ * should not be used in configuration nor in authentication.
+ *
+ * @param username the username to check
+ * @returns true if the username is not empty and belongs to a 
+ * list of restricted values, false if it does not belong to the list
+ * or if it is NULL
+ */
+bool
+pgagroal_is_username_reserved(char* username);
+
+/**
+ * Utility function to understand if a given database name
+ * is restricted.
+ *
+ * @param database the database name
+ * @returns true if the database name is not null and belongs
+ * to a list of restricted database names, false if it does not
+ * belong or it is empty.
+ */
+bool
+pgagroal_is_database_reserved(char* database);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -1493,7 +1493,7 @@ pgagroal_read_limit_configuration(void* shm, char* filename)
             }
             else
             {
-               warnx("Invalid LIMIT entry /%s:%d)", config->limit_path, lineno);
+               warnx("Invalid LIMIT entry %s:%d)", config->limit_path, lineno);
             }
 
             free(database);
@@ -3185,12 +3185,11 @@ extract_limit(char* str, int server_max, char** database, char** user, int* max_
       // Split to check database name part before '='
       *alias_start = '\0';
 
-      // Check if the database name part is "all"
-      if (!strcasecmp("all", db_part))
+      /* avoid considering aliases on a restricted name database */
+      if (pgagroal_is_database_reserved(db_part))
       {
-         // This is invalid: "all" cannot have aliases
-         pgagroal_log_fatal("Database 'all' cannot have aliases. Invalid configuration: '%s'", str);
-         pgagroal_log_fatal("Pgagroal_Database Configuration is invalid. Exiting.");
+         // This is invalid: "all" and restricted databases cannot have aliases
+         pgagroal_log_fatal("database '%s' cannot have aliases. Invalid configuration: '%s'", db_part, str);
          free(db_part);
          exit(1);
       }
@@ -3200,7 +3199,7 @@ extract_limit(char* str, int server_max, char** database, char** user, int* max_
    }
 
    // Check if it's "all" - if so, don't parse for aliases
-   if (!strcasecmp("all", db_part))
+   if (pgagroal_is_database_reserved(db_part))
    {
       *database = strdup(db_part);
       if (!*database)
@@ -3248,7 +3247,7 @@ extract_limit(char* str, int server_max, char** database, char** user, int* max_
 
                if (strlen(token) > 0)
                {
-                  total_aliases_found++; // ← Count every valid alias found
+                  total_aliases_found++; //  Count every valid alias found
                   //Ensure alias length doesn't exceed MAX_DATABASE_LENGTH - 1
                   if (*aliases_count < MAX_ALIASES)
                   {
@@ -3259,6 +3258,13 @@ extract_limit(char* str, int server_max, char** database, char** user, int* max_
                         pgagroal_log_fatal("Server configuration is invalid. Exiting.");
                         free(db_part);
                         free(alias_copy);
+                        exit(1);
+                     }
+
+                     /* avoid reserved words databases */
+                     if (pgagroal_is_database_reserved(token))
+                     {
+                        pgagroal_log_fatal("Cannot use alias '%s' on entry %s", token, str);
                         exit(1);
                      }
 

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -1292,6 +1292,19 @@ pgagroal_prefill(bool initial)
 
       if (size > 0)
       {
+         // do not perform prefil if
+         // - the database is a reserved word
+         // - the username is reserved
+         if (pgagroal_is_database_reserved(config->limits[i].database) || pgagroal_is_username_reserved(config->limits[i].username))
+         {
+            pgagroal_log_warn("Cannot perform prefill for database '%s' user '%s' at limit entry %d (row %d)",
+                              config->limits[i].database,
+                              config->limits[i].username,
+                              i + 1,
+                              config->limits[i].lineno);
+            continue;
+         }
+
          if (strcmp("all", config->limits[i].database) && strcmp("all", config->limits[i].username))
          {
             int user = -1;
@@ -1361,13 +1374,6 @@ pgagroal_prefill(bool initial)
                pgagroal_log_warn("Unknown user '%s' for limit entry (%d)", config->limits[i].username, i + 1);
             }
          }
-         else if (!strcmp("all", config->limits[i].database))
-         {
-            pgagroal_log_warn("Cannot perform prefill for database '%s' at limit entry %d (row %d)", config->limits[i].database,
-                              i + 1,
-                              config->limits[i].lineno);
-         }
-
          else
          {
             pgagroal_log_warn("Limit entry %d with invalid definition at row %d",

--- a/src/libpgagroal/utils.c
+++ b/src/libpgagroal/utils.c
@@ -2267,3 +2267,53 @@ pgagroal_cleanse(void* data, size_t size)
       OPENSSL_cleanse(data, size);
    }
 }
+
+bool
+pgagroal_is_username_reserved(char* username)
+{
+   char* restricted_usernames[] = {"all", "sameuser"};
+   int i;
+   size_t count;
+
+   if (username == NULL || strlen(username) <= 0)
+   {
+      return false;
+   }
+
+   count = sizeof restricted_usernames / sizeof restricted_usernames[0];
+
+   for (i = 0; i < count; i++)
+   {
+      if (pgagroal_compare_string(username, restricted_usernames[i]))
+      {
+         return true;
+      }
+   }
+
+   return false;
+}
+
+bool
+pgagroal_is_database_reserved(char* database)
+{
+   char* restricted_databases[] = {"all", "replication"};
+   int i;
+   size_t count;
+
+   if (database == NULL || strlen(database) <= 0)
+   {
+      return false;
+   }
+
+   count = sizeof restricted_databases / sizeof restricted_databases[0];
+
+   for (i = 0; i < count; i++)
+   {
+      if (pgagroal_compare_string(database, restricted_databases[i]))
+      {
+         return true;
+      }
+   }
+
+   return false;
+}

--- a/test/testcases/test_reserved_names.c
+++ b/test/testcases/test_reserved_names.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 The pgagroal community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ *    of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ *    list of conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <mctf.h>
+#include <utils.h>
+
+MCTF_TEST(test_utils_reserved_username)
+{
+   MCTF_ASSERT(!pgagroal_is_username_reserved(NULL), cleanup, "NULL username should not be reserved");
+   MCTF_ASSERT(!pgagroal_is_username_reserved(""), cleanup, "empty username should not be reserved");
+
+   MCTF_ASSERT(pgagroal_is_username_reserved("all"), cleanup, "'all' should be reserved");
+   MCTF_ASSERT(pgagroal_is_username_reserved("sameuser"), cleanup, "'sameuser' should be reserved");
+
+   MCTF_ASSERT(!pgagroal_is_username_reserved("postgres"), cleanup, "'postgres' should not be reserved");
+   MCTF_ASSERT(!pgagroal_is_username_reserved("app_user"), cleanup, "'app_user' should not be reserved");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_utils_reserved_database)
+{
+   MCTF_ASSERT(!pgagroal_is_database_reserved(NULL), cleanup, "NULL database should not be reserved");
+   MCTF_ASSERT(!pgagroal_is_database_reserved(""), cleanup, "empty database should not be reserved");
+
+   MCTF_ASSERT(pgagroal_is_database_reserved("all"), cleanup, "'all' should be reserved");
+   MCTF_ASSERT(pgagroal_is_database_reserved("replication"), cleanup, "'replication' should be reserved");
+
+   MCTF_ASSERT(!pgagroal_is_database_reserved("postgres"), cleanup, "'postgres' should not be reserved");
+   MCTF_ASSERT(!pgagroal_is_database_reserved("appdb"), cleanup, "'appdb' should not be reserved");
+
+cleanup:
+   MCTF_FINISH();
+}


### PR DESCRIPTION
Add two new utility functions:
- pgagroal_is_username_reserved
- pgagroal_is_database_reserved

that accept a username or database name and return true if the name belongs (case insensitive) to the list of reserved words. This for example prevents the usage of 'all` as a valid entry for `pgagroal-admin` or to use `all` as an alias in entry like

      pgbench=all pgbench 10 5 3

since it would not make any sense.

`pool.c` has been modified to prevent prefil when either a username or a database is set to a reserved word. This is more strict than just avoiding the prefil for `all` as database/username, but it does not make sense at all to prefill against a dataabse/username that PostgreSQL will reject.

Added a specific test for the two new functions.

Close #997