### PR TITLE
Remove invalid initializers from atomic signal arrays

### DIFF
--- a/src/libpgagroal/ev.c
+++ b/src/libpgagroal/ev.c
@@ -141,8 +141,8 @@ static void init_watcher_message(struct io_watcher* watcher);
 /* context globals */
 
 static struct event_loop* loop = NULL;
-static _Atomic(struct signal_watcher*) signal_watchers[PGAGROAL_NSIG] = {0};
-static _Atomic(signal_cb) signal_callbacks[PGAGROAL_NSIG] = {0};
+static _Atomic(struct signal_watcher*) signal_watchers[PGAGROAL_NSIG];
+static _Atomic(signal_cb) signal_callbacks[PGAGROAL_NSIG];
 
 #if HAVE_LINUX
 


### PR DESCRIPTION
Clang fails to compile `ev.c` because `{0}` is not a valid constant initializer for the` _Atomic` pointer/function-pointer arrays `signal_watchers` and `signal_callbacks`. Since these variables have static storage duration, the explicit initializers can be removed and they will still be zero-initialized automatically.