### PR TITLE
Check the hex dump line before measuring it

### DIFF
--- a/src/libpgagroal/logging.c
+++ b/src/libpgagroal/logging.c
@@ -597,6 +597,15 @@ retry:
                      }
                   }
 
+                  /* pgagroal_append() returns its input on allocation
+                     failure, so l is still NULL if the first append failed. */
+                  if (l == NULL)
+                  {
+                     free(n);
+                     n = NULL;
+                     break;
+                  }
+
                   if (strlen(l) == LINE_LENGTH * 2)
                   {
                      full_line = true;
@@ -605,8 +614,8 @@ retry:
                   {
                      if (strlen(l) < LINE_LENGTH * 2)
                      {
-                        int chars_missing = (LINE_LENGTH * 2) - strlen(l);
-                        for (int i = 0; i < chars_missing; i++)
+                        size_t chars_missing = (LINE_LENGTH * 2) - strlen(l);
+                        for (size_t i = 0; i < chars_missing; i++)
                         {
                            l = pgagroal_append_char(l, ' ');
                         }


### PR DESCRIPTION
Cross-port of pgmoneta/pgmoneta#1259, merged there as `267e367`.

In the hex-dump branch of `pgagroal_log_mem()`, `l` starts as NULL and is built up one byte at
a time:

```c
char* l = NULL;
size_t count = MIN((int)remaining, (int)LINE_LENGTH);

for (size_t i = 0; i < count; i++)
{
   ...
   l = pgagroal_append(l, &buf[0]);
}

if (strlen(l) == LINE_LENGTH * 2)
```

`pgagroal_append()` returns its input unchanged when it cannot allocate, so if the very first
append fails, `l` is still NULL when `strlen(l)` runs. The loop always executes at least once
— the enclosing `while (remaining > 0)` guarantees `count >= 1` — so there is no path where
`strlen` is reached with `l` untouched for any other reason.

This needs a real allocation failure to trigger, same as the merged pgmoneta#1246 class.

The guard frees `n` and breaks. `break` is enough rather than a new label: `t` is still NULL at
that point, and the `atomic_store(&config->common.log_lock, STATE_FREE)` that releases the log
lock sits after the loop, so it still runs.

The `int` → `size_t` change on `chars_missing` is the other half of the merged pgmoneta commit;
the subtraction is `size_t` arithmetic and the branch already proves it is positive.

## Verification

cppcheck 2.21.0 reports `nullPointer` at this line before the change and nothing after
(`--enable=warning --inline-suppr`). I could not build here, so the reachability argument is
from reading, not from running it. `clang-format` reports no changes.

Independent of my other open PRs — merge order does not matter.
