### PR TITLE
Check the realloc results before using them

### DIFF
--- a/src/libpgagroal/logging.c
+++ b/src/libpgagroal/logging.c
@@ -655,6 +655,13 @@ dynamic_buffer_append(void* orig, size_t orig_size,
    {
       s = orig_size + append_size;
       d = realloc(orig, s);
+
+      if (d == NULL)
+      {
+         *new_size = orig_size;
+         return orig;
+      }
+
       memcpy((char*)d + orig_size, append, append_size);
    }
    else

--- a/src/libpgagroal/utils.c
+++ b/src/libpgagroal/utils.c
@@ -903,6 +903,11 @@ pgagroal_append(char* orig, char* s)
 
    n = (char*)realloc(orig, orig_length + s_length + 1);
 
+   if (n == NULL)
+   {
+      return orig;
+   }
+
    memcpy(n + orig_length, s, s_length);
 
    n[orig_length + s_length] = '\0';


### PR DESCRIPTION
Cross-port of pgmoneta/pgmoneta#1246, which fixed the same class there.

Two `realloc` results are used without being checked.

`pgagroal_append()` (`utils.c`) reallocs and then `memcpy`s into the result immediately:

```c
n = (char*)realloc(orig, orig_length + s_length + 1);

memcpy(n + orig_length, s, s_length);
```

On allocation failure `realloc` returns NULL and leaves `orig` valid, so this writes to
`NULL + orig_length`. `pgmoneta_append()` — the same function in the sibling project — returns
`orig` in that case, and every other `pgagroal_*_append` helper funnels through this one, so
the whole string-building path in the daemon depends on it.

`dynamic_buffer_append()` (`logging.c`) has the same shape. Its single caller is
`pgagroal_log_mem()`:

```c
partial_buf = dynamic_buffer_append(partial_buf, partial_buf_size, msg->data, msg->length, &partial_buf_size);
```

so returning `orig` with `*new_size` left at `orig_size` keeps the buffer and its recorded
size consistent — the message being appended is dropped, which is the right outcome for a
debug log line under memory pressure. `realloc` failure does not free `orig`, so nothing leaks.

## Verification

Found by reading, not by a tool — **cppcheck reports nothing at either line**, with or
without the fix (`--enable=warning`, 2.21.0). I could not build pgagroal here, so this is
verified by reading the callers rather than by running it: `dynamic_buffer_append` has exactly
one caller, and `pgagroal_append`'s contract after the change matches `pgmoneta_append`'s,
which is already in use upstream. `clang-format` reports no changes.

Independent of merge order with respect to my other open PRs.
